### PR TITLE
Slice 13: Phase-1 audit closure pass — 5 gaps from re-audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@
 # ── Server Configuration ──────────────────────────────────────────────────────
 MNEMOS_PORT=5002
 MNEMOS_BIND=127.0.0.1
-MNEMOS_WORKERS=1  # IMPORTANT: Keep at 1 for in-process state (rate limiters, circuit breakers)
 
 # ── Database Configuration ────────────────────────────────────────────────────
 # PostgreSQL connection for memory storage, audit logs, sessions, and DAG versioning

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,8 @@ test:integration:
         db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql \
         db/migrations_v3_5_entities_namespace_unique.sql \
         db/migrations_v3_5_state_journal_namespace.sql \
-        db/migrations_v3_5_session_compression_ratio_drop.sql; do
+        db/migrations_v3_5_session_compression_ratio_drop.sql \
+        db/migrations_v3_5_session_compression_legacy_drop.sql; do
         if [ -f "$f" ]; then
           echo "applying $f"
           psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 -f "$f"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ single-site HA replication doctrine.
 
 ### Changed
 
+- **Slice 13 Phase-1 audit closure.** Internal categorization managers now
+  require caller context and scope state, journal, and entity CRUD by
+  `owner_id + namespace`; memory-created webhook delivery rows are enqueued in
+  the same transaction as the memory insert; unknown chat-completion models now
+  return OpenAI-style `404 model_not_found`; stale session compression columns
+  are dropped by a new v3.5 migration; deployment docs and templates now state
+  the v3.5 single-worker runtime contract.
 - **Memory read surfaces use one predicate.** `list_memories`,
   `get_memory`, search, rehydrate, and gateway context now share the
   owner/federated/world/group-readable predicate. The Redis search

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -33,10 +33,19 @@ python install.py
 
 # Start MNEMOS server
 export $(cat .env | grep -v '#' | xargs)
-python -m uvicorn api_server:app --host $MNEMOS_BIND --port $MNEMOS_PORT --workers $MNEMOS_WORKERS
+python -m uvicorn api_server:app --host $MNEMOS_BIND --port $MNEMOS_PORT
 ```
 
 The API will be available at `http://$MNEMOS_BIND:$MNEMOS_PORT`
+
+---
+
+## Single-Worker Runtime
+
+MNEMOS v3.5 runs single-worker by design. In-process state (rate limiter,
+dispatch semaphores, recovery worker) is not yet externalized. Horizontal
+scaling is on the v4 roadmap. Operators wanting throughput should scale memory
+size + DB; do not increase workers.
 
 ---
 
@@ -454,7 +463,6 @@ PG_POOL_SIZE=50
 
 MNEMOS_BIND=0.0.0.0
 MNEMOS_PORT=5002
-MNEMOS_WORKERS=1  # Keep at 1 for in-process state
 
 MNEMOS_API_KEY=$(openssl rand -hex 32)
 
@@ -487,8 +495,7 @@ WorkingDirectory=/opt/mnemos
 EnvironmentFile=/opt/mnemos/.env
 ExecStart=/usr/bin/python3 -m uvicorn api_server:app \
   --host ${MNEMOS_BIND} \
-  --port ${MNEMOS_PORT} \
-  --workers ${MNEMOS_WORKERS}
+  --port ${MNEMOS_PORT}
 Restart=always
 RestartSec=10
 

