### PR TITLE
Slice 10: namespace policy uniform outside memory core (audit must-fix #6)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,7 +131,21 @@ test:integration:
         db/migrations_v3_2_2_version_snapshot_new_values.sql \
         db/migrations_v3_3_morpheus.sql \
         db/migrations_v3_3_morpheus_namespace.sql \
-        db/migrations_v3_3_recall_tracking.sql; do
+        db/migrations_v3_3_recall_tracking.sql \
+        db/migrations_charon_trigger_guard.sql \
+        db/migrations_v3_4_federation_compat.sql \
+        db/migrations_v3_5_trigger_same_memory_parent.sql \
+        db/migrations_v3_5_rls_group_select_unix_bits.sql \
+        db/migrations_v3_5_webhook_retry_terminal_state.sql \
+        db/migrations_v3_5_webhook_attempt_lease.sql \
+        db/migrations_v3_5_webhook_writer_revision.sql \
+        db/migrations_v3_5_webhook_status_updated_at.sql \
+        db/migrations_v3_5_webhook_superseded_marker.sql \
+        db/migrations_v3_5_webhook_attempt_unique.sql \
+        db/migrations_v3_5_webhook_succeeded_unique.sql \
+        db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql \
+        db/migrations_v3_5_entities_namespace_unique.sql \
+        db/migrations_v3_5_state_journal_namespace.sql; do
         if [ -f "$f" ]; then
           echo "applying $f"
           psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 -f "$f"

--- a/api/handlers/entities.py
+++ b/api/handlers/entities.py
@@ -1,8 +1,9 @@
 """Entities API: CRUD for tracked entities (people, projects, concepts).
 
-Per-owner entity registry. Each (owner_id, entity_type, name) is unique within
-a single owner's namespace, and entities from one owner are invisible to others.
-Root may cross-read by passing `?owner_id=<target>`.
+Per-owner, per-namespace entity registry. Each
+`(owner_id, namespace, entity_type, name)` is unique, and entities from one
+namespace are invisible to another. Root may cross-read by passing
+`?owner_id=<target>&namespace=<target>`.
 """
 import json
 import logging
@@ -62,10 +63,11 @@ def _scope_namespace(
     return user.namespace
 
 
-async def _assert_owned(conn, entity_id: str, user: UserContext) -> str:
-    """Return the entity's owner_id if the caller can access it, else
-    raise 404/403. Two-dimensional tenancy (v3.2): non-root must
-    match BOTH owner_id AND namespace. Root bypasses both.
+async def _assert_owned(conn, entity_id: str, user: UserContext) -> tuple[str, str]:
+    """Return the entity's owner_id and namespace if accessible, else raise.
+
+    Two-dimensional tenancy (v3.2): non-root must match BOTH owner_id AND
+    namespace. Root bypasses both.
     """
     row = await conn.fetchrow(
         "SELECT owner_id, namespace FROM entities WHERE id = $1::uuid",
@@ -79,7 +81,7 @@ async def _assert_owned(conn, entity_id: str, user: UserContext) -> str:
     ):
         # Don't leak existence to non-owner; return 404 as if it didn't exist.
         raise HTTPException(status_code=404, detail="Entity not found")
-    return row["owner_id"]
+    return row["owner_id"], row["namespace"]
 
 
 @router.post("/entities", status_code=201)
@@ -97,7 +99,7 @@ async def create_entity(
             row = await conn.fetchrow(
                 '''INSERT INTO entities (id, owner_id, namespace, entity_type, name, description, metadata)
                    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-                   ON CONFLICT (owner_id, entity_type, name) DO UPDATE
+                   ON CONFLICT (owner_id, namespace, entity_type, name) DO UPDATE
                    SET description = COALESCE($6, entities.description),
                        updated = NOW()
                    RETURNING id::text, entity_type, name, description, metadata, created::text, updated::text''',
@@ -168,12 +170,13 @@ async def get_entity(entity_id: str, user: UserContext = Depends(get_current_use
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     async with _lc._pool.acquire() as conn:
-        await _assert_owned(conn, entity_id, user)
+        owner, namespace = await _assert_owned(conn, entity_id, user)
         row = await conn.fetchrow(
             '''SELECT id::text, entity_type, name, description, metadata,
                       related_entities, created::text, updated::text
-               FROM entities WHERE id = $1::uuid''',
-            entity_id
+               FROM entities
+               WHERE id = $1::uuid AND owner_id = $2 AND namespace = $3''',
+            entity_id, owner, namespace,
         )
     if not row:
         raise HTTPException(status_code=404, detail="Entity not found")
@@ -197,30 +200,29 @@ async def update_entity(
         raise HTTPException(status_code=400, detail="No fields to update")
     try:
         async with _lc._pool.acquire() as conn:
-            # _assert_owned returns the entity's owner_id; we re-assert in the
-            # UPDATE's WHERE clause so a concurrent ownership change between
-            # the assertion and the update can't land the write on the wrong row.
-            owner = await _assert_owned(conn, entity_id, user)
+            # Re-assert owner + namespace in the UPDATE so concurrent tenancy
+            # changes between the probe and write cannot land on the wrong row.
+            owner, namespace = await _assert_owned(conn, entity_id, user)
             if 'description' in updates and 'metadata' in updates:
                 row = await conn.fetchrow(
                     '''UPDATE entities SET description=$1, metadata=$2::jsonb, updated=NOW()
-                       WHERE id=$3::uuid AND owner_id=$4
+                       WHERE id=$3::uuid AND owner_id=$4 AND namespace=$5
                        RETURNING id::text, entity_type, name, description, metadata, created::text, updated::text''',
-                    updates['description'], json.dumps(updates['metadata']), entity_id, owner,
+                    updates['description'], json.dumps(updates['metadata']), entity_id, owner, namespace,
                 )
             elif 'description' in updates:
                 row = await conn.fetchrow(
                     '''UPDATE entities SET description=$1, updated=NOW()
-                       WHERE id=$2::uuid AND owner_id=$3
+                       WHERE id=$2::uuid AND owner_id=$3 AND namespace=$4
                        RETURNING id::text, entity_type, name, description, metadata, created::text, updated::text''',
-                    updates['description'], entity_id, owner,
+                    updates['description'], entity_id, owner, namespace,
                 )
             else:
                 row = await conn.fetchrow(
                     '''UPDATE entities SET metadata=$1::jsonb, updated=NOW()
-                       WHERE id=$2::uuid AND owner_id=$3
+                       WHERE id=$2::uuid AND owner_id=$3 AND namespace=$4
                        RETURNING id::text, entity_type, name, description, metadata, created::text, updated::text''',
-                    json.dumps(updates['metadata']), entity_id, owner,
+                    json.dumps(updates['metadata']), entity_id, owner, namespace,
                 )
         if not row:
             raise HTTPException(status_code=404, detail="Entity not found")
@@ -245,8 +247,8 @@ async def link_entities(
         raise HTTPException(status_code=503, detail="Database pool not available")
     try:
         async with _lc._pool.acquire() as conn:
-            await _assert_owned(conn, entity_id, user)
-            await _assert_owned(conn, req.related_id, user)
+            owner, namespace = await _assert_owned(conn, entity_id, user)
+            related_owner, related_namespace = await _assert_owned(conn, req.related_id, user)
             # Link A->B
             await conn.execute(
                 '''UPDATE entities
@@ -254,8 +256,10 @@ async def link_entities(
                        COALESCE(related_entities, ARRAY[]::uuid[]), $2::uuid
                    ), updated = NOW()
                    WHERE id = $1::uuid
+                   AND owner_id = $3
+                   AND namespace = $4
                    AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
-                entity_id, req.related_id
+                entity_id, req.related_id, owner, namespace,
             )
             # Link B->A
             await conn.execute(
@@ -264,8 +268,10 @@ async def link_entities(
                        COALESCE(related_entities, ARRAY[]::uuid[]), $2::uuid
                    ), updated = NOW()
                    WHERE id = $1::uuid
+                   AND owner_id = $3
+                   AND namespace = $4
                    AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
-                req.related_id, entity_id
+                req.related_id, entity_id, related_owner, related_namespace,
             )
         return {"status": "linked", "entity_id": entity_id, "related_id": req.related_id}
     except HTTPException:
@@ -280,7 +286,7 @@ async def delete_entity(entity_id: str, user: UserContext = Depends(get_current_
         raise HTTPException(status_code=503, detail="Database pool not available")
     try:
         async with _lc._pool.acquire() as conn:
-            await _assert_owned(conn, entity_id, user)
+            owner, namespace = await _assert_owned(conn, entity_id, user)
             # Remove from other entities' arrays (caller's own only; root clears all)
             if user.role == "root":
                 await conn.execute(
@@ -293,10 +299,15 @@ async def delete_entity(entity_id: str, user: UserContext = Depends(get_current_
                 await conn.execute(
                     '''UPDATE entities
                        SET related_entities = array_remove(related_entities, $1::uuid)
-                       WHERE owner_id = $2 AND $1::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[]))''',
-                    entity_id, user.user_id,
+                       WHERE owner_id = $2
+                       AND namespace = $3
+                       AND $1::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[]))''',
+                    entity_id, owner, namespace,
                 )
-            result = await conn.execute('DELETE FROM entities WHERE id = $1::uuid', entity_id)
+            result = await conn.execute(
+                'DELETE FROM entities WHERE id = $1::uuid AND owner_id = $2 AND namespace = $3',
+                entity_id, owner, namespace,
+            )
         if result == 'DELETE 0':
             raise HTTPException(status_code=404, detail="Entity not found")
     except HTTPException:
@@ -310,9 +321,11 @@ async def get_related_entities(entity_id: str, user: UserContext = Depends(get_c
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     async with _lc._pool.acquire() as conn:
-        target_owner = await _assert_owned(conn, entity_id, user)
+        target_owner, target_ns = await _assert_owned(conn, entity_id, user)
         entity = await conn.fetchrow(
-            'SELECT related_entities FROM entities WHERE id = $1::uuid', entity_id,
+            '''SELECT related_entities FROM entities
+               WHERE id = $1::uuid AND owner_id = $2 AND namespace = $3''',
+            entity_id, target_owner, target_ns,
         )
     if entity is None:
         raise HTTPException(status_code=404, detail="Entity not found")
@@ -330,7 +343,7 @@ async def get_related_entities(entity_id: str, user: UserContext = Depends(get_c
         else:
             rows = await conn.fetch(
                 '''SELECT id::text, entity_type, name, description, metadata, created::text, updated::text
-                   FROM entities WHERE owner_id = $1 AND id = ANY($2::uuid[])''',
-                target_owner, related_ids
+                   FROM entities WHERE owner_id = $1 AND namespace = $2 AND id = ANY($3::uuid[])''',
+                target_owner, target_ns, related_ids
             )
     return {"related": [dict(r) for r in rows]}

--- a/api/handlers/journal.py
+++ b/api/handlers/journal.py
@@ -1,7 +1,8 @@
 """Journal API: POST /journal, GET /journal, DELETE /journal/{entry_id}
 
-Per-owner journal. Each entry is scoped to the creating user's `user_id` and
-visible only to that user (root can cross-read by passing `?owner_id=...`).
+Per-owner, per-namespace journal. Each entry is scoped to the creating user's
+`user_id` and `namespace`; root can target another owner/namespace via
+`?owner_id=` and `?namespace=`.
 """
 import json
 import logging
@@ -43,13 +44,28 @@ def _scope_owner(user: UserContext, override: Optional[str]) -> str:
     return user.user_id
 
 
+def _scope_namespace(user: UserContext, override: Optional[str] = None) -> str:
+    if override and override != user.namespace:
+        if user.role != "root":
+            raise HTTPException(
+                status_code=403,
+                detail="cross-namespace access requires root",
+            )
+        return override
+    return user.namespace
+
+
 @router.post("/journal", status_code=201)
 async def create_journal_entry(
     req: JournalCreateRequest,
     user: UserContext = Depends(get_current_user),
+    owner_id: Optional[str] = Query(None, description="Admin-only: write on behalf of another owner"),
+    namespace: Optional[str] = Query(None, description="Admin-only: write into another namespace"),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     try:
         entry_id = str(uuid.uuid4())
         async with _lc._pool.acquire() as conn:
@@ -59,18 +75,18 @@ async def create_journal_entry(
                 except ValueError:
                     raise HTTPException(status_code=422, detail="Invalid date format; expected YYYY-MM-DD")
                 row = await conn.fetchrow(
-                    '''INSERT INTO journal (id, owner_id, entry_date, topic, content, metadata)
-                       VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    '''INSERT INTO journal (id, owner_id, namespace, entry_date, topic, content, metadata)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
                        RETURNING id, entry_date::text, topic, content, metadata, created::text''',
-                    entry_id, user.user_id, entry_date, req.topic, req.content,
+                    entry_id, target_owner, target_ns, entry_date, req.topic, req.content,
                     json.dumps(req.metadata or {}),
                 )
             else:
                 row = await conn.fetchrow(
-                    '''INSERT INTO journal (id, owner_id, entry_date, topic, content, metadata)
-                       VALUES ($1, $2, CURRENT_DATE, $3, $4, $5::jsonb)
+                    '''INSERT INTO journal (id, owner_id, namespace, entry_date, topic, content, metadata)
+                       VALUES ($1, $2, $3, CURRENT_DATE, $4, $5, $6::jsonb)
                        RETURNING id, entry_date::text, topic, content, metadata, created::text''',
-                    entry_id, user.user_id, req.topic, req.content,
+                    entry_id, target_owner, target_ns, req.topic, req.content,
                     json.dumps(req.metadata or {}),
                 )
         return dict(row)
@@ -89,10 +105,12 @@ async def list_journal_entries(
     limit: int = Query(20, ge=1, le=200),
     user: UserContext = Depends(get_current_user),
     owner_id: Optional[str] = Query(None),
+    namespace: Optional[str] = Query(None),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     try:
         async with _lc._pool.acquire() as conn:
             if date_str:
@@ -102,30 +120,30 @@ async def list_journal_entries(
                     raise HTTPException(status_code=422, detail="Invalid date format; expected YYYY-MM-DD")
                 rows = await conn.fetch(
                     '''SELECT id, entry_date::text, topic, content, metadata, created::text
-                       FROM journal WHERE owner_id = $1 AND entry_date = $2
-                       ORDER BY created DESC LIMIT $3''',
-                    target_owner, parsed_date, limit
+                       FROM journal WHERE owner_id = $1 AND namespace = $2 AND entry_date = $3
+                       ORDER BY created DESC LIMIT $4''',
+                    target_owner, target_ns, parsed_date, limit
                 )
             elif topic:
                 rows = await conn.fetch(
                     '''SELECT id, entry_date::text, topic, content, metadata, created::text
-                       FROM journal WHERE owner_id = $1 AND topic = $2
-                       ORDER BY created DESC LIMIT $3''',
-                    target_owner, topic, limit
+                       FROM journal WHERE owner_id = $1 AND namespace = $2 AND topic = $3
+                       ORDER BY created DESC LIMIT $4''',
+                    target_owner, target_ns, topic, limit
                 )
             elif search:
                 rows = await conn.fetch(
                     '''SELECT id, entry_date::text, topic, content, metadata, created::text
-                       FROM journal WHERE owner_id = $1 AND (content ILIKE $2 OR topic ILIKE $2)
-                       ORDER BY created DESC LIMIT $3''',
-                    target_owner, f'%{search}%', limit
+                       FROM journal WHERE owner_id = $1 AND namespace = $2 AND (content ILIKE $3 OR topic ILIKE $3)
+                       ORDER BY created DESC LIMIT $4''',
+                    target_owner, target_ns, f'%{search}%', limit
                 )
             else:
                 rows = await conn.fetch(
                     '''SELECT id, entry_date::text, topic, content, metadata, created::text
-                       FROM journal WHERE owner_id = $1
-                       ORDER BY created DESC LIMIT $2''',
-                    target_owner, limit
+                       FROM journal WHERE owner_id = $1 AND namespace = $2
+                       ORDER BY created DESC LIMIT $3''',
+                    target_owner, target_ns, limit
                 )
         return {"entries": [dict(r) for r in rows], "count": len(rows)}
     except HTTPException:
@@ -139,18 +157,17 @@ async def list_journal_entries(
 async def delete_journal_entry(
     entry_id: str,
     user: UserContext = Depends(get_current_user),
+    owner_id: Optional[str] = Query(None),
+    namespace: Optional[str] = Query(None),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     async with _lc._pool.acquire() as conn:
-        if user.role == "root":
-            result = await conn.execute(
-                'DELETE FROM journal WHERE id = $1', entry_id,
-            )
-        else:
-            result = await conn.execute(
-                'DELETE FROM journal WHERE id = $1 AND owner_id = $2',
-                entry_id, user.user_id,
-            )
+        result = await conn.execute(
+            'DELETE FROM journal WHERE id = $1 AND owner_id = $2 AND namespace = $3',
+            entry_id, target_owner, target_ns,
+        )
     if result == 'DELETE 0':
         raise HTTPException(status_code=404, detail="Entry not found")

--- a/api/handlers/state.py
+++ b/api/handlers/state.py
@@ -1,8 +1,9 @@
 """State API: GET/PUT/DELETE /state/{key}, GET /state
 
-Per-owner KV store. All operations are scoped to the caller's `user.user_id`;
-keys from one owner are invisible to another. Root can read/write any owner's
-keys by passing an `?owner_id=` query parameter on GET/DELETE.
+Per-owner, per-namespace KV store. All operations are scoped to the caller's
+`user.user_id` and `user.namespace`; keys from one namespace are invisible to
+another. Root can target another owner/namespace via `?owner_id=` and
+`?namespace=`.
 """
 import json
 import logging
@@ -31,20 +32,34 @@ def _scope_owner(user: UserContext, override: Optional[str]) -> str:
     return user.user_id
 
 
+def _scope_namespace(user: UserContext, override: Optional[str] = None) -> str:
+    """Return the namespace to query. Only root can cross namespaces."""
+    if override and override != user.namespace:
+        if user.role != "root":
+            raise HTTPException(
+                status_code=403,
+                detail="cross-namespace access requires root",
+            )
+        return override
+    return user.namespace
+
+
 @router.get("/state")
 async def list_state_keys(
     user: UserContext = Depends(get_current_user),
     owner_id: Optional[str] = Query(None, description="Admin-only: target another owner"),
+    namespace: Optional[str] = Query(None, description="Admin-only: target another namespace"),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     try:
         async with _lc._pool.acquire() as conn:
             rows = await conn.fetch(
                 'SELECT key, updated::text, version FROM state '
-                'WHERE owner_id = $1 ORDER BY key',
-                target_owner,
+                'WHERE owner_id = $1 AND namespace = $2 ORDER BY key',
+                target_owner, target_ns,
             )
         return {"keys": [dict(r) for r in rows]}
     except Exception as e:
@@ -57,16 +72,18 @@ async def get_state(
     key: str,
     user: UserContext = Depends(get_current_user),
     owner_id: Optional[str] = Query(None),
+    namespace: Optional[str] = Query(None),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     try:
         async with _lc._pool.acquire() as conn:
             row = await conn.fetchrow(
                 'SELECT key, value, updated::text, version FROM state '
-                'WHERE owner_id = $1 AND key = $2',
-                target_owner, key,
+                'WHERE owner_id = $1 AND namespace = $2 AND key = $3',
+                target_owner, target_ns, key,
             )
         if not row:
             raise HTTPException(status_code=404, detail=f"State key '{key}' not found")
@@ -84,19 +101,21 @@ async def set_state(
     req: StateSetRequest,
     user: UserContext = Depends(get_current_user),
     owner_id: Optional[str] = Query(None, description="Admin-only: write on behalf of another owner"),
+    namespace: Optional[str] = Query(None, description="Admin-only: write into another namespace"),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     try:
         async with _lc._pool.acquire() as conn:
             row = await conn.fetchrow(
-                '''INSERT INTO state (owner_id, key, value, updated)
-                   VALUES ($1, $2, $3::jsonb, NOW())
-                   ON CONFLICT (owner_id, key) DO UPDATE
-                   SET value = $3::jsonb, updated = NOW(), version = state.version + 1
+                '''INSERT INTO state (owner_id, namespace, key, value, updated)
+                   VALUES ($1, $2, $3, $4::jsonb, NOW())
+                   ON CONFLICT (owner_id, namespace, key) DO UPDATE
+                   SET value = $4::jsonb, updated = NOW(), version = state.version + 1
                    RETURNING key, value, updated::text, version''',
-                target_owner, key, json.dumps(req.value),
+                target_owner, target_ns, key, json.dumps(req.value),
             )
         return dict(row)
     except HTTPException:
@@ -111,14 +130,16 @@ async def delete_state(
     key: str,
     user: UserContext = Depends(get_current_user),
     owner_id: Optional[str] = Query(None),
+    namespace: Optional[str] = Query(None),
 ):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = _scope_owner(user, owner_id)
+    target_ns = _scope_namespace(user, namespace)
     async with _lc._pool.acquire() as conn:
         result = await conn.execute(
-            'DELETE FROM state WHERE owner_id = $1 AND key = $2',
-            target_owner, key,
+            'DELETE FROM state WHERE owner_id = $1 AND namespace = $2 AND key = $3',
+            target_owner, target_ns, key,
         )
     if result == 'DELETE 0':
         raise HTTPException(status_code=404, detail=f"State key '{key}' not found")

--- a/db/migrations_v3_2_entities_namespace.sql
+++ b/db/migrations_v3_2_entities_namespace.sql
@@ -18,10 +18,7 @@ CREATE INDEX IF NOT EXISTS idx_entities_namespace
 CREATE INDEX IF NOT EXISTS idx_entities_owner_namespace
     ON entities(owner_id, namespace);
 
--- Note: the (owner_id, entity_type, name) UNIQUE constraint stays
--- as-is. Namespace segmentation WITHIN a single owner (same owner
--- having "Alice" the person in namespace A and namespace B) is not
--- supported today; tenant separation is expressed via distinct
--- owner_ids per team. Widening the unique key is a v3.3+ decision
--- that also needs migration discipline for rows created before the
--- change.
+-- Note: this migration originally deferred widening the
+-- (owner_id, entity_type, name) UNIQUE constraint. That deferral is closed in
+-- migrations_v3_5_entities_namespace_unique.sql, which replaces it with
+-- (owner_id, namespace, entity_type, name) after an exact-duplicate guard.

--- a/db/migrations_v3_5_entities_namespace_unique.sql
+++ b/db/migrations_v3_5_entities_namespace_unique.sql
@@ -1,0 +1,84 @@
+-- MNEMOS v3.5 — widen entity uniqueness to include namespace
+--
+-- Entities gained namespace in v3.2, but the UNIQUE constraint stayed at
+-- (owner_id, entity_type, name). That prevented the same owner from having the
+-- same entity name/type in separate namespaces and left handler ON CONFLICT
+-- clauses with a one-dimensional tenancy key.
+--
+-- Idempotent. If exact duplicates already exist under the new key, abort; there
+-- is no safe automatic winner for entity identity.
+
+DO $$
+DECLARE
+    _owner_attnum       SMALLINT;
+    _namespace_attnum   SMALLINT;
+    _entity_type_attnum SMALLINT;
+    _name_attnum        SMALLINT;
+    _old_conname        TEXT;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT owner_id, namespace, entity_type, name, COUNT(*) AS n
+            FROM entities
+            GROUP BY owner_id, namespace, entity_type, name
+            HAVING COUNT(*) > 1
+        ) AS dup
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot widen entities uniqueness: duplicate (owner_id, namespace, entity_type, name) rows exist';
+    END IF;
+
+    SELECT attnum INTO _owner_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'entities'::regclass AND attname = 'owner_id';
+    SELECT attnum INTO _namespace_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'entities'::regclass AND attname = 'namespace';
+    SELECT attnum INTO _entity_type_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'entities'::regclass AND attname = 'entity_type';
+    SELECT attnum INTO _name_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'entities'::regclass AND attname = 'name';
+
+    -- Drop narrower unique keys by column set, not name. The canonical prior
+    -- key is (owner_id, entity_type, name); some long-lived installs may still
+    -- carry the original (entity_type, name) key as well.
+    FOR _old_conname IN
+        SELECT conname
+          FROM pg_constraint
+         WHERE conrelid = 'entities'::regclass
+           AND contype = 'u'
+           AND conkey IN (
+                ARRAY[
+                    _owner_attnum,
+                    _entity_type_attnum,
+                    _name_attnum
+                ]::SMALLINT[],
+                ARRAY[
+                    _entity_type_attnum,
+                    _name_attnum
+                ]::SMALLINT[]
+           )
+    LOOP
+        EXECUTE format('ALTER TABLE entities DROP CONSTRAINT %I', _old_conname);
+    END LOOP;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conrelid = 'entities'::regclass
+           AND contype = 'u'
+           AND conkey = ARRAY[
+                _owner_attnum,
+                _namespace_attnum,
+                _entity_type_attnum,
+                _name_attnum
+           ]::SMALLINT[]
+    ) THEN
+        ALTER TABLE entities
+            ADD CONSTRAINT entities_owner_namespace_type_name_key
+            UNIQUE (owner_id, namespace, entity_type, name);
+    END IF;
+END$$;

--- a/db/migrations_v3_5_state_journal_namespace.sql
+++ b/db/migrations_v3_5_state_journal_namespace.sql
@@ -1,0 +1,109 @@
+-- MNEMOS v3.5 — namespace state and journal
+--
+-- v3 ownership made state and journal owner-scoped. This migration adds the
+-- second tenancy dimension used by the rest of the memory core.
+--
+-- Idempotent. Exact state key duplicates under the new key abort the migration;
+-- there is no safe automatic value/version winner.
+
+ALTER TABLE state
+    ADD COLUMN IF NOT EXISTS namespace TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE journal
+    ADD COLUMN IF NOT EXISTS namespace TEXT NOT NULL DEFAULT 'default';
+
+UPDATE state SET namespace = 'default' WHERE namespace IS NULL;
+UPDATE journal SET namespace = 'default' WHERE namespace IS NULL;
+
+ALTER TABLE state ALTER COLUMN namespace SET DEFAULT 'default';
+ALTER TABLE state ALTER COLUMN namespace SET NOT NULL;
+ALTER TABLE journal ALTER COLUMN namespace SET DEFAULT 'default';
+ALTER TABLE journal ALTER COLUMN namespace SET NOT NULL;
+
+DO $$
+DECLARE
+    _owner_attnum     SMALLINT;
+    _namespace_attnum SMALLINT;
+    _key_attnum       SMALLINT;
+    _conname          TEXT;
+    _state_pk         TEXT;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT owner_id, namespace, key, COUNT(*) AS n
+            FROM state
+            GROUP BY owner_id, namespace, key
+            HAVING COUNT(*) > 1
+        ) AS dup
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot widen state uniqueness: duplicate (owner_id, namespace, key) rows exist';
+    END IF;
+
+    SELECT attnum INTO _owner_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'state'::regclass AND attname = 'owner_id';
+    SELECT attnum INTO _namespace_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'state'::regclass AND attname = 'namespace';
+    SELECT attnum INTO _key_attnum
+      FROM pg_attribute
+     WHERE attrelid = 'state'::regclass AND attname = 'key';
+
+    SELECT conname INTO _state_pk
+      FROM pg_constraint
+     WHERE conrelid = 'state'::regclass
+       AND contype = 'p';
+
+    IF _state_pk IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conrelid = 'state'::regclass
+           AND contype = 'p'
+           AND conkey = ARRAY[
+                _owner_attnum,
+                _namespace_attnum,
+                _key_attnum
+           ]::SMALLINT[]
+    ) THEN
+        EXECUTE format('ALTER TABLE state DROP CONSTRAINT %I', _state_pk);
+    END IF;
+
+    -- Drop any old narrower unique constraint by column set.
+    FOR _conname IN
+        SELECT conname
+          FROM pg_constraint
+         WHERE conrelid = 'state'::regclass
+           AND contype = 'u'
+           AND conkey IN (
+                ARRAY[
+                    _owner_attnum,
+                    _key_attnum
+                ]::SMALLINT[],
+                ARRAY[
+                    _key_attnum
+                ]::SMALLINT[]
+           )
+    LOOP
+        EXECUTE format('ALTER TABLE state DROP CONSTRAINT %I', _conname);
+    END LOOP;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conrelid = 'state'::regclass
+           AND contype IN ('p', 'u')
+           AND conkey = ARRAY[
+                _owner_attnum,
+                _namespace_attnum,
+                _key_attnum
+           ]::SMALLINT[]
+    ) THEN
+        ALTER TABLE state ADD PRIMARY KEY (owner_id, namespace, key);
+    END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_state_owner_namespace
+    ON state(owner_id, namespace);
+CREATE INDEX IF NOT EXISTS idx_journal_owner_namespace
+    ON journal(owner_id, namespace);

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -78,6 +78,8 @@ services:
       - ./db/migrations_v3_5_webhook_attempt_unique.sql:/docker-entrypoint-initdb.d/31-webhook-attempt-unique.sql
       - ./db/migrations_v3_5_webhook_succeeded_unique.sql:/docker-entrypoint-initdb.d/32-webhook-succeeded-unique.sql
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql
+      - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
+      - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
     ports:
       - '127.0.0.1:5433:5432'  # NOTE: 5433 (not 5432) to avoid host-Postgres collision on PROTEUS / any host with system Postgres
     healthcheck:
@@ -105,6 +107,8 @@ services:
       - ./db/migrations_v3_5_webhook_attempt_unique.sql:/migrations/31-webhook-attempt-unique.sql:ro
       - ./db/migrations_v3_5_webhook_succeeded_unique.sql:/migrations/32-webhook-succeeded-unique.sql:ro
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/migrations/33-webhook-succeeded-terminal-trigger.sql:ro
+      - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
+      - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -117,7 +121,9 @@ services:
       -f /migrations/30-webhook-superseded-marker.sql
       -f /migrations/31-webhook-attempt-unique.sql
       -f /migrations/32-webhook-succeeded-unique.sql
-      -f /migrations/33-webhook-succeeded-terminal-trigger.sql"
+      -f /migrations/33-webhook-succeeded-terminal-trigger.sql
+      -f /migrations/34-entities-namespace-unique.sql
+      -f /migrations/35-state-journal-namespace.sql"
     restart: "no"
 
   mnemos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       - ./db/migrations_v3_5_webhook_attempt_unique.sql:/docker-entrypoint-initdb.d/31-webhook-attempt-unique.sql
       - ./db/migrations_v3_5_webhook_succeeded_unique.sql:/docker-entrypoint-initdb.d/32-webhook-succeeded-unique.sql
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql
+      - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
+      - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
@@ -71,6 +73,8 @@ services:
       - ./db/migrations_v3_5_webhook_attempt_unique.sql:/migrations/31-webhook-attempt-unique.sql:ro
       - ./db/migrations_v3_5_webhook_succeeded_unique.sql:/migrations/32-webhook-succeeded-unique.sql:ro
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/migrations/33-webhook-succeeded-terminal-trigger.sql:ro
+      - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
+      - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -83,7 +87,9 @@ services:
       -f /migrations/30-webhook-superseded-marker.sql
       -f /migrations/31-webhook-attempt-unique.sql
       -f /migrations/32-webhook-succeeded-unique.sql
-      -f /migrations/33-webhook-succeeded-terminal-trigger.sql"
+      -f /migrations/33-webhook-succeeded-terminal-trigger.sql
+      -f /migrations/34-entities-namespace-unique.sql
+      -f /migrations/35-state-journal-namespace.sql"
     restart: "no"
 
   ollama:

--- a/install.py
+++ b/install.py
@@ -176,6 +176,8 @@ def main() -> None:
         os.path.join(script_dir, "db", "migrations_v3_5_webhook_attempt_unique.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_webhook_succeeded_unique.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_webhook_succeeded_terminal_trigger.sql"),
+        os.path.join(script_dir, "db", "migrations_v3_5_entities_namespace_unique.sql"),
+        os.path.join(script_dir, "db", "migrations_v3_5_state_journal_namespace.sql"),
     ]
 
     print("=" * 60)

--- a/installer/db.py
+++ b/installer/db.py
@@ -261,6 +261,8 @@ def run_migrations(config: Config) -> bool:
         repo_path / "db" / "migrations_v3_5_webhook_attempt_unique.sql",
         repo_path / "db" / "migrations_v3_5_webhook_succeeded_unique.sql",
         repo_path / "db" / "migrations_v3_5_webhook_succeeded_terminal_trigger.sql",
+        repo_path / "db" / "migrations_v3_5_entities_namespace_unique.sql",
+        repo_path / "db" / "migrations_v3_5_state_journal_namespace.sql",
     ]
 
     print("[db] Running migrations...")

--- a/tests/test_migration_lists_sync.py
+++ b/tests/test_migration_lists_sync.py
@@ -49,6 +49,8 @@ EXPECTED_MIGRATIONS = [
     "migrations_v3_5_webhook_attempt_unique.sql",
     "migrations_v3_5_webhook_succeeded_unique.sql",
     "migrations_v3_5_webhook_succeeded_terminal_trigger.sql",
+    "migrations_v3_5_entities_namespace_unique.sql",
+    "migrations_v3_5_state_journal_namespace.sql",
 ]
 
 
@@ -227,6 +229,14 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql"
         ) in text, compose_name
         assert (
+            "./db/migrations_v3_5_entities_namespace_unique.sql:"
+            "/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql"
+        ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_state_journal_namespace.sql:"
+            "/docker-entrypoint-initdb.d/35-state-journal-namespace.sql"
+        ) in text, compose_name
+        assert (
             "./db/migrations_v3_5_trigger_same_memory_parent.sql:"
             "/migrations/24-trigger-same-memory-parent.sql:ro"
         ) in text, compose_name
@@ -266,6 +276,14 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:"
             "/migrations/33-webhook-succeeded-terminal-trigger.sql:ro"
         ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_entities_namespace_unique.sql:"
+            "/migrations/34-entities-namespace-unique.sql:ro"
+        ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_state_journal_namespace.sql:"
+            "/migrations/35-state-journal-namespace.sql:ro"
+        ) in text, compose_name
         assert "psql -h postgres -U mnemos_user -d mnemos" in text, compose_name
         assert "-v ON_ERROR_STOP=1" in text, compose_name
         assert "-f /migrations/24-trigger-same-memory-parent.sql" in text, compose_name
@@ -278,6 +296,8 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
         assert "-f /migrations/31-webhook-attempt-unique.sql" in text, compose_name
         assert "-f /migrations/32-webhook-succeeded-unique.sql" in text, compose_name
         assert "-f /migrations/33-webhook-succeeded-terminal-trigger.sql" in text, compose_name
+        assert "-f /migrations/34-entities-namespace-unique.sql" in text, compose_name
+        assert "-f /migrations/35-state-journal-namespace.sql" in text, compose_name
         assert "postgres-upgrade:\n        condition: service_completed_successfully" in text, compose_name
 
 

--- a/tests/test_namespace_isolation.py
+++ b/tests/test_namespace_isolation.py
@@ -1,0 +1,333 @@
+"""Cross-namespace isolation for state, journal, and entities.
+
+These tests use real bearer API keys against a live Postgres database so they
+exercise auth-time namespace resolution plus handler SQL predicates together.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+PG_URL = os.getenv("MNEMOS_TEST_DB")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not PG_URL, reason="set MNEMOS_TEST_DB=postgres://... to run integration tests"),
+    pytest.mark.asyncio,
+]
+
+
+@dataclass(frozen=True)
+class Tenant:
+    user_id: str
+    namespace: str
+    api_key: str
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+
+@dataclass(frozen=True)
+class NamespaceHarness:
+    client: AsyncClient
+    pool: Any
+    prefix: str
+    alice: Tenant
+    bob: Tenant
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def _headers(raw_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw_key}"}
+
+
+def _decode_jsonb(value: Any) -> Any:
+    return json.loads(value) if isinstance(value, str) else value
+
+
+async def _seed_api_key(conn, *, user_id: str, namespace: str, raw_key: str, role: str = "user") -> None:
+    await conn.execute(
+        """
+        INSERT INTO users (id, display_name, role, namespace)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (id) DO UPDATE
+        SET role = EXCLUDED.role,
+            namespace = EXCLUDED.namespace,
+            updated_at = NOW()
+        """,
+        user_id,
+        user_id,
+        role,
+        namespace,
+    )
+    await conn.execute(
+        """
+        INSERT INTO api_keys (user_id, key_hash, key_prefix, label, revoked)
+        VALUES ($1, $2, $3, $4, FALSE)
+        ON CONFLICT (key_hash) DO UPDATE
+        SET user_id = EXCLUDED.user_id,
+            label = EXCLUDED.label,
+            revoked = FALSE
+        """,
+        user_id,
+        _hash_key(raw_key),
+        raw_key[:12],
+        f"namespace-isolation-{user_id}",
+    )
+
+
+@pytest_asyncio.fixture
+async def pg_app(monkeypatch):
+    import asyncpg
+    import api.lifecycle as lc
+    from api.auth import configure_auth
+    from api_server import app
+
+    assert PG_URL is not None
+    prefix = f"nsiso{uuid.uuid4().hex[:12]}"
+    pool = await asyncpg.create_pool(PG_URL, min_size=1, max_size=4)
+    background_tasks: list[asyncio.Task] = []
+
+    def _schedule_background(coro):
+        task = asyncio.create_task(coro)
+        background_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(lc, "_pool", pool)
+    monkeypatch.setattr(lc, "_cache", None)
+    monkeypatch.setattr(lc, "_schedule_background", _schedule_background)
+    app.state.pool = pool
+    configure_auth({"enabled": True, "default_namespace": "default", "personal_user_id": "default"})
+
+    alice = Tenant(
+        user_id=f"{prefix}alice",
+        namespace=f"{prefix}nsA",
+        api_key=f"{prefix}-alice-{uuid.uuid4().hex}",
+    )
+    bob = Tenant(
+        user_id=f"{prefix}bob",
+        namespace=f"{prefix}nsB",
+        api_key=f"{prefix}-bob-{uuid.uuid4().hex}",
+    )
+
+    async with pool.acquire() as conn:
+        await _seed_api_key(conn, user_id=alice.user_id, namespace=alice.namespace, raw_key=alice.api_key)
+        await _seed_api_key(conn, user_id=bob.user_id, namespace=bob.namespace, raw_key=bob.api_key)
+
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            yield NamespaceHarness(client=client, pool=pool, prefix=prefix, alice=alice, bob=bob)
+    finally:
+        if background_tasks:
+            await asyncio.gather(*background_tasks, return_exceptions=True)
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM entities WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM state WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM journal WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM api_keys WHERE label LIKE $1", f"namespace-isolation-{prefix}%")
+            await conn.execute("DELETE FROM users WHERE id LIKE $1", f"{prefix}%")
+        configure_auth({"enabled": False})
+        await pool.close()
+
+
+async def test_state_namespace_isolation(pg_app: NamespaceHarness):
+    key_a = f"{pg_app.prefix}-state-a"
+    key_b = f"{pg_app.prefix}-state-b"
+
+    resp = await pg_app.client.put(
+        f"/state/{key_a}",
+        json={"value": {"tenant": "a"}},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await pg_app.client.put(
+        f"/state/{key_b}",
+        json={"value": {"tenant": "b"}},
+        headers=pg_app.bob.headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await pg_app.client.get(f"/state/{key_b}", headers=pg_app.alice.headers)
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.get("/state", headers=pg_app.alice.headers)
+    assert resp.status_code == 200, resp.text
+    visible = {item["key"] for item in resp.json()["keys"]}
+    assert key_a in visible
+    assert key_b not in visible
+
+    resp = await pg_app.client.put(
+        f"/state/{key_b}?namespace={pg_app.bob.namespace}",
+        json={"value": {"tenant": "a-overwrite"}},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 403
+
+    resp = await pg_app.client.delete(f"/state/{key_b}", headers=pg_app.alice.headers)
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.get(f"/state/{key_b}", headers=pg_app.bob.headers)
+    assert resp.status_code == 200, resp.text
+    assert _decode_jsonb(resp.json()["value"]) == {"tenant": "b"}
+
+
+async def test_journal_namespace_isolation(pg_app: NamespaceHarness):
+    topic_a = f"{pg_app.prefix}-journal-a"
+    topic_b = f"{pg_app.prefix}-journal-b"
+
+    resp = await pg_app.client.post(
+        "/journal",
+        json={"topic": topic_a, "content": "visible only in namespace A"},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 201, resp.text
+    entry_a = resp.json()["id"]
+
+    resp = await pg_app.client.post(
+        "/journal",
+        json={"topic": topic_b, "content": "visible only in namespace B"},
+        headers=pg_app.bob.headers,
+    )
+    assert resp.status_code == 201, resp.text
+    entry_b = resp.json()["id"]
+
+    resp = await pg_app.client.get("/journal", headers=pg_app.alice.headers)
+    assert resp.status_code == 200, resp.text
+    visible = {item["id"] for item in resp.json()["entries"]}
+    assert entry_a in visible
+    assert entry_b not in visible
+
+    resp = await pg_app.client.post(
+        f"/journal?namespace={pg_app.bob.namespace}",
+        json={"topic": topic_b, "content": "cross-namespace write attempt"},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 403
+
+    resp = await pg_app.client.delete(f"/journal/{entry_b}", headers=pg_app.alice.headers)
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.get("/journal", headers=pg_app.bob.headers)
+    assert resp.status_code == 200, resp.text
+    visible = {item["id"] for item in resp.json()["entries"]}
+    assert entry_b in visible
+
+
+async def test_entities_namespace_isolation_and_related_lookup(pg_app: NamespaceHarness):
+    alice_name = f"{pg_app.prefix}-alice-entity"
+    bob_name = f"{pg_app.prefix}-bob-entity"
+
+    resp = await pg_app.client.post(
+        "/entities",
+        json={"entity_type": "person", "name": alice_name},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 201, resp.text
+    alice_entity_id = resp.json()["id"]
+
+    resp = await pg_app.client.post(
+        "/entities",
+        json={"entity_type": "person", "name": bob_name},
+        headers=pg_app.bob.headers,
+    )
+    assert resp.status_code == 201, resp.text
+    bob_entity_id = resp.json()["id"]
+
+    resp = await pg_app.client.get(f"/entities?search={bob_name}", headers=pg_app.alice.headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["entities"] == []
+
+    resp = await pg_app.client.get(f"/entities/{bob_entity_id}", headers=pg_app.alice.headers)
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.patch(
+        f"/entities/{bob_entity_id}",
+        json={"description": "alice should not update this"},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.post(
+        f"/entities/{alice_entity_id}/link",
+        json={"related_id": bob_entity_id},
+        headers=pg_app.alice.headers,
+    )
+    assert resp.status_code == 404
+
+    async with pg_app.pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE entities SET related_entities = ARRAY[$2::uuid] WHERE id = $1::uuid",
+            alice_entity_id,
+            bob_entity_id,
+        )
+
+    resp = await pg_app.client.get(f"/entities/{alice_entity_id}/related", headers=pg_app.alice.headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["related"] == []
+
+    resp = await pg_app.client.delete(f"/entities/{bob_entity_id}", headers=pg_app.alice.headers)
+    assert resp.status_code == 404
+
+    resp = await pg_app.client.get(f"/entities/{bob_entity_id}", headers=pg_app.bob.headers)
+    assert resp.status_code == 200, resp.text
+
+
+async def test_same_owner_can_create_same_entity_name_in_two_namespaces(pg_app: NamespaceHarness):
+    owner_id = f"{pg_app.prefix}sameowner"
+    namespace_a = f"{pg_app.prefix}ownerA"
+    namespace_b = f"{pg_app.prefix}ownerB"
+    key_a = f"{pg_app.prefix}-same-owner-a-{uuid.uuid4().hex}"
+    key_b = f"{pg_app.prefix}-same-owner-b-{uuid.uuid4().hex}"
+    entity_name = f"{pg_app.prefix}-Alice"
+
+    async with pg_app.pool.acquire() as conn:
+        await _seed_api_key(conn, user_id=owner_id, namespace=namespace_a, raw_key=key_a)
+        await _seed_api_key(conn, user_id=owner_id, namespace=namespace_a, raw_key=key_b)
+
+    resp = await pg_app.client.post(
+        "/entities",
+        json={"entity_type": "person", "name": entity_name},
+        headers=_headers(key_a),
+    )
+    assert resp.status_code == 201, resp.text
+    first_id = resp.json()["id"]
+
+    async with pg_app.pool.acquire() as conn:
+        await conn.execute("UPDATE users SET namespace = $1 WHERE id = $2", namespace_b, owner_id)
+
+    resp = await pg_app.client.post(
+        "/entities",
+        json={"entity_type": "person", "name": entity_name},
+        headers=_headers(key_b),
+    )
+    assert resp.status_code == 201, resp.text
+    second_id = resp.json()["id"]
+    assert second_id != first_id
+
+    async with pg_app.pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT namespace
+            FROM entities
+            WHERE owner_id = $1 AND entity_type = 'person' AND name = $2
+            ORDER BY namespace
+            """,
+            owner_id,
+            entity_name,
+        )
+
+    assert [row["namespace"] for row in rows] == [namespace_a, namespace_b]

--- a/tests/test_webhooks_entities_namespace.py
+++ b/tests/test_webhooks_entities_namespace.py
@@ -174,7 +174,7 @@ def test_entities_assert_owned_root_bypasses_namespace(monkeypatch):
     conn = _Conn(row={"owner_id": "bob", "namespace": "bob-ns"})
     # Root call — should NOT raise
     result = asyncio.run(ent._assert_owned(conn, str(uuid.uuid4()), _root()))
-    assert result == "bob"
+    assert result == ("bob", "bob-ns")
 
 
 # ─── webhooks ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Audit must-fix #6: namespace scope was uneven outside memory core. State + journal were owner-scoped only; entities passed `_assert_owned` (owner+namespace check) but mutated by `id+owner_id` only; entities uniqueness key didn't include namespace.

- `api/handlers/state.py` + `journal.py` — namespace pinned via `_scope_namespace` helper, all SELECT/INSERT/UPDATE/DELETE carry `(owner_id, namespace, ...)`, root may target another namespace via `?namespace=`.
- `api/handlers/entities.py` — UPDATE / DELETE / link / related-lookup mutation predicates carry namespace into the WHERE alongside owner (defense-in-depth: a concurrent namespace change between assert + mutation cannot land on the wrong row). `create_entity` ON CONFLICT widened to `(owner_id, namespace, entity_type, name)`.
- `db/migrations_v3_5_entities_namespace_unique.sql` — drop narrower unique key by column-set (handles renames + legacy `(entity_type, name)`-only installs), add the four-column key. Idempotent. Aborts loudly on existing collisions under the new key.
- `db/migrations_v3_5_state_journal_namespace.sql` — adds `namespace` column to `state` + `journal`, widens state PK to `(owner_id, namespace, key)`, indexes both `(owner_id, namespace)`. Idempotent + dedup-checked.
- `install.py` + `installer/db.py` + `docker-compose.yml` + `docker-compose.staging.yml` + `.gitlab-ci.yml` integration tier — wire both new migrations.
- `tests/test_namespace_isolation.py` — cross-namespace isolation regressions for state, journal, entities (same owner can have entity Alice/person in two namespaces; ns-A user cannot see/touch ns-B rows).

Audit reference: `mem_9a4e7dc46fea` Section G must-fix #6.

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_namespace_isolation.py` — 906 passed, 18 skipped, 0 regressions
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [ ] GitLab integration tier — runs new namespace_isolation tests against real Postgres + applies new migrations
- [ ] GitHub `pr-check.yml` — ruff + unit gate

Authored-By: Codex