### PR TITLE
Slice 12: compression semantics — prune session-layer NULL fiction (audit must-fix #7)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,8 @@ test:integration:
         db/migrations_v3_5_webhook_succeeded_unique.sql \
         db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql \
         db/migrations_v3_5_entities_namespace_unique.sql \
-        db/migrations_v3_5_state_journal_namespace.sql; do
+        db/migrations_v3_5_state_journal_namespace.sql \
+        db/migrations_v3_5_session_compression_ratio_drop.sql; do
         if [ -f "$f" ]; then
           echo "applying $f"
           psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 -f "$f"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ single-site HA replication doctrine.
   scenarios such as multi-site deployments, multi-org curated feeds, developer
   laptop replicas with intermittent connectivity, and planned v4 SQLite-based
   local-replica profiles.
+- **Slice 12 — compression semantics** — drop session-layer always-NULL
+  `compression_ratio` fiction columns from `session_messages` +
+  `session_memory_injections`; document operator-batched compression doctrine in
+  `docs/COMPRESSION.md`. Real compression layer (`compression_artifacts` /
+  contests, `StatsResponse`, `RehydrationResponse`, admin batch endpoints)
+  unchanged.
 
 ### Fixed
 

--- a/api/handlers/sessions.py
+++ b/api/handlers/sessions.py
@@ -136,7 +136,7 @@ async def add_session_message(
     This is the main stateful chat endpoint. It:
     1. Stores user message in history
     2. Searches MNEMOS for relevant context
-    3. Injects compressed memories into system prompt
+    3. Injects bounded memory snippets into system prompt
     4. Routes to provider with accumulated context
     5. Stores assistant response in history
     6. Updates session metrics
@@ -246,27 +246,19 @@ async def add_session_message(
 
         if mnemos_docs:
             # Store injection record for each memory.
-            # compression_ratio is NULL because the session-injection path
-            # currently ships raw-slice truncation (doc['content'][:500] below),
-            # not real ARTEMIS compression. Writing a
-            # fabricated ratio (previously: 0.45 literal) turned
-            # `session_memory_injections.compression_ratio` into a fiction
-            # column. It stays NULL until v3.1 wires compression into this
-            # path with a real ratio derived from the compression manifest.
             async with pool.acquire() as conn:
                 for i, doc in enumerate(mnemos_docs):
                     memory_id = doc.get("id", f"doc_{i}")
                     await conn.execute(
                         """
                         INSERT INTO session_memory_injections
-                        (session_id, message_id, memory_id, relevance_score, compression_ratio)
-                        VALUES ($1, $2, $3, $4, $5)
+                        (session_id, message_id, memory_id, relevance_score)
+                        VALUES ($1, $2, $3, $4)
                         """,
                         session_id,
                         message_id,
                         memory_id,
                         0.9 - (i * 0.1),  # decreasing relevance
-                        None,  # real ratio requires compression wired into the session path
                     )
 
             mnemos_context = "\n\n".join([f"[Memory]\n{doc['content'][:500]}" for doc in mnemos_docs])
@@ -300,7 +292,6 @@ async def add_session_message(
     model = request.model or session["model"]
     response_text = ""
     tokens_used = 0
-    compression_ratio = None
 
     try:
         response_text = await _route_to_provider(
@@ -313,11 +304,6 @@ async def add_session_message(
 
         # Estimate tokens (rough approximation: ~4 chars per token)
         tokens_used = len(response_text) // 4
-        # compression_ratio stays NULL at the session-message level until
-        # compression is actually wired into the session-injection path.
-        # Prior code computed `memories_injected / message_count` — a ratio
-        # with no semantic relationship to compression effectiveness.
-        compression_ratio = None
 
     except Exception as e:
         logger.error(f"[SESSIONS] Provider routing failed: {e}")
@@ -329,8 +315,8 @@ async def add_session_message(
         assistant_message_id = await conn.fetchval(
             """
             INSERT INTO session_messages
-            (session_id, role, content, model, tokens_used, memories_injected, compression_ratio)
-            VALUES ($1, 'assistant', $2, $3, $4, $5, $6)
+            (session_id, role, content, model, tokens_used, memories_injected)
+            VALUES ($1, 'assistant', $2, $3, $4, $5)
             RETURNING id
             """,
             session_id,
@@ -338,7 +324,6 @@ async def add_session_message(
             model,
             tokens_used,
             memories_injected,
-            compression_ratio,
         )
 
         # Update session metrics
@@ -368,7 +353,6 @@ async def add_session_message(
         timestamp=datetime.now(timezone.utc).isoformat(),
         tokens_used=tokens_used,
         memories_injected=memories_injected,
-        compression_ratio=compression_ratio,
     )
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -191,7 +191,6 @@ class SessionMessageResponse(BaseModel):
     timestamp: str
     tokens_used: int
     memories_injected: int
-    compression_ratio: Optional[float] = None
 
 
 class SessionHistoryRequest(BaseModel):

--- a/db/migrations_v3_5_session_compression_ratio_drop.sql
+++ b/db/migrations_v3_5_session_compression_ratio_drop.sql
@@ -1,0 +1,15 @@
+-- migrations_v3_5_session_compression_ratio_drop.sql
+--
+-- Audit must-fix #7: remove session-layer compression_ratio fiction.
+-- These columns were always NULL after placeholder ratios were removed;
+-- real compression ratios live in the operator-batched compression tables.
+
+BEGIN;
+
+ALTER TABLE session_messages
+    DROP COLUMN IF EXISTS compression_ratio;
+
+ALTER TABLE session_memory_injections
+    DROP COLUMN IF EXISTS compression_ratio;
+
+COMMIT;

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -80,6 +80,7 @@ services:
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
+      - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
     ports:
       - '127.0.0.1:5433:5432'  # NOTE: 5433 (not 5432) to avoid host-Postgres collision on PROTEUS / any host with system Postgres
     healthcheck:
@@ -109,6 +110,7 @@ services:
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/migrations/33-webhook-succeeded-terminal-trigger.sql:ro
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
+      - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -123,7 +125,8 @@ services:
       -f /migrations/32-webhook-succeeded-unique.sql
       -f /migrations/33-webhook-succeeded-terminal-trigger.sql
       -f /migrations/34-entities-namespace-unique.sql
-      -f /migrations/35-state-journal-namespace.sql"
+      -f /migrations/35-state-journal-namespace.sql
+      -f /migrations/36-session-compression-ratio-drop.sql"
     restart: "no"
 
   mnemos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
+      - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
@@ -75,6 +76,7 @@ services:
       - ./db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql:/migrations/33-webhook-succeeded-terminal-trigger.sql:ro
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
+      - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -89,7 +91,8 @@ services:
       -f /migrations/32-webhook-succeeded-unique.sql
       -f /migrations/33-webhook-succeeded-terminal-trigger.sql
       -f /migrations/34-entities-namespace-unique.sql
-      -f /migrations/35-state-journal-namespace.sql"
+      -f /migrations/35-state-journal-namespace.sql
+      -f /migrations/36-session-compression-ratio-drop.sql"
     restart: "no"
 
   ollama:

--- a/docs/COMPRESSION.md
+++ b/docs/COMPRESSION.md
@@ -1,0 +1,35 @@
+# MNEMOS compression — operator-batched doctrine
+
+Compression is opt-in and operator-batched through the admin endpoints:
+
+- `POST /v1/admin/compression/enqueue`
+- `POST /v1/admin/compression/enqueue-all`
+
+Memory creation does not auto-enqueue contest jobs. This is deliberate:
+compression is expensive work. It can involve LLM-judged contests and GPU
+execution, and pervasive auto-compression on every create would saturate the
+GPU pool while increasing cost-per-memory without an operator-controlled bound.
+
+The compression flow is:
+
+1. An operator enqueues specific memories or a bounded batch through the admin
+   API.
+2. Contest workers drain `memory_compression_queue`.
+3. Eligible engines produce candidates and the judge selects winners.
+4. `memory_compression_candidates` records the full contest audit trail.
+5. `memory_compressed_variants` stores the current winning artifact.
+6. `RehydrationResponse.compression_ratio` and
+   `StatsResponse.average_compression_ratio` surface real ratios from those
+   compression artifacts.
+
+The admin endpoint request models and queue inserts live in
+[`api/handlers/admin.py`](../api/handlers/admin.py).
+
+Session messages and session memory injections do not carry compression tags.
+Slice 12 dropped the always-NULL `compression_ratio` columns from
+`session_messages` and `session_memory_injections`. Session memory injection
+still slices `doc["content"][:500]` as a prompt-budget control. That is
+truncation, not compression, and no ratio is recorded for it.
+
+The Slice 12 migration drops are idempotent and safe: the removed session-layer
+columns were always NULL fiction columns, not the real compression store.

--- a/install.py
+++ b/install.py
@@ -178,6 +178,7 @@ def main() -> None:
         os.path.join(script_dir, "db", "migrations_v3_5_webhook_succeeded_terminal_trigger.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_entities_namespace_unique.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_state_journal_namespace.sql"),
+        os.path.join(script_dir, "db", "migrations_v3_5_session_compression_ratio_drop.sql"),
     ]
 
     print("=" * 60)

--- a/installer/db.py
+++ b/installer/db.py
@@ -263,6 +263,7 @@ def run_migrations(config: Config) -> bool:
         repo_path / "db" / "migrations_v3_5_webhook_succeeded_terminal_trigger.sql",
         repo_path / "db" / "migrations_v3_5_entities_namespace_unique.sql",
         repo_path / "db" / "migrations_v3_5_state_journal_namespace.sql",
+        repo_path / "db" / "migrations_v3_5_session_compression_ratio_drop.sql",
     ]
 
     print("[db] Running migrations...")

--- a/tests/test_migration_lists_sync.py
+++ b/tests/test_migration_lists_sync.py
@@ -51,6 +51,7 @@ EXPECTED_MIGRATIONS = [
     "migrations_v3_5_webhook_succeeded_terminal_trigger.sql",
     "migrations_v3_5_entities_namespace_unique.sql",
     "migrations_v3_5_state_journal_namespace.sql",
+    "migrations_v3_5_session_compression_ratio_drop.sql",
 ]
 
 
@@ -237,6 +238,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "/docker-entrypoint-initdb.d/35-state-journal-namespace.sql"
         ) in text, compose_name
         assert (
+            "./db/migrations_v3_5_session_compression_ratio_drop.sql:"
+            "/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql"
+        ) in text, compose_name
+        assert (
             "./db/migrations_v3_5_trigger_same_memory_parent.sql:"
             "/migrations/24-trigger-same-memory-parent.sql:ro"
         ) in text, compose_name
@@ -284,6 +289,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "./db/migrations_v3_5_state_journal_namespace.sql:"
             "/migrations/35-state-journal-namespace.sql:ro"
         ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_session_compression_ratio_drop.sql:"
+            "/migrations/36-session-compression-ratio-drop.sql:ro"
+        ) in text, compose_name
         assert "psql -h postgres -U mnemos_user -d mnemos" in text, compose_name
         assert "-v ON_ERROR_STOP=1" in text, compose_name
         assert "-f /migrations/24-trigger-same-memory-parent.sql" in text, compose_name
@@ -298,6 +307,7 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
         assert "-f /migrations/33-webhook-succeeded-terminal-trigger.sql" in text, compose_name
         assert "-f /migrations/34-entities-namespace-unique.sql" in text, compose_name
         assert "-f /migrations/35-state-journal-namespace.sql" in text, compose_name
+        assert "-f /migrations/36-session-compression-ratio-drop.sql" in text, compose_name
         assert "postgres-upgrade:\n        condition: service_completed_successfully" in text, compose_name
 
 


### PR DESCRIPTION
## Summary
Last audit must-fix item. Session-layer `compression_ratio` columns on `session_messages` + `session_memory_injections` were always-NULL fiction (per audit's framing in `mem_9a4e7dc46fea` Section G #7) — populated to NULL with apologetic inline comments since v2 and never wired to real compression. Pruned + codified the operator-batched doctrine.

- `api/handlers/sessions.py` + `api/models.py` — dropped `compression_ratio` from session_message INSERT, session_memory_injections INSERT, and `SessionMessageResponse`. Removed apologetic comments describing now-deleted code.
- `db/migrations_v3_5_session_compression_ratio_drop.sql` (NEW, prefix 36) — idempotent `DROP COLUMN IF EXISTS` on both tables.
- `docs/COMPRESSION.md` (NEW) — doctrine doc: compression is opt-in, operator-batched via `/v1/admin/compression/enqueue{,-all}`. Memory creation does NOT auto-enqueue. Session injection still slices `doc["content"][:500]` as a prompt-budget control — that is truncation, not compression.
- `install.py` + `installer/db.py` + `docker-compose.yml` + `docker-compose.staging.yml` + `.gitlab-ci.yml` integration tier — wire migration.
- `CHANGELOG.md` — slice 12 entry.

**Real compression layer untouched**: `StatsResponse.average_compression_ratio`, `RehydrationResponse.compression_ratio`, `compression_artifacts`, `compression_contests`, all admin batch endpoints stay as-is.

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_namespace_isolation.py` — 909 passed, 18 skipped, 0 regressions
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [ ] GitLab integration tier — applies new migration on real Postgres
- [ ] GitHub `pr-check.yml`

Audit reference: `mem_9a4e7dc46fea` Section G must-fix #7.

Authored-By: Codex