--- a/README.md
+++ b/README.md
@@ -610,6 +610,11 @@ python api_server.py        # MNEMOS on port 5002
 curl http://localhost:5002/health
 ```
 
+MNEMOS v3.5 runs single-worker by design. In-process state (rate limiter,
+dispatch semaphores, recovery worker) is not yet externalized. Horizontal
+scaling is on the v4 roadmap. Operators wanting throughput should scale memory
+size + DB; do not increase workers.
+
 ---
 
 ## API reference

--- a/api/handlers/consultations.py
+++ b/api/handlers/consultations.py
@@ -434,14 +434,17 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
         try:
             from api.webhook_dispatcher import dispatch as _dispatch_webhook
             if _lc._pool and consultation_id is not None:
-                async with _lc._pool.acquire() as _wh_conn:
-                    await _dispatch_webhook(_wh_conn, "consultation.completed", {
+                await _dispatch_webhook(
+                    "consultation.completed",
+                    {
                         "consultation_id": str(consultation_id),
                         "task_type": body.task_type,
                         "winning_muse": result.get("winning_muse"),
                         "consensus_score": result.get("consensus_score"),
                         "owner_id": user.user_id,
-                    }, owner_id=user.user_id)
+                    },
+                    owner_id=user.user_id,
+                )
         except Exception:
             logger.warning("webhook dispatch failed for consultation.completed %s", consultation_id, exc_info=True)
 

--- a/api/handlers/dag.py
+++ b/api/handlers/dag.py
@@ -957,8 +957,9 @@ async def merge_branch(
 
             try:
                 from api.webhook_dispatcher import dispatch as _dispatch_webhook
-                async with _lc._pool.acquire() as _wh_conn:
-                    await _dispatch_webhook(_wh_conn, "memory.updated", {
+                await _dispatch_webhook(
+                    "memory.updated",
+                    {
                         "memory_id": memory_id,
                         "category": source_head["category"],
                         "subcategory": source_head["subcategory"],
@@ -967,7 +968,10 @@ async def merge_branch(
                         "namespace": merge_namespace,
                         "merge_source": request.source_branch,
                         "merge_target": target_branch,
-                    }, owner_id=merge_owner_id, namespace=merge_namespace)
+                    },
+                    owner_id=merge_owner_id,
+                    namespace=merge_namespace,
+                )
             except Exception:
                 logger.warning(
                     "webhook dispatch failed for memory.updated %s",

--- a/api/handlers/document_import.py
+++ b/api/handlers/document_import.py
@@ -267,22 +267,21 @@ async def import_memories_from_document(
                 pass
         try:
             from api.webhook_dispatcher import dispatch as _dispatch_webhook
-            async with _lc._pool.acquire() as _wh_conn:
-                for mid, chunk in zip(memory_ids, chunks):
-                    await _dispatch_webhook(
-                        _wh_conn, "memory.created",
-                        {
-                            "memory_id": mid,
-                            "category": category,
-                            "subcategory": subcategory,
-                            "content": chunk["content"],
-                            "owner_id": user.user_id,
-                            "namespace": user.namespace,
-                            "source": "document_import",
-                        },
-                        owner_id=user.user_id,
-                        namespace=user.namespace,
-                    )
+            for mid, chunk in zip(memory_ids, chunks):
+                await _dispatch_webhook(
+                    "memory.created",
+                    {
+                        "memory_id": mid,
+                        "category": category,
+                        "subcategory": subcategory,
+                        "content": chunk["content"],
+                        "owner_id": user.user_id,
+                        "namespace": user.namespace,
+                        "source": "document_import",
+                    },
+                    owner_id=user.user_id,
+                    namespace=user.namespace,
+                )
         except Exception:
             logger.warning(
                 "webhook dispatch failed for document_import (%d memories)",

--- a/api/handlers/memories.py
+++ b/api/handlers/memories.py
@@ -526,27 +526,52 @@ async def create_memory(
     owner_id = request.owner_id or user.user_id
     namespace = request.namespace or user.namespace
 
-    async with _lc._pool.acquire() as conn:
-        async with _rls_context(conn, user):
-            async with conn.transaction():
-                meta = json.dumps(request.metadata or {"source": request.source})
-                verbatim = request.verbatim_content if request.verbatim_content is not None else request.content
-                await conn.execute(
-                    "INSERT INTO memories "
-                    "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
-                    "owner_id, namespace, permission_mode, "
-                    "source_model, source_provider, source_session, source_agent) "
-                    "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
-                    mem_id, request.content, request.category, request.subcategory, meta, verbatim,
-                    owner_id, namespace, 600,
-                    request.source_model, request.source_provider,
-                    request.source_session, request.source_agent,
-                )
-                # (trigger trg_memory_version_insert inserts version 1 automatically,
-                # computing commit_hash + branch; no explicit handler INSERT needed)
-                row = await conn.fetchrow(
-                    f"SELECT {_MEMORY_COLS} FROM memories WHERE id=$1", mem_id,
-                )
+    try:
+        async with _lc._pool.acquire() as conn:
+            async with _rls_context(conn, user):
+                async with conn.transaction():
+                    meta = json.dumps(request.metadata or {"source": request.source})
+                    verbatim = (
+                        request.verbatim_content
+                        if request.verbatim_content is not None
+                        else request.content
+                    )
+                    await conn.execute(
+                        "INSERT INTO memories "
+                        "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
+                        "owner_id, namespace, permission_mode, "
+                        "source_model, source_provider, source_session, source_agent) "
+                        "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
+                        mem_id, request.content, request.category, request.subcategory, meta, verbatim,
+                        owner_id, namespace, 600,
+                        request.source_model, request.source_provider,
+                        request.source_session, request.source_agent,
+                    )
+                    # (trigger trg_memory_version_insert inserts version 1 automatically,
+                    # computing commit_hash + branch; no explicit handler INSERT needed)
+                    row = await conn.fetchrow(
+                        f"SELECT {_MEMORY_COLS} FROM memories WHERE id=$1", mem_id,
+                    )
+                    from api.webhook_dispatcher import dispatch as _dispatch_webhook
+                    await _dispatch_webhook(
+                        "memory.created",
+                        {
+                            "memory_id": mem_id,
+                            "category": request.category,
+                            "subcategory": request.subcategory,
+                            "content": request.content,
+                            "owner_id": owner_id,
+                            "namespace": namespace,
+                        },
+                        conn=conn,
+                        owner_id=owner_id,
+                        namespace=namespace,
+                    )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("memory.create transaction failed for %s: %s", mem_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Memory creation failed") from e
     if _lc._cache:
         try:
             await _lc._cache.delete("stats:global")
@@ -560,19 +585,6 @@ async def create_memory(
                 pass
         except Exception:
             pass
-    try:
-        from api.webhook_dispatcher import dispatch as _dispatch_webhook
-        async with _lc._pool.acquire() as _wh_conn:
-            await _dispatch_webhook(_wh_conn, "memory.created", {
-                "memory_id": mem_id,
-                "category": request.category,
-                "subcategory": request.subcategory,
-                "content": request.content,
-                "owner_id": owner_id,
-                "namespace": namespace,
-            }, owner_id=owner_id, namespace=namespace)
-    except Exception:
-        logger.warning("webhook dispatch failed for memory.created %s", mem_id, exc_info=True)
     return _row_to_memory(row)
 
 
@@ -587,42 +599,67 @@ async def bulk_create_memories(
     import time as _time
     created_ids: list[str] = []
     errors: list[str] = []
-    webhook_events: list[tuple[str, str, str, Optional[str], str, str]] = []
-    async with _lc._pool.acquire() as conn:
-        async with _rls_context(conn, user):
-            for i, mem in enumerate(request.memories):
-                if not mem.content.strip():
-                    errors.append(f"[{i}] content is empty")
-                    continue
-                try:
-                    if mem.owner_id and mem.owner_id != user.user_id and user.role != "root":
-                        errors.append(f"[{i}] owner_id override requires root")
-                        continue
-                    if mem.namespace and mem.namespace != user.namespace and user.role != "root":
-                        errors.append(f"[{i}] namespace override requires root")
-                        continue
-                    mid = f"mem_{int(_time.time() * 1000)}_{uuid.uuid4().hex[:6]}"
-                    verbatim = mem.verbatim_content if mem.verbatim_content is not None else mem.content
-                    owner_id = mem.owner_id or user.user_id
-                    namespace = mem.namespace or user.namespace
-                    await conn.execute(
-                        "INSERT INTO memories "
-                        "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
-                        "owner_id, namespace, permission_mode, "
-                        "source_model, source_provider, source_session, source_agent) "
-                        "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
-                        mid, mem.content, mem.category, mem.subcategory,
-                        json.dumps(mem.metadata or {}), verbatim,
-                        owner_id, namespace, 600,
-                        mem.source_model, mem.source_provider,
-                        mem.source_session, mem.source_agent,
-                    )
-                    created_ids.append(mid)
-                    webhook_events.append((
-                        mid, mem.content, mem.category, mem.subcategory, owner_id, namespace,
-                    ))
-                except Exception as e:
-                    errors.append(f"[{i}] {e}")
+    try:
+        from api.webhook_dispatcher import dispatch as _dispatch_webhook
+
+        async with _lc._pool.acquire() as conn:
+            async with _rls_context(conn, user):
+                async with conn.transaction():
+                    for i, mem in enumerate(request.memories):
+                        if not mem.content.strip():
+                            errors.append(f"[{i}] content is empty")
+                            continue
+                        if mem.owner_id and mem.owner_id != user.user_id and user.role != "root":
+                            errors.append(f"[{i}] owner_id override requires root")
+                            continue
+                        if mem.namespace and mem.namespace != user.namespace and user.role != "root":
+                            errors.append(f"[{i}] namespace override requires root")
+                            continue
+                        mid = f"mem_{int(_time.time() * 1000)}_{uuid.uuid4().hex[:6]}"
+                        verbatim = (
+                            mem.verbatim_content
+                            if mem.verbatim_content is not None
+                            else mem.content
+                        )
+                        owner_id = mem.owner_id or user.user_id
+                        namespace = mem.namespace or user.namespace
+                        try:
+                            async with conn.transaction():
+                                await conn.execute(
+                                    "INSERT INTO memories "
+                                    "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
+                                    "owner_id, namespace, permission_mode, "
+                                    "source_model, source_provider, source_session, source_agent) "
+                                    "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
+                                    mid, mem.content, mem.category, mem.subcategory,
+                                    json.dumps(mem.metadata or {}), verbatim,
+                                    owner_id, namespace, 600,
+                                    mem.source_model, mem.source_provider,
+                                    mem.source_session, mem.source_agent,
+                                )
+                        except Exception as e:
+                            errors.append(f"[{i}] {e}")
+                            continue
+                        created_ids.append(mid)
+                        await _dispatch_webhook(
+                            "memory.created",
+                            {
+                                "memory_id": mid,
+                                "category": mem.category,
+                                "subcategory": mem.subcategory,
+                                "content": mem.content,
+                                "owner_id": owner_id,
+                                "namespace": namespace,
+                            },
+                            conn=conn,
+                            owner_id=owner_id,
+                            namespace=namespace,
+                        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("memory.bulk_create transaction failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Bulk memory creation failed") from e
     if _lc._cache:
         try:
             await _lc._cache.delete("stats:global")
@@ -636,21 +673,6 @@ async def bulk_create_memories(
                 pass
         except Exception:
             pass
-    if webhook_events:
-        try:
-            from api.webhook_dispatcher import dispatch as _dispatch_webhook
-            async with _lc._pool.acquire() as _wh_conn:
-                for mid, content, category, subcategory, owner_id, namespace in webhook_events:
-                    await _dispatch_webhook(_wh_conn, "memory.created", {
-                        "memory_id": mid,
-                        "category": category,
-                        "subcategory": subcategory,
-                        "content": content,
-                        "owner_id": owner_id,
-                        "namespace": namespace,
-                    }, owner_id=owner_id, namespace=namespace)
-        except Exception:
-            logger.warning("webhook dispatch failed for memory.created bulk", exc_info=True)
     return BulkCreateResponse(created=len(created_ids), memory_ids=created_ids, errors=errors)
 
 
@@ -740,15 +762,19 @@ async def update_memory(
             pass
     try:
         from api.webhook_dispatcher import dispatch as _dispatch_webhook
-        async with _lc._pool.acquire() as _wh_conn:
-            await _dispatch_webhook(_wh_conn, "memory.updated", {
+        await _dispatch_webhook(
+            "memory.updated",
+            {
                 "memory_id": memory_id,
                 "category": row["category"],
                 "subcategory": row["subcategory"],
                 "content": row["content"],
                 "owner_id": row["owner_id"],
                 "namespace": row["namespace"],
-            }, owner_id=row["owner_id"], namespace=row["namespace"])
+            },
+            owner_id=row["owner_id"],
+            namespace=row["namespace"],
+        )
     except Exception:
         logger.warning("webhook dispatch failed for memory.updated %s", memory_id, exc_info=True)
     return _lc._row_to_memory(row)
@@ -798,12 +824,16 @@ async def delete_memory(
             pass
     try:
         from api.webhook_dispatcher import dispatch as _dispatch_webhook
-        async with _lc._pool.acquire() as _wh_conn:
-            await _dispatch_webhook(_wh_conn, "memory.deleted", {
+        await _dispatch_webhook(
+            "memory.deleted",
+            {
                 "memory_id": memory_id,
                 "owner_id": user.user_id,
                 "namespace": user.namespace,
-            }, owner_id=user.user_id, namespace=user.namespace)
+            },
+            owner_id=user.user_id,
+            namespace=user.namespace,
+        )
     except Exception:
         logger.warning("webhook dispatch failed for memory.deleted %s", memory_id, exc_info=True)
 

--- a/api/handlers/openai_compat.py
+++ b/api/handlers/openai_compat.py
@@ -809,6 +809,16 @@ def _fallback_provider_from_name(model: str) -> Optional[str]:
     return None
 
 
+def _model_not_found_error(model: str) -> dict[str, dict[str, str]]:
+    return {
+        "error": {
+            "message": f"The model `{model}` does not exist or you do not have access to it.",
+            "type": "invalid_request_error",
+            "code": "model_not_found",
+        }
+    }
+
+
 async def _resolve_provider_for_model(model: str) -> Optional[str]:
     """Look up `model` in model_registry and return its provider.
 
@@ -906,13 +916,8 @@ async def _prepare_provider_route(
             "fallback substring match", model,
         )
         raise HTTPException(
-            status_code=400,
-            detail=(
-                f"unknown model {model!r}; not in model_registry and "
-                f"no provider heuristic matched. Add the model to the "
-                f"registry (update_model_registry.py) or use a known "
-                f"model id."
-            ),
+            status_code=404,
+            detail=_model_not_found_error(model),
         )
 
     bare_model = _strip_gateway_namespace(model, provider)

--- a/api/webhook_dispatcher.py
+++ b/api/webhook_dispatcher.py
@@ -2,7 +2,7 @@
 
 Usage from handlers:
     from api.webhook_dispatcher import dispatch
-    await dispatch(conn, "memory.created", {"memory_id": ..., "content": ...})
+    await dispatch("memory.created", {"memory_id": ..., "content": ...}, conn=conn)
 
 Design notes
 ------------
@@ -171,6 +171,60 @@ class _ClaimedDelivery:
 
 
 async def dispatch(
+    event_type: str | asyncpg.Connection,
+    payload: Dict[str, Any] | str,
+    legacy_payload: Optional[Dict[str, Any]] = None,
+    *,
+    conn: Optional[asyncpg.Connection] = None,
+    owner_id: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> None:
+    """Fan out an event to all matching subscriptions.
+
+    Records a `webhook_deliveries` row per subscription, then schedules each
+    delivery as a background task. When `conn` is provided, the delivery rows
+    are inserted on that connection and join the caller's transaction. Without
+    `conn`, the dispatcher acquires its own connection, preserving the
+    stand-alone behavior used by non-transactional callers.
+    """
+    target_conn = conn
+    resolved_event_type = event_type
+    resolved_payload = payload
+    if legacy_payload is not None:
+        if conn is not None:
+            raise TypeError("dispatch received both positional and keyword conn")
+        target_conn = event_type
+        resolved_event_type = payload
+        resolved_payload = legacy_payload
+    if not isinstance(resolved_event_type, str) or not isinstance(resolved_payload, dict):
+        raise TypeError("dispatch expects dispatch(event_type, payload, *, conn=conn)")
+
+    if target_conn is not None:
+        await _dispatch_on_conn(
+            target_conn,
+            resolved_event_type,
+            resolved_payload,
+            owner_id=owner_id,
+            namespace=namespace,
+        )
+        return
+
+    from api.lifecycle import _pool as lifecycle_pool  # noqa: WPS433
+    if not lifecycle_pool:
+        logger.warning("webhook dispatcher: no DB pool — skipping event %s", resolved_event_type)
+        return
+
+    async with lifecycle_pool.acquire() as acquired_conn:
+        await _dispatch_on_conn(
+            acquired_conn,
+            resolved_event_type,
+            resolved_payload,
+            owner_id=owner_id,
+            namespace=namespace,
+        )
+
+
+async def _dispatch_on_conn(
     conn: asyncpg.Connection,
     event_type: str,
     payload: Dict[str, Any],
@@ -178,12 +232,7 @@ async def dispatch(
     owner_id: Optional[str] = None,
     namespace: Optional[str] = None,
 ) -> None:
-    """Fan out an event to all matching subscriptions.
-
-    Records a `webhook_deliveries` row per subscription, then schedules
-    each delivery as a background task. Safe to call from inside any
-    handler that already has a DB connection.
-    """
+    """Insert delivery intents using an already-selected connection."""
     subs = await _matching_subscriptions(conn, event_type, owner_id, namespace)
     if not subs:
         return

--- a/config.toml.example
+++ b/config.toml.example
@@ -188,7 +188,6 @@ backup_count = 5
 host = "0.0.0.0"
 port = 5002           # Default port; override with MNEMOS_PORT env var
 debug = false
-workers = 4
 
 [features]
 compression = true

--- a/db/migrations_v3_5_session_compression_legacy_drop.sql
+++ b/db/migrations_v3_5_session_compression_legacy_drop.sql
@@ -1,0 +1,17 @@
+-- migrations_v3_5_session_compression_legacy_drop.sql
+--
+-- Remove the remaining legacy session-compression columns. Real compression
+-- state lives in memory_compression_queue and memory_compressed_variants.
+
+BEGIN;
+
+ALTER TABLE session_messages
+    DROP COLUMN IF EXISTS compressed;
+
+ALTER TABLE session_memory_injections
+    DROP COLUMN IF EXISTS compressed;
+
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS compression_tier;
+
+COMMIT;

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,6 @@ if [ -z "${DEPLOY_HOST:-}" ]; then
 fi
 
 # Configuration
-DEPLOY_HOST=""
 DEPLOY_USER="${DEPLOY_USER:-$(whoami)}"
 DEPLOY_DIR="/opt/mnemos"
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -126,7 +125,6 @@ DATABASE_PASSWORD=mnemos_secure_password
 # API Server
 MNEMOS_HOST=0.0.0.0
 MNEMOS_PORT=5000
-MNEMOS_WORKERS=4
 MNEMOS_DEBUG=false
 
 # Graeae Integration
@@ -171,12 +169,41 @@ SQL
 
     echo "Database created"
 
-    # Run migrations
+    # Run migrations in canonical order. Keep install.py::main()
+    # migration_files (see install.py:169-178) as the canonical source.
     cd $DEPLOY_DIR
     source venv/bin/activate
-    # Give mnemos user a simple password for local connections
-    sudo -u postgres psql -d mnemos -f db/migrations.sql 2>/dev/null || \
-    sudo -u postgres psql -d mnemos -f db/migrations.sql
+    python - <<'PY' | while IFS= read -r migration_file; do
+import ast
+from pathlib import Path
+
+tree = ast.parse(Path("install.py").read_text())
+for node in ast.walk(tree):
+    if not isinstance(node, ast.FunctionDef) or node.name != "main":
+        continue
+    for stmt in ast.walk(node):
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "migration_files"
+            and isinstance(stmt.value, ast.List)
+        ):
+            for item in stmt.value.elts:
+                filename = None
+                for subnode in ast.walk(item):
+                    if isinstance(subnode, ast.Constant) and isinstance(subnode.value, str):
+                        if subnode.value.endswith(".sql"):
+                            filename = subnode.value
+                if filename is not None:
+                    print(f"db/{filename}")
+            raise SystemExit(0)
+raise SystemExit("migration_files list not found in install.py")
+PY
+        [ -n "\$migration_file" ] || continue
+        echo "Applying \$migration_file"
+        sudo -u postgres psql -d mnemos -v ON_ERROR_STOP=1 -f "\$migration_file"
+    done
 
     echo "Migrations completed"
 DBEOF

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -81,6 +81,7 @@ services:
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
+      - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql
     ports:
       - '127.0.0.1:5433:5432'  # NOTE: 5433 (not 5432) to avoid host-Postgres collision on PROTEUS / any host with system Postgres
     healthcheck:
@@ -111,6 +112,7 @@ services:
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
+      - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/migrations/37-session-compression-legacy-drop.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -126,7 +128,8 @@ services:
       -f /migrations/33-webhook-succeeded-terminal-trigger.sql
       -f /migrations/34-entities-namespace-unique.sql
       -f /migrations/35-state-journal-namespace.sql
-      -f /migrations/36-session-compression-ratio-drop.sql"
+      -f /migrations/36-session-compression-ratio-drop.sql
+      -f /migrations/37-session-compression-legacy-drop.sql"
     restart: "no"
 
   mnemos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/docker-entrypoint-initdb.d/34-entities-namespace-unique.sql
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
+      - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
@@ -77,6 +78,7 @@ services:
       - ./db/migrations_v3_5_entities_namespace_unique.sql:/migrations/34-entities-namespace-unique.sql:ro
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
+      - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/migrations/37-session-compression-legacy-drop.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -92,7 +94,8 @@ services:
       -f /migrations/33-webhook-succeeded-terminal-trigger.sql
       -f /migrations/34-entities-namespace-unique.sql
       -f /migrations/35-state-journal-namespace.sql
-      -f /migrations/36-session-compression-ratio-drop.sql"
+      -f /migrations/36-session-compression-ratio-drop.sql
+      -f /migrations/37-session-compression-legacy-drop.sql"
     restart: "no"
 
   ollama:

--- a/install.py
+++ b/install.py
@@ -179,6 +179,7 @@ def main() -> None:
         os.path.join(script_dir, "db", "migrations_v3_5_entities_namespace_unique.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_state_journal_namespace.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_session_compression_ratio_drop.sql"),
+        os.path.join(script_dir, "db", "migrations_v3_5_session_compression_legacy_drop.sql"),
     ]
 
     print("=" * 60)

--- a/installer/db.py
+++ b/installer/db.py
@@ -264,6 +264,7 @@ def run_migrations(config: Config) -> bool:
         repo_path / "db" / "migrations_v3_5_entities_namespace_unique.sql",
         repo_path / "db" / "migrations_v3_5_state_journal_namespace.sql",
         repo_path / "db" / "migrations_v3_5_session_compression_ratio_drop.sql",
+        repo_path / "db" / "migrations_v3_5_session_compression_legacy_drop.sql",
     ]
 
     print("[db] Running migrations...")

--- a/mnemos.service
+++ b/mnemos.service
@@ -11,10 +11,10 @@ WorkingDirectory=/opt/mnemos
 Environment="PATH=/opt/mnemos/venv/bin"
 EnvironmentFile=/opt/mnemos/.env
 # Canonical port is 5002; this overrides [api].port in config.toml if different
+# MNEMOS v3.5 is single-worker by design; do not configure multiple Uvicorn workers.
 ExecStart=/opt/mnemos/venv/bin/python -m uvicorn api_server:app \
     --host 0.0.0.0 \
     --port 5002 \
-    --workers 1 \
     --log-level info
 
 # Auto-restart on failure

--- a/modules/hooks/session_start.py
+++ b/modules/hooks/session_start.py
@@ -14,6 +14,8 @@ from typing import Dict, Any
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from api.auth import UserContext
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,9 +61,17 @@ class SessionStartHook:
         # Load state if available
         try:
             if self.state_manager:
-                logger.debug("Loading session state from StateManager")
-                state = await self._load_state()
-                context['state'] = state
+                user = context.get('user') or context.get('user_context')
+                if user is None:
+                    logger.warning(
+                        "StateManager configured but no UserContext in hook context; "
+                        "skipping state load"
+                    )
+                    context['state'] = {}
+                else:
+                    logger.debug("Loading session state from StateManager")
+                    state = await self._load_state(user)
+                    context['state'] = state
             else:
                 logger.debug("No StateManager configured, skipping state load")
         except Exception as e:
@@ -91,7 +101,7 @@ class SessionStartHook:
         logger.info(f"Session initialized: {context['session_id']}")
         return context
 
-    async def _load_state(self) -> Dict[str, Any]:
+    async def _load_state(self, user: UserContext) -> Dict[str, Any]:
         """Load session state
 
         Returns:
@@ -102,7 +112,7 @@ class SessionStartHook:
         try:
             # Load identity
             if hasattr(self.state_manager, 'load_identity'):
-                state['identity'] = await self.state_manager.load_identity()
+                state['identity'] = await self.state_manager.load_identity(user=user)
                 logger.debug("Loaded identity")
         except Exception as e:
             logger.debug(f"Could not load identity: {e}")
@@ -110,7 +120,7 @@ class SessionStartHook:
         try:
             # Load today
             if hasattr(self.state_manager, 'load_today'):
-                state['today'] = await self.state_manager.load_today()
+                state['today'] = await self.state_manager.load_today(user=user)
                 logger.debug("Loaded today")
         except Exception as e:
             logger.debug(f"Could not load today: {e}")
@@ -118,7 +128,7 @@ class SessionStartHook:
         try:
             # Load workspace
             if hasattr(self.state_manager, 'load_workspace'):
-                state['workspace'] = await self.state_manager.load_workspace()
+                state['workspace'] = await self.state_manager.load_workspace(user=user)
                 logger.debug("Loaded workspace")
         except Exception as e:
             logger.debug(f"Could not load workspace: {e}")
@@ -159,16 +169,20 @@ class SessionStartHook:
 
 async def session_start_hook(context: Dict[str, Any],
                             memory_store=None,
-                            state_manager=None) -> Dict[str, Any]:
+                            state_manager=None,
+                            user: UserContext | None = None) -> Dict[str, Any]:
     """Standalone session start hook function
 
     Args:
         context: Hook context
         memory_store: MemoryStore instance
         state_manager: StateManager instance
+        user: Optional UserContext to insert into context for scoped state
 
     Returns:
         Modified context
     """
+    if user is not None:
+        context = {**context, 'user': user}
     hook = SessionStartHook(memory_store, state_manager)
     return await hook(context)

--- a/modules/memory_categorization/entities.py
+++ b/modules/memory_categorization/entities.py
@@ -16,13 +16,15 @@ Provides:
 # subsystem for use in Python applications that embed MNEMOS directly.
 # The REST API handlers (api/handlers/) use direct asyncpg queries for performance.
 
+import json
 import logging
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-logger = logging.getLogger(__name__)
-
+from api.auth import UserContext
 from modules.memory_categorization.constants import ENTITY_TYPES
+
+logger = logging.getLogger(__name__)
 
 
 class EntityManager:
@@ -31,22 +33,33 @@ class EntityManager:
     def __init__(self, db_pool=None):
         self.db_pool = db_pool
 
+    @staticmethod
+    def _scope(user: UserContext) -> tuple[str, str]:
+        return user.user_id, user.namespace
+
     async def create_entity(self, entity_type: str, name: str,
                             description: Optional[str] = None,
-                            metadata: Optional[Dict] = None) -> Optional[str]:
+                            metadata: Optional[Dict] = None,
+                            *,
+                            user: UserContext) -> Optional[str]:
         """Create entity. Returns entity id or None on error."""
         if entity_type not in ENTITY_TYPES:
             logger.warning(f"Unknown entity type: {entity_type}")
         entity_id = str(uuid4())
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return entity_id
         try:
             async with self.db_pool.acquire() as conn:
                 await conn.execute(
-                    '''INSERT INTO entities (id, entity_type, name, description, metadata)
-                       VALUES ($1, $2, $3, $4, $5)
-                       ON CONFLICT (entity_type, name) DO NOTHING''',
-                    entity_id, entity_type, name, description, metadata or {}
+                    '''INSERT INTO entities
+                       (id, owner_id, namespace, entity_type, name, description, metadata)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+                       ON CONFLICT (owner_id, namespace, entity_type, name) DO UPDATE
+                       SET description = COALESCE($6, entities.description),
+                           updated = NOW()''',
+                    entity_id, owner_id, namespace, entity_type, name,
+                    description, json.dumps(metadata or {}),
                 )
             logger.debug(f"Created entity: {entity_type}/{name}")
             return entity_id
@@ -54,35 +67,58 @@ class EntityManager:
             logger.error(f"Error creating entity: {e}", exc_info=True)
             return None
 
-    async def get_entity(self, entity_id: str) -> Optional[Dict]:
+    async def get_entity(self, entity_id: str, *, user: UserContext) -> Optional[Dict]:
         """Fetch entity by id."""
-        if not self.db_pool:
-            return None
-        try:
-            async with self.db_pool.acquire() as conn:
-                row = await conn.fetchrow('SELECT * FROM entities WHERE id = $1', entity_id)
-                return dict(row) if row else None
-        except Exception as e:
-            logger.error(f"Error fetching entity: {e}", exc_info=True)
-            return None
-
-    async def get_by_name(self, entity_type: str, name: str) -> Optional[Dict]:
-        """Fetch entity by type+name."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return None
         try:
             async with self.db_pool.acquire() as conn:
                 row = await conn.fetchrow(
-                    'SELECT * FROM entities WHERE entity_type = $1 AND name = $2',
-                    entity_type, name
+                    '''SELECT * FROM entities
+                       WHERE id = $1::uuid AND owner_id = $2 AND namespace = $3''',
+                    entity_id, owner_id, namespace,
+                )
+                return dict(row) if row else None
+        except Exception as e:
+            logger.error(f"Error fetching entity: {e}", exc_info=True)
+            return None
+
+    async def get_by_name(
+        self,
+        entity_type: str,
+        name: str,
+        *,
+        user: UserContext,
+    ) -> Optional[Dict]:
+        """Fetch entity by type+name."""
+        owner_id, namespace = self._scope(user)
+        if not self.db_pool:
+            return None
+        try:
+            async with self.db_pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    '''SELECT * FROM entities
+                       WHERE owner_id = $1
+                         AND namespace = $2
+                         AND entity_type = $3
+                         AND name = $4''',
+                    owner_id, namespace, entity_type, name,
                 )
                 return dict(row) if row else None
         except Exception as e:
             logger.error(f"Error fetching entity by name: {e}", exc_info=True)
             return None
 
-    async def link_entities(self, entity_id: str, related_id: str) -> bool:
+    async def link_entities(
+        self,
+        entity_id: str,
+        related_id: str,
+        *,
+        user: UserContext,
+    ) -> bool:
         """Add related_id to entity's related_entities array (bidirectional)."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return False
         try:
@@ -94,8 +130,11 @@ class EntityManager:
                            $2::uuid
                        ),
                        updated = NOW()
-                       WHERE id = $1 AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
-                    entity_id, related_id
+                       WHERE id = $1::uuid
+                         AND owner_id = $3
+                         AND namespace = $4
+                         AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
+                    entity_id, related_id, owner_id, namespace,
                 )
                 # Also link in reverse
                 await conn.execute(
@@ -105,8 +144,11 @@ class EntityManager:
                            $2::uuid
                        ),
                        updated = NOW()
-                       WHERE id = $1 AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
-                    related_id, entity_id
+                       WHERE id = $1::uuid
+                         AND owner_id = $3
+                         AND namespace = $4
+                         AND NOT ($2::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[])))''',
+                    related_id, entity_id, owner_id, namespace,
                 )
             logger.debug(f"Linked entities: {entity_id} <-> {related_id}")
             return True
@@ -116,50 +158,75 @@ class EntityManager:
 
     async def query_entities(self, entity_type: Optional[str] = None,
                              name_search: Optional[str] = None,
-                             limit: int = 50) -> List[Dict]:
+                             limit: int = 50,
+                             *,
+                             user: UserContext) -> List[Dict]:
         """Search entities."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return []
         try:
             async with self.db_pool.acquire() as conn:
                 if entity_type and name_search:
                     rows = await conn.fetch(
-                        '''SELECT * FROM entities WHERE entity_type = $1 AND name ILIKE $2
-                           ORDER BY name LIMIT $3''',
-                        entity_type, f'%{name_search}%', limit
+                        '''SELECT * FROM entities
+                           WHERE owner_id = $1
+                             AND namespace = $2
+                             AND entity_type = $3
+                             AND name ILIKE $4
+                           ORDER BY name LIMIT $5''',
+                        owner_id, namespace, entity_type, f'%{name_search}%', limit,
                     )
                 elif entity_type:
                     rows = await conn.fetch(
-                        'SELECT * FROM entities WHERE entity_type = $1 ORDER BY name LIMIT $2',
-                        entity_type, limit
+                        '''SELECT * FROM entities
+                           WHERE owner_id = $1 AND namespace = $2 AND entity_type = $3
+                           ORDER BY name LIMIT $4''',
+                        owner_id, namespace, entity_type, limit,
                     )
                 elif name_search:
                     rows = await conn.fetch(
-                        'SELECT * FROM entities WHERE name ILIKE $1 ORDER BY name LIMIT $2',
-                        f'%{name_search}%', limit
+                        '''SELECT * FROM entities
+                           WHERE owner_id = $1
+                             AND namespace = $2
+                             AND name ILIKE $3
+                           ORDER BY name LIMIT $4''',
+                        owner_id, namespace, f'%{name_search}%', limit,
                     )
                 else:
                     rows = await conn.fetch(
-                        'SELECT * FROM entities ORDER BY entity_type, name LIMIT $1', limit
+                        '''SELECT * FROM entities
+                           WHERE owner_id = $1 AND namespace = $2
+                           ORDER BY entity_type, name LIMIT $3''',
+                        owner_id, namespace, limit,
                     )
                 return [dict(row) for row in rows]
         except Exception as e:
             logger.error(f"Error querying entities: {e}", exc_info=True)
             return []
 
-    async def get_related_entities(self, entity_id: str) -> List[Dict]:
+    async def get_related_entities(
+        self,
+        entity_id: str,
+        *,
+        user: UserContext,
+    ) -> List[Dict]:
         """Get all entities linked to this one via related_entities array."""
-        entity = await self.get_entity(entity_id)
+        entity = await self.get_entity(entity_id, user=user)
         if not entity or not entity.get('related_entities'):
             return []
         related_ids = entity['related_entities']
+        owner_id, namespace = self._scope(user)
         if not related_ids or not self.db_pool:
             return []
         try:
             async with self.db_pool.acquire() as conn:
                 rows = await conn.fetch(
-                    'SELECT * FROM entities WHERE id = ANY($1::uuid[])',
-                    related_ids
+                    '''SELECT * FROM entities
+                       WHERE owner_id = $1
+                         AND namespace = $2
+                         AND id = ANY($3::uuid[])''',
+                    owner_id, namespace, related_ids,
                 )
                 return [dict(row) for row in rows]
         except Exception as e:
@@ -168,34 +235,44 @@ class EntityManager:
 
     async def update_entity(self, entity_id: str,
                             description: Optional[str] = None,
-                            metadata: Optional[Dict] = None) -> bool:
+                            metadata: Optional[Dict] = None,
+                            *,
+                            user: UserContext) -> bool:
         """Update entity description/metadata."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return False
         try:
             async with self.db_pool.acquire() as conn:
                 if description is not None and metadata is not None:
                     await conn.execute(
-                        'UPDATE entities SET description=$1, metadata=$2, updated=NOW() WHERE id=$3',
-                        description, metadata, entity_id
+                        '''UPDATE entities
+                           SET description = $1, metadata = $2::jsonb, updated = NOW()
+                           WHERE id = $3::uuid AND owner_id = $4 AND namespace = $5''',
+                        description, json.dumps(metadata), entity_id, owner_id, namespace,
                     )
                 elif description is not None:
                     await conn.execute(
-                        'UPDATE entities SET description=$1, updated=NOW() WHERE id=$2',
-                        description, entity_id
+                        '''UPDATE entities
+                           SET description = $1, updated = NOW()
+                           WHERE id = $2::uuid AND owner_id = $3 AND namespace = $4''',
+                        description, entity_id, owner_id, namespace,
                     )
                 elif metadata is not None:
                     await conn.execute(
-                        'UPDATE entities SET metadata=$1, updated=NOW() WHERE id=$2',
-                        metadata, entity_id
+                        '''UPDATE entities
+                           SET metadata = $1::jsonb, updated = NOW()
+                           WHERE id = $2::uuid AND owner_id = $3 AND namespace = $4''',
+                        json.dumps(metadata), entity_id, owner_id, namespace,
                     )
             return True
         except Exception as e:
             logger.error(f"Error updating entity: {e}", exc_info=True)
             return False
 
-    async def delete_entity(self, entity_id: str) -> bool:
+    async def delete_entity(self, entity_id: str, *, user: UserContext) -> bool:
         """Delete entity and remove from other entities' related_entities arrays."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return False
         try:
@@ -204,24 +281,38 @@ class EntityManager:
                 await conn.execute(
                     '''UPDATE entities
                        SET related_entities = array_remove(related_entities, $1::uuid)
-                       WHERE $1::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[]))''',
-                    entity_id
+                       WHERE owner_id = $2
+                         AND namespace = $3
+                         AND $1::uuid = ANY(COALESCE(related_entities, ARRAY[]::uuid[]))''',
+                    entity_id, owner_id, namespace,
                 )
-                result = await conn.execute('DELETE FROM entities WHERE id = $1', entity_id)
+                result = await conn.execute(
+                    '''DELETE FROM entities
+                       WHERE id = $1::uuid AND owner_id = $2 AND namespace = $3''',
+                    entity_id, owner_id, namespace,
+                )
                 return result != 'DELETE 0'
         except Exception as e:
             logger.error(f"Error deleting entity: {e}", exc_info=True)
             return False
 
-    async def get_statistics(self) -> Dict[str, Any]:
+    async def get_statistics(self, *, user: UserContext) -> Dict[str, Any]:
         stats = {'total_entities': 0, 'by_type': {}}
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return stats
         try:
             async with self.db_pool.acquire() as conn:
-                stats['total_entities'] = await conn.fetchval('SELECT COUNT(*) FROM entities') or 0
+                stats['total_entities'] = await conn.fetchval(
+                    '''SELECT COUNT(*) FROM entities
+                       WHERE owner_id = $1 AND namespace = $2''',
+                    owner_id, namespace,
+                ) or 0
                 type_rows = await conn.fetch(
-                    'SELECT entity_type, COUNT(*) as count FROM entities GROUP BY entity_type ORDER BY count DESC'
+                    '''SELECT entity_type, COUNT(*) as count FROM entities
+                       WHERE owner_id = $1 AND namespace = $2
+                       GROUP BY entity_type ORDER BY count DESC''',
+                    owner_id, namespace,
                 )
                 stats['by_type'] = {row['entity_type']: row['count'] for row in type_rows}
         except Exception as e:

--- a/modules/memory_categorization/journal.py
+++ b/modules/memory_categorization/journal.py
@@ -12,10 +12,13 @@ Provides:
 # subsystem for use in Python applications that embed MNEMOS directly.
 # The REST API handlers (api/handlers/) use direct asyncpg queries for performance.
 
+import json
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
+
+from api.auth import UserContext
 
 logger = logging.getLogger(__name__)
 
@@ -47,22 +50,32 @@ class JournalManager:
     def __init__(self, db_pool=None):
         self.db_pool = db_pool
 
+    @staticmethod
+    def _scope(user: UserContext) -> tuple[str, str]:
+        return user.user_id, user.namespace
+
     async def append(self, topic: str, content: str,
-                     metadata: Optional[Dict] = None) -> str:
+                     metadata: Optional[Dict] = None,
+                     *,
+                     user: UserContext) -> str:
         entry = JournalEntry(topic, content, metadata)
         logger.debug(f"Adding journal entry: {topic}")
+        owner_id, namespace = self._scope(user)
 
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
                     await conn.execute(
-                        '''INSERT INTO journal (id, entry_date, topic, content, metadata)
-                           VALUES ($1, $2, $3, $4, $5)''',
+                        '''INSERT INTO journal
+                           (id, owner_id, namespace, entry_date, topic, content, metadata)
+                           VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)''',
                         entry.id,
+                        owner_id,
+                        namespace,
                         entry.created_at.date(),
                         entry.topic,
                         entry.content,
-                        entry.metadata,
+                        json.dumps(entry.metadata),
                     )
                 logger.debug(f"Saved journal entry: {entry.id}")
             except Exception as e:
@@ -70,94 +83,132 @@ class JournalManager:
 
         return entry.id
 
-    async def get_recent(self, count: int = 10, topic: Optional[str] = None) -> List[Dict]:
+    async def get_recent(
+        self,
+        count: int = 10,
+        topic: Optional[str] = None,
+        *,
+        user: UserContext,
+    ) -> List[Dict]:
         entries = []
+        owner_id, namespace = self._scope(user)
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
                     if topic:
                         rows = await conn.fetch(
-                            'SELECT * FROM journal WHERE topic = $1 ORDER BY created DESC LIMIT $2',
-                            topic, count
+                            '''SELECT * FROM journal
+                               WHERE owner_id = $1 AND namespace = $2 AND topic = $3
+                               ORDER BY created DESC LIMIT $4''',
+                            owner_id, namespace, topic, count,
                         )
                     else:
                         rows = await conn.fetch(
-                            'SELECT * FROM journal ORDER BY created DESC LIMIT $1',
-                            count
+                            '''SELECT * FROM journal
+                               WHERE owner_id = $1 AND namespace = $2
+                               ORDER BY created DESC LIMIT $3''',
+                            owner_id, namespace, count,
                         )
                     entries = [dict(row) for row in rows]
             except Exception as e:
                 logger.error(f"Error fetching recent entries: {e}", exc_info=True)
         return entries
 
-    async def query(self, search: str, limit: int = 20) -> List[Dict]:
+    async def query(self, search: str, limit: int = 20, *, user: UserContext) -> List[Dict]:
         entries = []
+        owner_id, namespace = self._scope(user)
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
                     rows = await conn.fetch(
                         '''SELECT * FROM journal
-                           WHERE content ILIKE $1 OR topic ILIKE $1
-                           ORDER BY created DESC LIMIT $2''',
-                        f'%{search}%', limit
+                           WHERE owner_id = $1
+                             AND namespace = $2
+                             AND (content ILIKE $3 OR topic ILIKE $3)
+                           ORDER BY created DESC LIMIT $4''',
+                        owner_id, namespace, f'%{search}%', limit,
                     )
                     entries = [dict(row) for row in rows]
             except Exception as e:
                 logger.error(f"Error searching journal: {e}", exc_info=True)
         return entries
 
-    async def get_by_date(self, date_str: str) -> List[Dict]:
+    async def get_by_date(self, date_str: str, *, user: UserContext) -> List[Dict]:
         entries = []
+        owner_id, namespace = self._scope(user)
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
                     rows = await conn.fetch(
-                        'SELECT * FROM journal WHERE entry_date = $1 ORDER BY created DESC',
-                        date_str
+                        '''SELECT * FROM journal
+                           WHERE owner_id = $1 AND namespace = $2 AND entry_date = $3
+                           ORDER BY created DESC''',
+                        owner_id, namespace, date_str,
                     )
                     entries = [dict(row) for row in rows]
             except Exception as e:
                 logger.error(f"Error fetching entries by date: {e}", exc_info=True)
         return entries
 
-    async def get_date_range(self, start_date: str, end_date: str) -> List[Dict]:
+    async def get_date_range(
+        self,
+        start_date: str,
+        end_date: str,
+        *,
+        user: UserContext,
+    ) -> List[Dict]:
         entries = []
+        owner_id, namespace = self._scope(user)
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
                     rows = await conn.fetch(
                         '''SELECT * FROM journal
-                           WHERE entry_date BETWEEN $1 AND $2
+                           WHERE owner_id = $1
+                             AND namespace = $2
+                             AND entry_date BETWEEN $3 AND $4
                            ORDER BY created DESC''',
-                        start_date, end_date
+                        owner_id, namespace, start_date, end_date,
                     )
                     entries = [dict(row) for row in rows]
             except Exception as e:
                 logger.error(f"Error fetching date range: {e}", exc_info=True)
         return entries
 
-    async def get_statistics(self) -> Dict[str, Any]:
+    async def get_statistics(self, *, user: UserContext) -> Dict[str, Any]:
         stats = {
             'total_entries': 0,
             'topics': {},
             'entries_today': 0,
             'entries_this_week': 0,
         }
+        owner_id, namespace = self._scope(user)
         if self.db_pool:
             try:
                 async with self.db_pool.acquire() as conn:
-                    stats['total_entries'] = await conn.fetchval('SELECT COUNT(*) FROM journal') or 0
+                    stats['total_entries'] = await conn.fetchval(
+                        '''SELECT COUNT(*) FROM journal
+                           WHERE owner_id = $1 AND namespace = $2''',
+                        owner_id, namespace,
+                    ) or 0
                     topic_rows = await conn.fetch(
-                        'SELECT topic, COUNT(*) as count FROM journal GROUP BY topic ORDER BY count DESC'
+                        '''SELECT topic, COUNT(*) as count FROM journal
+                           WHERE owner_id = $1 AND namespace = $2
+                           GROUP BY topic ORDER BY count DESC''',
+                        owner_id, namespace,
                     )
                     stats['topics'] = {row['topic']: row['count'] for row in topic_rows}
                     today = datetime.now(timezone.utc).date()
                     stats['entries_today'] = await conn.fetchval(
-                        'SELECT COUNT(*) FROM journal WHERE entry_date = $1', today
+                        '''SELECT COUNT(*) FROM journal
+                           WHERE owner_id = $1 AND namespace = $2 AND entry_date = $3''',
+                        owner_id, namespace, today,
                     ) or 0
                     week_ago = datetime.now(timezone.utc).date() - timedelta(days=7)
                     stats['entries_this_week'] = await conn.fetchval(
-                        'SELECT COUNT(*) FROM journal WHERE entry_date >= $1', week_ago
+                        '''SELECT COUNT(*) FROM journal
+                           WHERE owner_id = $1 AND namespace = $2 AND entry_date >= $3''',
+                        owner_id, namespace, week_ago,
                     ) or 0
             except Exception as e:
                 logger.error(f"Error getting statistics: {e}", exc_info=True)

--- a/modules/memory_categorization/state.py
+++ b/modules/memory_categorization/state.py
@@ -13,9 +13,12 @@ Provides:
 # subsystem for use in Python applications that embed MNEMOS directly.
 # The REST API handlers (api/handlers/) use direct asyncpg queries for performance.
 
+import json
 import logging
-from typing import Dict, Any, Optional, List
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from api.auth import UserContext
 
 logger = logging.getLogger(__name__)
 
@@ -25,62 +28,86 @@ class StateManager:
 
     def __init__(self, db_pool=None):
         self.db_pool = db_pool
-        self._cache: Dict[str, Any] = {}
+        self._cache: Dict[tuple[str, str, str], Any] = {}
 
-    async def get(self, key: str) -> Optional[Any]:
+    @staticmethod
+    def _scope(user: UserContext) -> tuple[str, str]:
+        return user.user_id, user.namespace
+
+    async def get(self, key: str, *, user: UserContext) -> Optional[Any]:
         """Load value for key."""
-        if key in self._cache:
-            return self._cache[key]
+        owner_id, namespace = self._scope(user)
+        cache_key = (owner_id, namespace, key)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
         if not self.db_pool:
             return None
         try:
             async with self.db_pool.acquire() as conn:
-                row = await conn.fetchrow('SELECT value FROM state WHERE key = $1', key)
+                row = await conn.fetchrow(
+                    'SELECT value FROM state '
+                    'WHERE owner_id = $1 AND namespace = $2 AND key = $3',
+                    owner_id, namespace, key,
+                )
                 if row:
                     val = row['value']
-                    self._cache[key] = val
+                    self._cache[cache_key] = val
                     return val
         except Exception as e:
             logger.error(f"Error loading state key '{key}': {e}", exc_info=True)
         return None
 
-    async def set(self, key: str, value: Any) -> None:
+    async def set(self, key: str, value: Any, *, user: UserContext) -> None:
         """Upsert key-value pair."""
-        self._cache[key] = value
+        owner_id, namespace = self._scope(user)
+        self._cache[(owner_id, namespace, key)] = value
         if not self.db_pool:
             return
         try:
             async with self.db_pool.acquire() as conn:
                 await conn.execute(
-                    '''INSERT INTO state (key, value, updated)
-                       VALUES ($1, $2::jsonb, NOW())
-                       ON CONFLICT (key) DO UPDATE SET value = $2::jsonb, updated = NOW()''',
-                    key, value
+                    '''INSERT INTO state (owner_id, namespace, key, value, updated)
+                       VALUES ($1, $2, $3, $4::jsonb, NOW())
+                       ON CONFLICT (owner_id, namespace, key) DO UPDATE
+                       SET value = $4::jsonb,
+                           updated = NOW(),
+                           version = state.version + 1''',
+                    owner_id, namespace, key, json.dumps(value),
                 )
             logger.debug(f"Saved state key: {key}")
         except Exception as e:
             logger.error(f"Error saving state key '{key}': {e}", exc_info=True)
 
-    async def delete(self, key: str) -> bool:
+    async def delete(self, key: str, *, user: UserContext) -> bool:
         """Delete key. Returns True if it existed."""
-        self._cache.pop(key, None)
+        owner_id, namespace = self._scope(user)
+        self._cache.pop((owner_id, namespace, key), None)
         if not self.db_pool:
             return False
         try:
             async with self.db_pool.acquire() as conn:
-                result = await conn.execute('DELETE FROM state WHERE key = $1', key)
+                result = await conn.execute(
+                    'DELETE FROM state '
+                    'WHERE owner_id = $1 AND namespace = $2 AND key = $3',
+                    owner_id, namespace, key,
+                )
                 return result != 'DELETE 0'
         except Exception as e:
             logger.error(f"Error deleting state key '{key}': {e}", exc_info=True)
             return False
 
-    async def list_keys(self) -> List[Dict[str, Any]]:
+    async def list_keys(self, *, user: UserContext) -> List[Dict[str, Any]]:
         """Return all state keys."""
+        owner_id, namespace = self._scope(user)
         if not self.db_pool:
             return []
         try:
             async with self.db_pool.acquire() as conn:
-                rows = await conn.fetch('SELECT key, updated FROM state ORDER BY key')
+                rows = await conn.fetch(
+                    'SELECT key, updated FROM state '
+                    'WHERE owner_id = $1 AND namespace = $2 ORDER BY key',
+                    owner_id, namespace,
+                )
                 return [dict(row) for row in rows]
         except Exception as e:
             logger.error(f"Error listing state keys: {e}", exc_info=True)
@@ -88,12 +115,12 @@ class StateManager:
 
     # ── Convenience accessors ────────────────────────────────────────────────
 
-    async def load_identity(self) -> Dict[str, Any]:
-        val = await self.get('identity')
+    async def load_identity(self, *, user: UserContext) -> Dict[str, Any]:
+        val = await self.get('identity', user=user)
         return val or {'id': 'unknown', 'name': 'Unknown User', 'workspace': 'default'}
 
-    async def load_today(self) -> Dict[str, Any]:
-        val = await self.get('today')
+    async def load_today(self, *, user: UserContext) -> Dict[str, Any]:
+        val = await self.get('today', user=user)
         if val:
             return val
         now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -104,8 +131,8 @@ class StateManager:
             'events': [],
         }
 
-    async def load_workspace(self) -> Dict[str, Any]:
-        val = await self.get('workspace')
+    async def load_workspace(self, *, user: UserContext) -> Dict[str, Any]:
+        val = await self.get('workspace', user=user)
         return val or {'id': 'default', 'name': 'Default Workspace', 'projects': []}
 
     def clear_cache(self) -> None:

--- a/tests/test_bulk_webhook_parity.py
+++ b/tests/test_bulk_webhook_parity.py
@@ -122,7 +122,7 @@ async def test_bulk_create_emits_memory_created_for_each_success(
     _install_pool(monkeypatch, pool)
     events: list[dict[str, Any]] = []
 
-    async def fake_dispatch(conn, event_type, payload, *, owner_id, namespace):
+    async def fake_dispatch(event_type, payload, *, conn=None, owner_id, namespace):
         events.append(
             {
                 "conn": conn,
@@ -160,8 +160,8 @@ async def test_bulk_create_emits_memory_created_for_each_success(
     assert {event["namespace"] for event in events} == {"alice-ns"}
     assert {event["payload"]["owner_id"] for event in events} == {"alice"}
     assert {event["payload"]["namespace"] for event in events} == {"alice-ns"}
-    assert len(pool.connections) == 2
-    assert {event["conn"] for event in events} == {pool.connections[1]}
+    assert len(pool.connections) == 1
+    assert {event["conn"] for event in events} == {pool.connections[0]}
     assert {insert["conn"] for insert in pool.inserts} == {pool.connections[0]}
 
 
@@ -175,7 +175,7 @@ async def test_bulk_create_dispatches_only_successful_items(
     _install_pool(monkeypatch, pool)
     events: list[dict[str, Any]] = []
 
-    async def fake_dispatch(conn, event_type, payload, *, owner_id, namespace):
+    async def fake_dispatch(event_type, payload, *, conn=None, owner_id, namespace):
         events.append({"payload": payload, "owner_id": owner_id, "namespace": namespace})
 
     from api import webhook_dispatcher
@@ -206,7 +206,7 @@ async def test_bulk_create_dispatches_only_successful_items(
     assert {event["namespace"] for event in events} == {"alice-ns"}
 
 
-async def test_bulk_create_tolerates_webhook_dispatch_failure(
+async def test_bulk_create_fails_when_outbox_enqueue_fails(
     client,
     auth_headers: dict[str, str],
     current_user_override,
@@ -218,7 +218,7 @@ async def test_bulk_create_tolerates_webhook_dispatch_failure(
     dispatch_attempts: list[dict[str, Any]] = []
     caplog.set_level(logging.WARNING, logger="api.handlers.memories")
 
-    async def failing_dispatch(conn, event_type, payload, *, owner_id, namespace):
+    async def failing_dispatch(event_type, payload, *, conn=None, owner_id, namespace):
         dispatch_attempts.append(payload)
         raise RuntimeError("dispatcher unavailable")
 
@@ -232,14 +232,7 @@ async def test_bulk_create_tolerates_webhook_dispatch_failure(
         headers=auth_headers,
     )
 
-    assert resp.status_code == 201, resp.text
-    data = resp.json()
-    assert data["created"] == 2
-    assert data["errors"] == []
-    assert [insert["id"] for insert in pool.inserts] == data["memory_ids"]
+    assert resp.status_code == 500, resp.text
+    assert resp.json()["detail"] == "Bulk memory creation failed"
     assert dispatch_attempts
-    assert dispatch_attempts[0]["memory_id"] == data["memory_ids"][0]
-    assert any(
-        record.message == "webhook dispatch failed for memory.created bulk"
-        for record in caplog.records
-    )
+    assert "webhook dispatch failed" not in caplog.text

--- a/tests/test_gateway_provider_routing.py
+++ b/tests/test_gateway_provider_routing.py
@@ -217,10 +217,10 @@ def test_resolve_falls_back_when_pool_missing(monkeypatch):
 # ─── _route_to_provider ─────────────────────────────────────────────────────
 
 
-def test_route_unknown_model_raises_400(monkeypatch):
-    """v3.2 contract: unknown model_id is an explicit 400, NOT a
-    silent route to groq. Operators see the failure at the edge
-    instead of getting garbage responses from the wrong provider."""
+def test_route_unknown_model_raises_404(monkeypatch):
+    """Unknown model_id is an explicit OpenAI-style 404, NOT a silent
+    route to groq. Operators see the failure at the edge instead of
+    getting garbage responses from the wrong provider."""
     from api.handlers import openai_compat
 
     conn = _Conn(row=None)
@@ -234,9 +234,8 @@ def test_route_unknown_model_raises_400(monkeypatch):
             temperature=0.7, max_tokens=100,
             user=_user(),
         ))
-    assert exc.value.status_code == 400
-    assert "unknown model" in exc.value.detail
-    assert "model_registry" in exc.value.detail
+    assert exc.value.status_code == 404
+    assert exc.value.detail["error"]["code"] == "model_not_found"
 
 
 def test_route_uses_registry_hit_over_heuristic(monkeypatch):

--- a/tests/test_migration_lists_sync.py
+++ b/tests/test_migration_lists_sync.py
@@ -52,6 +52,7 @@ EXPECTED_MIGRATIONS = [
     "migrations_v3_5_entities_namespace_unique.sql",
     "migrations_v3_5_state_journal_namespace.sql",
     "migrations_v3_5_session_compression_ratio_drop.sql",
+    "migrations_v3_5_session_compression_legacy_drop.sql",
 ]
 
 
@@ -242,6 +243,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql"
         ) in text, compose_name
         assert (
+            "./db/migrations_v3_5_session_compression_legacy_drop.sql:"
+            "/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql"
+        ) in text, compose_name
+        assert (
             "./db/migrations_v3_5_trigger_same_memory_parent.sql:"
             "/migrations/24-trigger-same-memory-parent.sql:ro"
         ) in text, compose_name
@@ -293,6 +298,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "./db/migrations_v3_5_session_compression_ratio_drop.sql:"
             "/migrations/36-session-compression-ratio-drop.sql:ro"
         ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_session_compression_legacy_drop.sql:"
+            "/migrations/37-session-compression-legacy-drop.sql:ro"
+        ) in text, compose_name
         assert "psql -h postgres -U mnemos_user -d mnemos" in text, compose_name
         assert "-v ON_ERROR_STOP=1" in text, compose_name
         assert "-f /migrations/24-trigger-same-memory-parent.sql" in text, compose_name
@@ -308,6 +317,7 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
         assert "-f /migrations/34-entities-namespace-unique.sql" in text, compose_name
         assert "-f /migrations/35-state-journal-namespace.sql" in text, compose_name
         assert "-f /migrations/36-session-compression-ratio-drop.sql" in text, compose_name
+        assert "-f /migrations/37-session-compression-legacy-drop.sql" in text, compose_name
         assert "postgres-upgrade:\n        condition: service_completed_successfully" in text, compose_name
 
 

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1033,6 +1033,30 @@ def test_unknown_model_returns_404(monkeypatch):
     assert exc.value.detail == "model not found"
 
 
+def test_chat_completion_unknown_model_returns_model_not_found(monkeypatch):
+    async def _unknown_model(model: str):
+        return None
+
+    monkeypatch.setattr(openai_compat, "_search_mnemos_context", _no_context)
+    monkeypatch.setattr(openai_compat, "_resolve_provider_for_model", _unknown_model)
+    req = openai_compat.ChatCompletionRequest(
+        model="nonexistent-model",
+        messages=[openai_compat.ChatMessage(role="user", content="hello")],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(openai_compat.chat_completions(req, authorization=None, user=_user()))
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == {
+        "error": {
+            "message": "The model `nonexistent-model` does not exist or you do not have access to it.",
+            "type": "invalid_request_error",
+            "code": "model_not_found",
+        }
+    }
+
+
 def test_registered_model_lookup_works(monkeypatch):
     _install_pool(monkeypatch, _Conn(row={"provider": "openai"}))
 

--- a/tests/test_webhook_outbox_transactional.py
+++ b/tests/test_webhook_outbox_transactional.py
@@ -1,0 +1,208 @@
+"""Memory create and webhook outbox rows share one transaction."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from api.auth import UserContext
+from api.handlers import memories
+from api.models import MemoryCreateRequest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _user() -> UserContext:
+    return UserContext(
+        user_id="alice",
+        group_ids=[],
+        role="user",
+        namespace="alice-ns",
+        authenticated=True,
+    )
+
+
+class _Txn:
+    def __init__(self, conn: "_OutboxConn"):
+        self.conn = conn
+
+    async def __aenter__(self):
+        self.conn._begin()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            self.conn._commit()
+        else:
+            self.conn._rollback()
+        return False
+
+
+class _OutboxConn:
+    def __init__(self, *, fail_delivery_insert: bool = False):
+        self.fail_delivery_insert = fail_delivery_insert
+        self.memories: list[dict[str, Any]] = []
+        self.deliveries: list[dict[str, Any]] = []
+        self._staged_memories: list[dict[str, Any]] | None = None
+        self._staged_deliveries: list[dict[str, Any]] | None = None
+        self.commits = 0
+        self.rollbacks = 0
+
+    def transaction(self):
+        return _Txn(self)
+
+    def _begin(self) -> None:
+        if self._staged_memories is not None:
+            raise AssertionError("nested transaction not expected in this test")
+        self._staged_memories = []
+        self._staged_deliveries = []
+
+    def _commit(self) -> None:
+        self.memories.extend(self._staged_memories or [])
+        self.deliveries.extend(self._staged_deliveries or [])
+        self._staged_memories = None
+        self._staged_deliveries = None
+        self.commits += 1
+
+    def _rollback(self) -> None:
+        self._staged_memories = None
+        self._staged_deliveries = None
+        self.rollbacks += 1
+
+    async def execute(self, sql: str, *args):
+        compact = " ".join(sql.split())
+        if compact.startswith("INSERT INTO memories "):
+            row = {
+                "id": args[0],
+                "content": args[1],
+                "category": args[2],
+                "subcategory": args[3],
+                "metadata": args[4],
+                "quality_rating": 75,
+                "verbatim_content": args[5],
+                "owner_id": args[6],
+                "group_id": None,
+                "namespace": args[7],
+                "permission_mode": args[8],
+                "source_model": args[9],
+                "source_provider": args[10],
+                "source_session": args[11],
+                "source_agent": args[12],
+                "compressed_content": None,
+                "created": datetime.now(timezone.utc),
+                "updated": datetime.now(timezone.utc),
+            }
+            target = self._staged_memories if self._staged_memories is not None else self.memories
+            target.append(row)
+            return "INSERT 0 1"
+        return "OK"
+
+    async def fetch(self, sql: str, *args):
+        if "FROM webhook_subscriptions" in sql:
+            return [
+                {
+                    "id": "sub_1",
+                    "url": "https://example.test/hook",
+                    "events": ["memory.created"],
+                    "secret": "secret",
+                    "owner_id": "alice",
+                    "namespace": "alice-ns",
+                }
+            ]
+        return []
+
+    async def fetchrow(self, sql: str, *args):
+        if "FROM memories WHERE id=$1" in sql:
+            memory_id = args[0]
+            rows = list(self.memories)
+            if self._staged_memories is not None:
+                rows.extend(self._staged_memories)
+            return next(row for row in rows if row["id"] == memory_id)
+        return None
+
+    async def fetchval(self, sql: str, *args):
+        if "INSERT INTO webhook_deliveries" in sql:
+            if self.fail_delivery_insert:
+                raise RuntimeError("delivery insert failed")
+            delivery_id = f"delivery_{len(self.deliveries) + 1}"
+            row = {
+                "id": delivery_id,
+                "subscription_id": args[0],
+                "event_type": args[1],
+                "payload": args[2],
+                "payload_hash": args[3],
+                "writer_revision": args[4],
+            }
+            target = (
+                self._staged_deliveries
+                if self._staged_deliveries is not None
+                else self.deliveries
+            )
+            target.append(row)
+            return delivery_id
+        return None
+
+
+class _Acquire:
+    def __init__(self, conn: _OutboxConn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Pool:
+    def __init__(self, conn: _OutboxConn):
+        self.conn = conn
+
+    def acquire(self):
+        return _Acquire(self.conn)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, conn: _OutboxConn) -> None:
+    import api.lifecycle as lc
+
+    monkeypatch.setattr(memories._lc, "_pool", _Pool(conn))
+    monkeypatch.setattr(memories._lc, "_cache", None)
+    monkeypatch.setattr(memories._lc, "_rls_enabled", False)
+    monkeypatch.setattr(lc, "_schedule_delivery_attempt", lambda coro: coro.close())
+
+
+async def test_memory_create_commits_memory_and_webhook_delivery(monkeypatch):
+    conn = _OutboxConn()
+    _install(monkeypatch, conn)
+
+    response = await memories.create_memory(
+        MemoryCreateRequest(content="remember this", category="facts"),
+        user=_user(),
+    )
+
+    assert response.id == conn.memories[0]["id"]
+    assert len(conn.memories) == 1
+    assert len(conn.deliveries) == 1
+    assert conn.deliveries[0]["event_type"] == "memory.created"
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+
+
+async def test_webhook_delivery_failure_rolls_back_memory_insert(monkeypatch):
+    conn = _OutboxConn(fail_delivery_insert=True)
+    _install(monkeypatch, conn)
+
+    with pytest.raises(HTTPException) as exc:
+        await memories.create_memory(
+            MemoryCreateRequest(content="remember this", category="facts"),
+            user=_user(),
+        )
+
+    assert exc.value.status_code == 500
+    assert conn.memories == []
+    assert conn.deliveries == []
+    assert conn.commits == 0
+    assert conn.rollbacks == 1

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -242,8 +242,9 @@ class TestWebhookIntegration:
 
             try:
                 await dispatch(
-                    conn, "memory.created",
+                    "memory.created",
                     {"memory_id": "mem_test"},
+                    conn=conn,
                     owner_id="default", namespace="default",
                 )
 


### PR DESCRIPTION
## Summary
The post-Phase-1 super-sweep re-audit (`mem_c16357bc379d`, Codex `task-moiwoh0t-uttr8d`) returned verdict: **mostly coherent but not fully clear across whole product surface** — five concrete remaining gaps. Slice 13 closes all five.

### Gaps closed
1. **Namespace closure outside REST** — `modules/memory_categorization/{state,journal,entities}.py` was a parallel CRUD layer with globally-scoped SQL, no `owner_id`/`namespace`, old `(entity_type, name)` conflict key. Slice 10 fixed `api/handlers/*` but not this. All three modules now thread `UserContext`/owner+namespace; entity ON CONFLICT widened to `(owner_id, namespace, entity_type, name)`. Downstream callers updated (`api/handlers/dag.py`, `document_import.py`, `memories.py`, `consultations.py`, `modules/hooks/session_start.py`).

2. **Webhook outbox transactional** — `api/webhook_dispatcher.dispatch()` now accepts an optional `conn` argument. When passed, the `webhook_attempts` INSERT joins the source-mutation transaction. `memories.py` single + bulk create now wrap memory INSERT + webhook dispatch in one `conn.transaction()` block. Process crashes between commit and dispatch can no longer lose events.

3. **Unknown chat-completion model 404** — `api/handlers/openai_compat.py` now returns OpenAI-shape 404 with `model_not_found` code for unknown models on `/v1/chat/completions`, matching `/v1/models/{id}` semantics.

4. **Stale session compression columns** — `db/migrations_v3_5_session_compression_legacy_drop.sql` drops `session_messages.compressed BOOLEAN` and `sessions.compression_tier INT`. Slice 12 dropped `compression_ratio` but missed these. Wired through all five sites.

5. **Single-worker doctrine + deploy.sh sync** — `DEPLOYMENT.md` clarifies single-worker is by design (in-process state); `config.toml.example` + `mnemos.service` purged of worker-scaling knobs; `deploy.sh` migration list synced to canonical loaders with comment pointing at `install.py` as authoritative.

### New tests
- `tests/test_webhook_outbox_transactional.py` (208 lines) — outbox semantics regressions
- `tests/test_openai_compat.py` — chat completion 404 for unknown model
- `tests/test_migration_lists_sync.py` — keeps drift detector in sync with new migration

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_namespace_isolation.py` — **912 passed**, 18 skipped, 0 regressions
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [ ] GitLab integration tier — applies new migration on real Postgres + namespace_isolation tests against full schema
- [ ] GitHub `pr-check.yml`

After this PR merges, re-run super-sweep audit to verify all gaps held + verdict flips to "fully realized" before tagging v3.5.0 GA.

Audit reference: `mem_c16357bc379d`.

Authored-By: Codex