### PR TITLE
Slice 14: Phase-1 audit closure round 2 — 6 gaps from third audit pass

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,8 @@ test:integration:
         db/migrations_v3_5_entities_namespace_unique.sql \
         db/migrations_v3_5_state_journal_namespace.sql \
         db/migrations_v3_5_session_compression_ratio_drop.sql \
-        db/migrations_v3_5_session_compression_legacy_drop.sql; do
+        db/migrations_v3_5_session_compression_legacy_drop.sql \
+        db/migrations_v3_5_sessions_consultations_namespace.sql; do
         if [ -f "$f" ]; then
           echo "applying $f"
           psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 -f "$f"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -276,15 +276,26 @@ when the data directory is first initialized. They do not re-run when an
 existing `postgres_data` volume starts with newer migration files mounted.
 For v3.5-dev, `docker-compose.yml` and `docker-compose.staging.yml`
 therefore include `postgres-upgrade`, which waits for Postgres health and
-then applies the v3.5 upgrade migrations through
-`db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql` before the MNEMOS service
-starts.
+then applies the v3.5 upgrade tail before the MNEMOS service starts.
 
-Fresh volumes still receive these migrations from the initdb mounts, ending at
-`/docker-entrypoint-initdb.d/33-webhook-succeeded-terminal-trigger.sql`. Existing volumes
-receive the same SQL through `/migrations/33-webhook-succeeded-terminal-trigger.sql` in
-the one-shot service. Keep the compose mounts and `installer/db.py` /
-`install.py` migration order in sync.
+The canonical order lives in `install.py` and `installer/db.py`; compose must
+mirror those loaders. Current v3.5-dev upgrade tail is prefixes 24-38, in
+order:
+`trigger-same-memory-parent`, `rls-group-select-unix-bits`,
+`webhook-retry-terminal-state`, `webhook-attempt-lease`,
+`webhook-writer-revision`, `webhook-status-updated-at`,
+`webhook-superseded-marker`, `webhook-attempt-unique`,
+`webhook-succeeded-unique`, `webhook-succeeded-terminal-trigger`,
+`entities-namespace-unique`, `state-journal-namespace`,
+`session-compression-ratio-drop`, `session-compression-legacy-drop`, and
+`sessions-consultations-namespace`.
+
+Fresh volumes receive these migrations from the initdb mounts, ending at
+`/docker-entrypoint-initdb.d/38-sessions-consultations-namespace.sql`. Existing
+volumes receive the same SQL through `/migrations/24-...sql` through
+`/migrations/38-sessions-consultations-namespace.sql` in the one-shot
+`postgres-upgrade` service. Use the `docker-compose.yml` `postgres-upgrade`
+service block as the example for manual upgrades.
 
 ---
 
@@ -444,9 +455,27 @@ sudo -u postgres createuser -P mnemos  # Enter password interactively
 # Run migrations in canonical order
 python install.py
 
-# Existing DBs on v3.4.1 that only need the v3.5 trigger replacement:
+# Existing DBs on v3.4.1 must apply v3.5 migrations 24-38 in order.
+# The compose one-shot is the canonical example for existing volumes:
+docker compose up postgres-upgrade
+
+# For non-compose installs, follow the same order as install.py / installer/db.py:
 psql -U mnemos -d mnemos -v ON_ERROR_STOP=1 \
-  -f db/migrations_v3_5_trigger_same_memory_parent.sql
+  -f db/migrations_v3_5_trigger_same_memory_parent.sql \
+  -f db/migrations_v3_5_rls_group_select_unix_bits.sql \
+  -f db/migrations_v3_5_webhook_retry_terminal_state.sql \
+  -f db/migrations_v3_5_webhook_attempt_lease.sql \
+  -f db/migrations_v3_5_webhook_writer_revision.sql \
+  -f db/migrations_v3_5_webhook_status_updated_at.sql \
+  -f db/migrations_v3_5_webhook_superseded_marker.sql \
+  -f db/migrations_v3_5_webhook_attempt_unique.sql \
+  -f db/migrations_v3_5_webhook_succeeded_unique.sql \
+  -f db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql \
+  -f db/migrations_v3_5_entities_namespace_unique.sql \
+  -f db/migrations_v3_5_state_journal_namespace.sql \
+  -f db/migrations_v3_5_session_compression_ratio_drop.sql \
+  -f db/migrations_v3_5_session_compression_legacy_drop.sql \
+  -f db/migrations_v3_5_sessions_consultations_namespace.sql
 
 # Verify
 psql -U mnemos -d mnemos -c "SELECT version();"

--- a/api/handlers/consultations.py
+++ b/api/handlers/consultations.py
@@ -32,6 +32,19 @@ def _is_root(user: UserContext) -> bool:
     return user.role == "root"
 
 
+def _scope_namespace(
+    user: UserContext, override: Optional[str] = None
+) -> str:
+    if override and override != user.namespace:
+        if user.role != "root":
+            raise HTTPException(
+                status_code=403,
+                detail="cross-namespace access requires root",
+            )
+        return override
+    return user.namespace
+
+
 # ── Custom Query selection (v3.2) ─────────────────────────────────────────────
 
 _VALID_TIERS = {"frontier", "premium", "budget"}
@@ -393,8 +406,8 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
                         row = await conn.fetchrow(
                             """INSERT INTO graeae_consultations
                                 (prompt, task_type, consensus_response, consensus_score,
-                                 winning_muse, cost, latency_ms, mode, owner_id)
-                               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                                 winning_muse, cost, latency_ms, mode, owner_id, namespace)
+                               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                                RETURNING id""",
                             body.prompt,
                             body.task_type,
@@ -405,6 +418,7 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
                             engine_latency_ms,
                             body.mode or "auto",
                             user.user_id,
+                            user.namespace,
                         )
                         consultation_id = row["id"] if row else None
 
@@ -442,8 +456,10 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
                         "winning_muse": result.get("winning_muse"),
                         "consensus_score": result.get("consensus_score"),
                         "owner_id": user.user_id,
+                        "namespace": user.namespace,
                     },
                     owner_id=user.user_id,
+                    namespace=user.namespace,
                 )
         except Exception:
             logger.warning("webhook dispatch failed for consultation.completed %s", consultation_id, exc_info=True)
@@ -478,6 +494,7 @@ async def list_audit_log(
     request: Request,
     limit: int = Query(20, le=100),
     offset: int = 0,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """List GRAEAE audit log entries (newest first).
@@ -487,14 +504,25 @@ async def list_audit_log(
     """
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_ns = _scope_namespace(user, namespace)
     async with _lc._pool.acquire() as conn:
         is_root = _is_root(user)
-        if is_root:
+        if is_root and namespace is None:
             rows = await conn.fetch(
                 "SELECT id, sequence_num, consultation_id, prompt_hash, response_hash, "
                 "chain_hash, prev_id, task_type, provider, quality_score, created_at "
                 "FROM graeae_audit_log ORDER BY sequence_num DESC LIMIT $1 OFFSET $2",
                 limit, offset,
+            )
+        elif is_root:
+            rows = await conn.fetch(
+                "SELECT al.id, al.sequence_num, al.consultation_id, al.prompt_hash, al.response_hash, "
+                "al.chain_hash, al.prev_id, al.task_type, al.provider, al.quality_score, al.created_at "
+                "FROM graeae_audit_log al "
+                "JOIN graeae_consultations c ON c.id = al.consultation_id "
+                "WHERE c.namespace = $1 "
+                "ORDER BY al.sequence_num DESC LIMIT $2 OFFSET $3",
+                target_ns, limit, offset,
             )
         else:
             rows = await conn.fetch(
@@ -507,15 +535,15 @@ async def list_audit_log(
                 "LAG(al.id) OVER (ORDER BY al.sequence_num ASC) AS scoped_prev_id "
                 "FROM graeae_audit_log al "
                 "JOIN graeae_consultations c ON c.id = al.consultation_id "
-                "WHERE c.owner_id = $1 "
+                "WHERE c.owner_id = $1 AND c.namespace = $2 "
                 ") "
                 "SELECT id, scoped_sequence_num AS sequence_num, consultation_id, "
                 "prompt_hash, response_hash, NULL::text AS chain_hash, "
                 "scoped_prev_id AS prev_id, "
                 "task_type, provider, quality_score, created_at "
                 "FROM visible "
-                "ORDER BY global_sequence_num DESC LIMIT $2 OFFSET $3",
-                user.user_id, limit, offset,
+                "ORDER BY global_sequence_num DESC LIMIT $3 OFFSET $4",
+                user.user_id, target_ns, limit, offset,
             )
     return [
         AuditLogEntry(
@@ -539,6 +567,7 @@ async def list_audit_log(
 @limiter.limit("5/minute")
 async def verify_audit_chain(
     request: Request,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Verify the integrity of the hash chain in the GRAEAE audit log.
@@ -551,11 +580,33 @@ async def verify_audit_chain(
     """
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_ns = _scope_namespace(user, namespace)
+    verify_global_chain = _is_root(user) and namespace is None
     async with _lc._pool.acquire() as conn:
-        if _is_root(user):
+        if verify_global_chain:
             rows = await conn.fetch(
                 "SELECT sequence_num, prompt_hash, response_hash, chain_hash, prev_id "
                 "FROM graeae_audit_log ORDER BY sequence_num ASC"
+            )
+        elif _is_root(user):
+            rows = await conn.fetch(
+                "SELECT al.sequence_num, "
+                "ROW_NUMBER() OVER (ORDER BY al.sequence_num ASC) AS scoped_sequence_num, "
+                "al.prompt_hash, al.response_hash, "
+                "al.chain_hash, al.prev_id, al.prev_chain_hash, "
+                "prev.chain_hash AS expected_prev_hash "
+                "FROM graeae_audit_log al "
+                "JOIN graeae_consultations c ON c.id = al.consultation_id "
+                "LEFT JOIN LATERAL ("
+                "SELECT chain_hash "
+                "FROM graeae_audit_log "
+                "WHERE sequence_num < al.sequence_num "
+                "ORDER BY sequence_num DESC "
+                "LIMIT 1"
+                ") prev ON TRUE "
+                "WHERE c.namespace = $1 "
+                "ORDER BY al.sequence_num ASC",
+                target_ns,
             )
         else:
             rows = await conn.fetch(
@@ -573,9 +624,9 @@ async def verify_audit_chain(
                 "ORDER BY sequence_num DESC "
                 "LIMIT 1"
                 ") prev ON TRUE "
-                "WHERE c.owner_id = $1 "
+                "WHERE c.owner_id = $1 AND c.namespace = $2 "
                 "ORDER BY al.sequence_num ASC",
-                user.user_id,
+                user.user_id, target_ns,
             )
 
     if not rows:
@@ -584,12 +635,12 @@ async def verify_audit_chain(
             entries_checked=0,
             message=(
                 "Audit log is empty"
-                if _is_root(user)
+                if verify_global_chain
                 else "No audit entries visible for caller"
             ),
         )
 
-    if _is_root(user):
+    if verify_global_chain:
         prev_chain = _GENESIS_HASH
         failures: dict[int, str] = {}
         for row in rows:
@@ -728,6 +779,7 @@ async def list_modes(_: UserContext = Depends(get_current_user)):
 @router.get("/consultations/{consultation_id}")
 async def get_consultation(
     consultation_id: str,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Retrieve a consultation by ID.
@@ -738,21 +790,29 @@ async def get_consultation(
     """
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_ns = _scope_namespace(user, namespace)
 
     async with _lc._pool.acquire() as conn:
-        if _is_root(user):
+        if _is_root(user) and namespace is None:
             row = await conn.fetchrow(
                 "SELECT id, prompt, task_type, consensus_response, consensus_score, "
                 "winning_muse, cost, latency_ms, mode, created "
                 "FROM graeae_consultations WHERE id = $1",
                 consultation_id,
             )
+        elif _is_root(user):
+            row = await conn.fetchrow(
+                "SELECT id, prompt, task_type, consensus_response, consensus_score, "
+                "winning_muse, cost, latency_ms, mode, created "
+                "FROM graeae_consultations WHERE id = $1 AND namespace = $2",
+                consultation_id, target_ns,
+            )
         else:
             row = await conn.fetchrow(
                 "SELECT id, prompt, task_type, consensus_response, consensus_score, "
                 "winning_muse, cost, latency_ms, mode, created "
-                "FROM graeae_consultations WHERE id = $1 AND owner_id = $2",
-                consultation_id, user.user_id,
+                "FROM graeae_consultations WHERE id = $1 AND owner_id = $2 AND namespace = $3",
+                consultation_id, user.user_id, target_ns,
             )
 
     if not row:
@@ -775,24 +835,32 @@ async def get_consultation(
 @router.get("/consultations/{consultation_id}/artifacts")
 async def get_consultation_artifacts(
     consultation_id: str,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Retrieve structured outputs and citations from a consultation."""
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
+    target_ns = _scope_namespace(user, namespace)
 
     async with _lc._pool.acquire() as conn:
         # Get consultation — scoped to caller unless root.
-        if _is_root(user):
+        if _is_root(user) and namespace is None:
             consultation = await conn.fetchrow(
                 "SELECT id, created FROM graeae_consultations WHERE id = $1",
                 consultation_id,
             )
+        elif _is_root(user):
+            consultation = await conn.fetchrow(
+                "SELECT id, created FROM graeae_consultations "
+                "WHERE id = $1 AND namespace = $2",
+                consultation_id, target_ns,
+            )
         else:
             consultation = await conn.fetchrow(
                 "SELECT id, created FROM graeae_consultations "
-                "WHERE id = $1 AND owner_id = $2",
-                consultation_id, user.user_id,
+                "WHERE id = $1 AND owner_id = $2 AND namespace = $3",
+                consultation_id, user.user_id, target_ns,
             )
         if not consultation:
             raise HTTPException(status_code=404, detail="Consultation not found")

--- a/api/handlers/ingest.py
+++ b/api/handlers/ingest.py
@@ -1,5 +1,4 @@
 """Session ingestion endpoint."""
-import json
 import logging
 import uuid
 
@@ -8,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 import api.lifecycle as _lc
 from api.auth import UserContext, get_current_user
+from api.handlers.memories import _insert_memory_with_created_webhook, _rls_context
 from api.models import SessionIngestRequest, SessionIngestResponse
 
 logger = logging.getLogger(__name__)
@@ -45,59 +45,50 @@ async def ingest_session(request: SessionIngestRequest, user: UserContext = Depe
     try:
         data = request.raw_data
         async with _lc._pool.acquire() as conn:
-            if data.get("messages") or data.get("prompts"):
-                items = data.get("messages", []) or data.get("prompts", [])
-                if items:
-                    content = f"Session {request.session_id} — {len(items)} messages\n{_extract_readable(items)}"
-                    mem_id = f"mem_{uuid.uuid4().hex[:12]}"
-                    meta = json.dumps({
-                        "source": request.source, "session_id": request.session_id,
-                        "machine_id": request.machine_id, "agent_id": request.agent_id,
-                        "git_commit": request.git_commit, "item_count": len(items),
-                        "item_type": "messages",
-                    })
-                    await conn.execute(
-                        "INSERT INTO memories (id, content, category, metadata, quality_rating) "
-                        "VALUES ($1, $2, $3, $4::jsonb, 75)",
-                        mem_id, content, "session_activity", meta,
-                    )
-                    stored_ids.append(mem_id)
+            async with _rls_context(conn, user):
+                async with conn.transaction():
+                    for key, fallback_key, item_type, label, category in (
+                        ("messages", "prompts", "messages", "messages", "session_activity"),
+                        ("code_blocks", None, "code", "code blocks", "session_code"),
+                        ("tool_operations", "tools", "tools", "tool operations", "session_tools"),
+                    ):
+                        items = data.get(key, [])
+                        if not items and fallback_key:
+                            items = data.get(fallback_key, [])
+                        if not items:
+                            continue
 
-            if data.get("code_blocks"):
-                items = data.get("code_blocks", [])
-                if items:
-                    content = f"Session {request.session_id} — {len(items)} code blocks\n{_extract_readable(items)}"
-                    mem_id = f"mem_{uuid.uuid4().hex[:12]}"
-                    meta = json.dumps({
-                        "source": request.source, "session_id": request.session_id,
-                        "machine_id": request.machine_id, "agent_id": request.agent_id,
-                        "git_commit": request.git_commit, "item_count": len(items),
-                        "item_type": "code",
-                    })
-                    await conn.execute(
-                        "INSERT INTO memories (id, content, category, metadata, quality_rating) "
-                        "VALUES ($1, $2, $3, $4::jsonb, 75)",
-                        mem_id, content, "session_code", meta,
-                    )
-                    stored_ids.append(mem_id)
-
-            if data.get("tool_operations") or data.get("tools"):
-                items = data.get("tool_operations", []) or data.get("tools", [])
-                if items:
-                    content = f"Session {request.session_id} — {len(items)} tool operations\n{_extract_readable(items)}"
-                    mem_id = f"mem_{uuid.uuid4().hex[:12]}"
-                    meta = json.dumps({
-                        "source": request.source, "session_id": request.session_id,
-                        "machine_id": request.machine_id, "agent_id": request.agent_id,
-                        "git_commit": request.git_commit, "item_count": len(items),
-                        "item_type": "tools",
-                    })
-                    await conn.execute(
-                        "INSERT INTO memories (id, content, category, metadata, quality_rating) "
-                        "VALUES ($1, $2, $3, $4::jsonb, 75)",
-                        mem_id, content, "session_tools", meta,
-                    )
-                    stored_ids.append(mem_id)
+                        content = (
+                            f"Session {request.session_id} — {len(items)} {label}\n"
+                            f"{_extract_readable(items)}"
+                        )
+                        mem_id = f"mem_{uuid.uuid4().hex[:12]}"
+                        metadata = {
+                            "source": request.source,
+                            "session_id": request.session_id,
+                            "machine_id": request.machine_id,
+                            "agent_id": request.agent_id,
+                            "git_commit": request.git_commit,
+                            "item_count": len(items),
+                            "item_type": item_type,
+                        }
+                        await _insert_memory_with_created_webhook(
+                            conn=conn,
+                            mem_id=mem_id,
+                            content=content,
+                            category=category,
+                            subcategory=None,
+                            metadata=metadata,
+                            owner_id=user.user_id,
+                            namespace=user.namespace,
+                            permission_mode=600,
+                            verbatim_content=content,
+                            source_model=None,
+                            source_provider=request.source,
+                            source_session=request.session_id,
+                            source_agent=request.agent_id,
+                        )
+                        stored_ids.append(mem_id)
 
         if _lc._cache:
             try:

--- a/api/handlers/memories.py
+++ b/api/handlers/memories.py
@@ -75,6 +75,60 @@ def _read_visibility_predicate(
     )
 
 
+async def _insert_memory_with_created_webhook(
+    *,
+    conn,
+    mem_id: str,
+    content: str,
+    category: str,
+    subcategory: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    owner_id: str,
+    namespace: str,
+    permission_mode: int = 600,
+    verbatim_content: Optional[str] = None,
+    source_model: Optional[str] = None,
+    source_provider: Optional[str] = None,
+    source_session: Optional[str] = None,
+    source_agent: Optional[str] = None,
+    fetch_row: bool = False,
+):
+    """Insert a canonical memory row and enqueue memory.created in the same txn."""
+    verbatim = verbatim_content if verbatim_content is not None else content
+    await conn.execute(
+        "INSERT INTO memories "
+        "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
+        "owner_id, namespace, permission_mode, "
+        "source_model, source_provider, source_session, source_agent) "
+        "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
+        mem_id, content, category, subcategory, json.dumps(metadata or {}), verbatim,
+        owner_id, namespace, permission_mode,
+        source_model, source_provider, source_session, source_agent,
+    )
+    row = None
+    if fetch_row:
+        row = await conn.fetchrow(
+            f"SELECT {_MEMORY_COLS} FROM memories WHERE id=$1", mem_id,
+        )
+
+    from api.webhook_dispatcher import dispatch as _dispatch_webhook
+    await _dispatch_webhook(
+        "memory.created",
+        {
+            "memory_id": mem_id,
+            "category": category,
+            "subcategory": subcategory,
+            "content": content,
+            "owner_id": owner_id,
+            "namespace": namespace,
+        },
+        conn=conn,
+        owner_id=owner_id,
+        namespace=namespace,
+    )
+    return row
+
+
 async def _bump_recall_counters(memory_ids: list) -> None:
     """Increment recall_count + set last_recalled_at for a hit set.
 
@@ -530,42 +584,24 @@ async def create_memory(
         async with _lc._pool.acquire() as conn:
             async with _rls_context(conn, user):
                 async with conn.transaction():
-                    meta = json.dumps(request.metadata or {"source": request.source})
-                    verbatim = (
-                        request.verbatim_content
-                        if request.verbatim_content is not None
-                        else request.content
-                    )
-                    await conn.execute(
-                        "INSERT INTO memories "
-                        "(id, content, category, subcategory, metadata, quality_rating, verbatim_content, "
-                        "owner_id, namespace, permission_mode, "
-                        "source_model, source_provider, source_session, source_agent) "
-                        "VALUES ($1, $2, $3, $4, $5::jsonb, 75, $6, $7, $8, $9, $10, $11, $12, $13)",
-                        mem_id, request.content, request.category, request.subcategory, meta, verbatim,
-                        owner_id, namespace, 600,
-                        request.source_model, request.source_provider,
-                        request.source_session, request.source_agent,
-                    )
                     # (trigger trg_memory_version_insert inserts version 1 automatically,
                     # computing commit_hash + branch; no explicit handler INSERT needed)
-                    row = await conn.fetchrow(
-                        f"SELECT {_MEMORY_COLS} FROM memories WHERE id=$1", mem_id,
-                    )
-                    from api.webhook_dispatcher import dispatch as _dispatch_webhook
-                    await _dispatch_webhook(
-                        "memory.created",
-                        {
-                            "memory_id": mem_id,
-                            "category": request.category,
-                            "subcategory": request.subcategory,
-                            "content": request.content,
-                            "owner_id": owner_id,
-                            "namespace": namespace,
-                        },
+                    row = await _insert_memory_with_created_webhook(
                         conn=conn,
+                        mem_id=mem_id,
+                        content=request.content,
+                        category=request.category,
+                        subcategory=request.subcategory,
+                        metadata=request.metadata or {"source": request.source},
                         owner_id=owner_id,
                         namespace=namespace,
+                        permission_mode=600,
+                        verbatim_content=request.verbatim_content,
+                        source_model=request.source_model,
+                        source_provider=request.source_provider,
+                        source_session=request.source_session,
+                        source_agent=request.source_agent,
+                        fetch_row=True,
                     )
     except HTTPException:
         raise

--- a/api/handlers/openai_compat.py
+++ b/api/handlers/openai_compat.py
@@ -22,7 +22,7 @@ from typing import Optional, List, Dict, Any, Literal, Union
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Depends, Header
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 import api.lifecycle as _lc
@@ -819,6 +819,21 @@ def _model_not_found_error(model: str) -> dict[str, dict[str, str]]:
     }
 
 
+def _is_openai_error_detail(detail: Any) -> bool:
+    if not isinstance(detail, dict):
+        return False
+    error = detail.get("error")
+    return (
+        isinstance(error, dict)
+        and isinstance(error.get("type"), str)
+        and isinstance(error.get("code"), str)
+    )
+
+
+def _openai_error_response(exc: HTTPException) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=exc.detail)
+
+
 async def _resolve_provider_for_model(model: str) -> Optional[str]:
     """Look up `model` in model_registry and return its provider.
 
@@ -1270,7 +1285,9 @@ async def chat_completions(
             first_delta = await anext(provider_stream)
         except StopAsyncIteration:
             first_delta = None
-        except HTTPException:
+        except HTTPException as exc:
+            if _is_openai_error_detail(exc.detail):
+                return _openai_error_response(exc)
             raise
         except Exception as e:
             logger.error(f"[MNEMOS] Streaming request failed before response start: {e}")
@@ -1323,7 +1340,9 @@ async def chat_completions(
             request_params=request_params,
             user=user,
         )
-    except HTTPException:
+    except HTTPException as exc:
+        if _is_openai_error_detail(exc.detail):
+            return _openai_error_response(exc)
         raise
     except Exception as e:
         logger.error(f"[MNEMOS] Request failed: {e}")

--- a/api/handlers/sessions.py
+++ b/api/handlers/sessions.py
@@ -7,8 +7,9 @@ and context routing.
 
 import logging
 from datetime import datetime, timezone
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Query
 
 import api.lifecycle as _lc
 from api.auth import UserContext, get_current_user
@@ -30,6 +31,17 @@ def _require_pool():
     return _lc._pool
 
 
+def _scope_namespace(user: UserContext, override: Optional[str] = None) -> str:
+    if override and override != user.namespace:
+        if user.role != "root":
+            raise HTTPException(
+                status_code=403,
+                detail="cross-namespace access requires root",
+            )
+        return override
+    return user.namespace
+
+
 @router.post("", response_model=SessionResponse)
 async def create_session(
     request: SessionRequest,
@@ -43,11 +55,12 @@ async def create_session(
         async with pool.acquire() as conn:
             session_id = await conn.fetchval(
                 """
-                INSERT INTO sessions (user_id, model)
-                VALUES ($1, $2)
+                INSERT INTO sessions (user_id, namespace, model)
+                VALUES ($1, $2, $3)
                 RETURNING id
                 """,
                 user.user_id,
+                user.namespace,
                 request.model or "gpt-4o",
             )
 
@@ -67,8 +80,9 @@ async def create_session(
         # Return session metadata
         async with pool.acquire() as conn:
             row = await conn.fetchrow(
-                "SELECT id, created_at, model FROM sessions WHERE id = $1",
-                session_id,
+                "SELECT id, created_at, model FROM sessions "
+                "WHERE id = $1 AND user_id = $2 AND namespace = $3",
+                session_id, user.user_id, user.namespace,
             )
 
         return SessionResponse(
@@ -85,16 +99,19 @@ async def create_session(
 @router.get("/{session_id}", response_model=SessionContext)
 async def get_session(
     session_id: str,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Get session context and metadata."""
     pool = _require_pool()
+    target_ns = _scope_namespace(user, namespace)
 
     async with pool.acquire() as conn:
         session = await conn.fetchrow(
-            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2",
+            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2 AND namespace = $3",
             session_id,
             user.user_id,
+            target_ns,
         )
 
     if not session:
@@ -129,6 +146,7 @@ async def get_session(
 async def add_session_message(
     session_id: str,
     request: SessionMessage,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Add message to session, search memory, inject context, call provider, return response.
@@ -142,13 +160,15 @@ async def add_session_message(
     6. Updates session metrics
     """
     pool = _require_pool()
+    target_ns = _scope_namespace(user, namespace)
 
     # Verify session ownership
     async with pool.acquire() as conn:
         session = await conn.fetchrow(
-            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2",
+            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2 AND namespace = $3",
             session_id,
             user.user_id,
+            target_ns,
         )
 
     if not session:
@@ -333,10 +353,12 @@ async def add_session_message(
             SET message_count = message_count + 2,
                 total_tokens = total_tokens + $2,
                 last_activity = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND user_id = $3 AND namespace = $4
             """,
             session_id,
             tokens_used,
+            user.user_id,
+            target_ns,
         )
 
     logger.info(
@@ -361,17 +383,20 @@ async def get_session_history(
     session_id: str,
     limit: int = 50,
     offset: int = 0,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Get conversation history for session."""
     pool = _require_pool()
+    target_ns = _scope_namespace(user, namespace)
 
     # Verify session ownership
     async with pool.acquire() as conn:
         session = await conn.fetchrow(
-            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2",
+            "SELECT * FROM sessions WHERE id = $1 AND user_id = $2 AND namespace = $3",
             session_id,
             user.user_id,
+            target_ns,
         )
 
     if not session:
@@ -416,17 +441,20 @@ async def get_session_history(
 @router.delete("/{session_id}")
 async def delete_session(
     session_id: str,
+    namespace: Optional[str] = Query(None),
     user: UserContext = Depends(get_current_user),
 ):
     """Close and delete session."""
     pool = _require_pool()
+    target_ns = _scope_namespace(user, namespace)
 
     # Verify session ownership
     async with pool.acquire() as conn:
         session = await conn.fetchrow(
-            "SELECT id FROM sessions WHERE id = $1 AND user_id = $2",
+            "SELECT id FROM sessions WHERE id = $1 AND user_id = $2 AND namespace = $3",
             session_id,
             user.user_id,
+            target_ns,
         )
 
     if not session:
@@ -434,7 +462,10 @@ async def delete_session(
 
     # Delete session (cascade deletes messages and injections)
     async with pool.acquire() as conn:
-        await conn.execute("DELETE FROM sessions WHERE id = $1", session_id)
+        await conn.execute(
+            "DELETE FROM sessions WHERE id = $1 AND user_id = $2 AND namespace = $3",
+            session_id, user.user_id, target_ns,
+        )
 
     logger.info(f"[SESSIONS] Deleted session {session_id}")
 

--- a/db/migrations_v3_5_sessions_consultations_namespace.sql
+++ b/db/migrations_v3_5_sessions_consultations_namespace.sql
@@ -1,0 +1,18 @@
+-- v3.5: namespace scoping for sessions and GRAEAE consultations.
+-- Extends the v3.2 namespace tenancy model to remaining product surfaces.
+
+BEGIN;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS namespace TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE graeae_consultations
+    ADD COLUMN IF NOT EXISTS namespace TEXT NOT NULL DEFAULT 'default';
+
+CREATE INDEX IF NOT EXISTS idx_sessions_owner_namespace
+    ON sessions(user_id, namespace);
+
+CREATE INDEX IF NOT EXISTS idx_graeae_consultations_owner_namespace
+    ON graeae_consultations(owner_id, namespace);
+
+COMMIT;

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@
 # Automated deployment with verification
 #
 
-set -e  # Exit on error
+set -euo pipefail  # Exit on error
 
 # Required: set DEPLOY_HOST to the target server hostname or IP
 if [ -z "${DEPLOY_HOST:-}" ]; then
@@ -170,8 +170,8 @@ SQL
     echo "Database created"
 
     # Run migrations in canonical order. Keep install.py::main()
-    # migration_files (see install.py:169-178) as the canonical source.
-    cd $DEPLOY_DIR
+    # migration_files as the canonical source.
+    cd "$DEPLOY_DIR"
     source venv/bin/activate
     python - <<'PY' | while IFS= read -r migration_file; do
 import ast
@@ -213,14 +213,15 @@ log_info "Database setup complete"
 # Step 7: Run tests
 log_info "Running test suite..."
 ssh "$DEPLOY_USER@$DEPLOY_HOST" bash << TESTEOF
+    set -euo pipefail
     cd "$DEPLOY_DIR"
     source venv/bin/activate
 
     echo "Running unit tests..."
-    python -m pytest tests/test_hooks.py -v --tb=short 2>&1 | head -100 || true
+    python -m pytest tests/test_unit.py -v --tb=short
 
     echo "Running E2E tests..."
-    python -m pytest tests/test_e2e.py -v --tb=short 2>&1 | head -100 || true
+    python -m pytest tests/test_e2e.py -v --tb=short
 
     echo "Test run completed"
 TESTEOF
@@ -230,16 +231,15 @@ log_info "Test suite executed"
 # Step 8: Verify deployment
 log_info "Verifying deployment..."
 ssh "$DEPLOY_USER@$DEPLOY_HOST" bash << VERIFYEOF
+    set -euo pipefail
     cd "$DEPLOY_DIR"
 
     # Check if API server starts
     source venv/bin/activate
-    timeout 5 python -c "from api_server import app; print('API server imports OK')" || true
+    timeout 5 python -c "from api_server import app; print('API server imports OK')"
 
     # Check if modules import
-    timeout 5 python -c "from modules.compression import distill; print('Compression module OK')" || true
-    timeout 5 python -c "from modules.hooks import HookRegistry; print('Hooks module OK')" || true
-    timeout 5 python -c "from modules.bundles import BundleRouter; print('Bundles module OK')" || true
+    timeout 5 python -c "from modules.hooks import HookRegistry; print('Hooks module OK')"
 
     echo "Module imports verified"
 VERIFYEOF

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -82,6 +82,7 @@ services:
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
       - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql
+      - ./db/migrations_v3_5_sessions_consultations_namespace.sql:/docker-entrypoint-initdb.d/38-sessions-consultations-namespace.sql
     ports:
       - '127.0.0.1:5433:5432'  # NOTE: 5433 (not 5432) to avoid host-Postgres collision on PROTEUS / any host with system Postgres
     healthcheck:
@@ -113,6 +114,7 @@ services:
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
       - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/migrations/37-session-compression-legacy-drop.sql:ro
+      - ./db/migrations_v3_5_sessions_consultations_namespace.sql:/migrations/38-sessions-consultations-namespace.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -129,7 +131,8 @@ services:
       -f /migrations/34-entities-namespace-unique.sql
       -f /migrations/35-state-journal-namespace.sql
       -f /migrations/36-session-compression-ratio-drop.sql
-      -f /migrations/37-session-compression-legacy-drop.sql"
+      -f /migrations/37-session-compression-legacy-drop.sql
+      -f /migrations/38-sessions-consultations-namespace.sql"
     restart: "no"
 
   mnemos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./db/migrations_v3_5_state_journal_namespace.sql:/docker-entrypoint-initdb.d/35-state-journal-namespace.sql
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/docker-entrypoint-initdb.d/36-session-compression-ratio-drop.sql
       - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql
+      - ./db/migrations_v3_5_sessions_consultations_namespace.sql:/docker-entrypoint-initdb.d/38-sessions-consultations-namespace.sql
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
@@ -79,6 +80,7 @@ services:
       - ./db/migrations_v3_5_state_journal_namespace.sql:/migrations/35-state-journal-namespace.sql:ro
       - ./db/migrations_v3_5_session_compression_ratio_drop.sql:/migrations/36-session-compression-ratio-drop.sql:ro
       - ./db/migrations_v3_5_session_compression_legacy_drop.sql:/migrations/37-session-compression-legacy-drop.sql:ro
+      - ./db/migrations_v3_5_sessions_consultations_namespace.sql:/migrations/38-sessions-consultations-namespace.sql:ro
     command: >
       sh -c "psql -h postgres -U mnemos_user -d mnemos
       -v ON_ERROR_STOP=1
@@ -95,7 +97,8 @@ services:
       -f /migrations/34-entities-namespace-unique.sql
       -f /migrations/35-state-journal-namespace.sql
       -f /migrations/36-session-compression-ratio-drop.sql
-      -f /migrations/37-session-compression-legacy-drop.sql"
+      -f /migrations/37-session-compression-legacy-drop.sql
+      -f /migrations/38-sessions-consultations-namespace.sql"
     restart: "no"
 
   ollama:

--- a/install.py
+++ b/install.py
@@ -180,6 +180,7 @@ def main() -> None:
         os.path.join(script_dir, "db", "migrations_v3_5_state_journal_namespace.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_session_compression_ratio_drop.sql"),
         os.path.join(script_dir, "db", "migrations_v3_5_session_compression_legacy_drop.sql"),
+        os.path.join(script_dir, "db", "migrations_v3_5_sessions_consultations_namespace.sql"),
     ]
 
     print("=" * 60)

--- a/installer/db.py
+++ b/installer/db.py
@@ -265,6 +265,7 @@ def run_migrations(config: Config) -> bool:
         repo_path / "db" / "migrations_v3_5_state_journal_namespace.sql",
         repo_path / "db" / "migrations_v3_5_session_compression_ratio_drop.sql",
         repo_path / "db" / "migrations_v3_5_session_compression_legacy_drop.sql",
+        repo_path / "db" / "migrations_v3_5_sessions_consultations_namespace.sql",
     ]
 
     print("[db] Running migrations...")

--- a/modules/memory_categorization/entities.py
+++ b/modules/memory_categorization/entities.py
@@ -51,18 +51,19 @@ class EntityManager:
             return entity_id
         try:
             async with self.db_pool.acquire() as conn:
-                await conn.execute(
+                row = await conn.fetchrow(
                     '''INSERT INTO entities
                        (id, owner_id, namespace, entity_type, name, description, metadata)
                        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
                        ON CONFLICT (owner_id, namespace, entity_type, name) DO UPDATE
                        SET description = COALESCE($6, entities.description),
-                           updated = NOW()''',
+                           updated = NOW()
+                       RETURNING id::text''',
                     entity_id, owner_id, namespace, entity_type, name,
                     description, json.dumps(metadata or {}),
                 )
             logger.debug(f"Created entity: {entity_type}/{name}")
-            return entity_id
+            return row["id"] if row else None
         except Exception as e:
             logger.error(f"Error creating entity: {e}", exc_info=True)
             return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,7 @@ class FakeConnection:
                 "latency_ms": args[6],
                 "mode": args[7],
                 "owner_id": args[8],
+                "namespace": args[9],
                 "created": _utcnow(),
             }
             self.state["consultations"][consultation_id] = record

--- a/tests/test_consultations_namespace_isolation.py
+++ b/tests/test_consultations_namespace_isolation.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_namespace_isolation import NamespaceHarness, PG_URL
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not PG_URL, reason="set MNEMOS_TEST_DB=postgres://... to run integration tests"),
+    pytest.mark.asyncio,
+]
+
+
+class _FakeGraeae:
+    async def consult(self, prompt: str, task_type: str | None, selection=None):
+        return {
+            "all_responses": {
+                "openai": {
+                    "response_text": f"response for {prompt}",
+                    "final_score": 0.9,
+                    "latency_ms": 10,
+                    "status": "success",
+                }
+            },
+            "consensus_response": f"response for {prompt}",
+            "consensus_score": 0.9,
+            "winning_muse": "openai",
+            "cost": 0.01,
+            "latency_ms": 10,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "memory_ids": [],
+        }
+
+
+async def _cleanup(pg_app: NamespaceHarness) -> None:
+    async with pg_app.pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM graeae_audit_log WHERE consultation_id IN "
+            "(SELECT id FROM graeae_consultations WHERE owner_id LIKE $1)",
+            f"{pg_app.prefix}%",
+        )
+        await conn.execute(
+            "DELETE FROM consultation_memory_refs WHERE consultation_id IN "
+            "(SELECT id FROM graeae_consultations WHERE owner_id LIKE $1)",
+            f"{pg_app.prefix}%",
+        )
+        await conn.execute("DELETE FROM graeae_consultations WHERE owner_id LIKE $1", f"{pg_app.prefix}%")
+
+
+async def test_consultations_are_isolated_by_owner_and_namespace(pg_app: NamespaceHarness, monkeypatch):
+    import graeae.engine as graeae_engine
+
+    monkeypatch.setattr(graeae_engine, "get_graeae_engine", lambda: _FakeGraeae())
+
+    try:
+        resp = await pg_app.client.post(
+            "/v1/consultations",
+            json={"prompt": f"{pg_app.prefix} alice prompt", "task_type": "reasoning"},
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        alice_consultation = resp.json()["consultation_id"]
+
+        resp = await pg_app.client.post(
+            "/v1/consultations",
+            json={"prompt": f"{pg_app.prefix} bob prompt", "task_type": "reasoning"},
+            headers=pg_app.bob.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        bob_consultation = resp.json()["consultation_id"]
+
+        resp = await pg_app.client.get(
+            f"/v1/consultations/{bob_consultation}",
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.get(
+            f"/v1/consultations/{bob_consultation}/artifacts",
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.get("/v1/consultations/audit", headers=pg_app.alice.headers)
+        assert resp.status_code == 200, resp.text
+        visible_ids = {entry["consultation_id"] for entry in resp.json()}
+        assert alice_consultation in visible_ids
+        assert bob_consultation not in visible_ids
+
+        resp = await pg_app.client.get(
+            f"/v1/consultations/{alice_consultation}",
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == alice_consultation
+
+        async with pg_app.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id::text, owner_id, namespace FROM graeae_consultations "
+                "WHERE id = ANY($1::uuid[])",
+                [alice_consultation, bob_consultation],
+            )
+        by_id = {row["id"]: row for row in rows}
+        assert by_id[alice_consultation]["namespace"] == pg_app.alice.namespace
+        assert by_id[bob_consultation]["namespace"] == pg_app.bob.namespace
+    finally:
+        await _cleanup(pg_app)

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from api.auth import UserContext
+from modules.memory_categorization.entities import EntityManager
+
+pytestmark = pytest.mark.asyncio
+
+
+def _user() -> UserContext:
+    return UserContext(
+        user_id="alice",
+        group_ids=[],
+        role="user",
+        namespace="alice-ns",
+        authenticated=True,
+    )
+
+
+class _Acquire:
+    def __init__(self, conn: "_Conn"):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Pool:
+    def __init__(self, conn: "_Conn"):
+        self.conn = conn
+
+    def acquire(self):
+        return _Acquire(self.conn)
+
+
+class _Conn:
+    def __init__(self, returned_id: str):
+        self.returned_id = returned_id
+        self.inserted_id: str | None = None
+
+    async def fetchrow(self, sql: str, *args):
+        self.inserted_id = args[0]
+        assert "ON CONFLICT" in sql
+        assert "RETURNING id::text" in sql
+        return {"id": self.returned_id}
+
+
+async def test_entity_manager_create_entity_returns_existing_id_on_conflict():
+    existing_id = "11111111-1111-1111-1111-111111111111"
+    conn = _Conn(returned_id=existing_id)
+    manager = EntityManager(_Pool(conn))
+
+    entity_id = await manager.create_entity(
+        "person",
+        "Alice",
+        description="updated",
+        user=_user(),
+    )
+
+    assert entity_id == existing_id
+    assert conn.inserted_id is not None
+    assert conn.inserted_id != existing_id

--- a/tests/test_ingest_owner_namespace.py
+++ b/tests/test_ingest_owner_namespace.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.test_namespace_isolation import NamespaceHarness, PG_URL
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not PG_URL, reason="set MNEMOS_TEST_DB=postgres://... to run integration tests"),
+    pytest.mark.asyncio,
+]
+
+
+async def _cleanup(pg_app: NamespaceHarness) -> None:
+    async with pg_app.pool.acquire() as conn:
+        await conn.execute(
+            """
+            DELETE FROM webhook_deliveries d
+            USING webhook_subscriptions s
+            WHERE d.subscription_id = s.id
+              AND s.owner_id LIKE $1
+            """,
+            f"{pg_app.prefix}%",
+        )
+        await conn.execute("DELETE FROM webhook_subscriptions WHERE owner_id LIKE $1", f"{pg_app.prefix}%")
+        await conn.execute(
+            "DELETE FROM memory_branches WHERE memory_id IN "
+            "(SELECT id FROM memories WHERE owner_id LIKE $1)",
+            f"{pg_app.prefix}%",
+        )
+        await conn.execute("DELETE FROM memory_versions WHERE owner_id LIKE $1", f"{pg_app.prefix}%")
+        await conn.execute("DELETE FROM memories WHERE owner_id LIKE $1", f"{pg_app.prefix}%")
+
+
+async def _subscribe(conn, *, owner_id: str, namespace: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO webhook_subscriptions (url, events, secret, owner_id, namespace)
+        VALUES ('https://example.test/hook', ARRAY['memory.created']::text[], 'secret', $1, $2)
+        """,
+        owner_id,
+        namespace,
+    )
+
+
+async def test_ingest_session_stamps_owner_namespace_and_emits_webhooks(pg_app: NamespaceHarness, monkeypatch):
+    import api.lifecycle as lc
+
+    monkeypatch.setattr(lc, "_schedule_delivery_attempt", lambda coro: coro.close())
+
+    try:
+        async with pg_app.pool.acquire() as conn:
+            await _subscribe(conn, owner_id=pg_app.alice.user_id, namespace=pg_app.alice.namespace)
+
+        resp = await pg_app.client.post(
+            "/ingest/session",
+            headers=pg_app.alice.headers,
+            json={
+                "session_id": f"{pg_app.prefix}-alice-session",
+                "source": "claude-code",
+                "agent_id": "agent-a",
+                "raw_data": {"messages": [{"role": "user", "content": "alice-only memory"}]},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        alice_memory_id = resp.json()["memory_ids"][0]
+
+        resp = await pg_app.client.post(
+            "/ingest/session",
+            headers=pg_app.bob.headers,
+            json={
+                "session_id": f"{pg_app.prefix}-bob-session",
+                "source": "claude-code",
+                "agent_id": "agent-b",
+                "raw_data": {"code_blocks": [{"text": "bob-only memory"}]},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        bob_memory_id = resp.json()["memory_ids"][0]
+
+        resp = await pg_app.client.get("/v1/memories?category=session_activity", headers=pg_app.alice.headers)
+        assert resp.status_code == 200, resp.text
+        assert {m["id"] for m in resp.json()["memories"]} == {alice_memory_id}
+
+        resp = await pg_app.client.get("/v1/memories?category=session_code", headers=pg_app.alice.headers)
+        assert resp.status_code == 200, resp.text
+        assert bob_memory_id not in {m["id"] for m in resp.json()["memories"]}
+
+        resp = await pg_app.client.get("/v1/memories?category=session_activity", headers=pg_app.bob.headers)
+        assert resp.status_code == 200, resp.text
+        assert alice_memory_id not in {m["id"] for m in resp.json()["memories"]}
+
+        resp = await pg_app.client.get("/v1/memories?category=session_code", headers=pg_app.bob.headers)
+        assert resp.status_code == 200, resp.text
+        assert {m["id"] for m in resp.json()["memories"]} == {bob_memory_id}
+
+        async with pg_app.pool.acquire() as conn:
+            memory = await conn.fetchrow(
+                """
+                SELECT owner_id, namespace, permission_mode, verbatim_content,
+                       source_provider, source_session, source_agent
+                FROM memories
+                WHERE id = $1
+                """,
+                alice_memory_id,
+            )
+            deliveries = await conn.fetch(
+                """
+                SELECT d.event_type, d.payload
+                FROM webhook_deliveries d
+                JOIN webhook_subscriptions s ON s.id = d.subscription_id
+                WHERE s.owner_id = $1 AND s.namespace = $2
+                """,
+                pg_app.alice.user_id,
+                pg_app.alice.namespace,
+            )
+
+        assert memory["owner_id"] == pg_app.alice.user_id
+        assert memory["namespace"] == pg_app.alice.namespace
+        assert memory["permission_mode"] == 600
+        assert memory["source_provider"] == "claude-code"
+        assert memory["source_session"] == f"{pg_app.prefix}-alice-session"
+        assert memory["source_agent"] == "agent-a"
+        assert "alice-only memory" in memory["verbatim_content"]
+        assert [row["event_type"] for row in deliveries] == ["memory.created"]
+        assert alice_memory_id in deliveries[0]["payload"]
+    finally:
+        await _cleanup(pg_app)
+
+
+async def test_ingest_session_rolls_back_webhook_when_memory_insert_fails(pg_app: NamespaceHarness, monkeypatch):
+    import api.lifecycle as lc
+    from api.handlers import ingest
+
+    monkeypatch.setattr(lc, "_schedule_delivery_attempt", lambda coro: coro.close())
+    monkeypatch.setattr(ingest.uuid, "uuid4", lambda: SimpleNamespace(hex="sameid000000000000000000000000"))
+
+    try:
+        async with pg_app.pool.acquire() as conn:
+            await _subscribe(conn, owner_id=pg_app.alice.user_id, namespace=pg_app.alice.namespace)
+
+        resp = await pg_app.client.post(
+            "/ingest/session",
+            headers=pg_app.alice.headers,
+            json={
+                "session_id": f"{pg_app.prefix}-rollback-session",
+                "source": "claude-code",
+                "raw_data": {
+                    "messages": [{"role": "user", "content": "first insert"}],
+                    "code_blocks": [{"text": "duplicate id insert"}],
+                },
+            },
+        )
+        assert resp.status_code == 500, resp.text
+
+        async with pg_app.pool.acquire() as conn:
+            memory_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM memories WHERE owner_id = $1 AND source_session = $2",
+                pg_app.alice.user_id,
+                f"{pg_app.prefix}-rollback-session",
+            )
+            delivery_count = await conn.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM webhook_deliveries d
+                JOIN webhook_subscriptions s ON s.id = d.subscription_id
+                WHERE s.owner_id = $1 AND s.namespace = $2
+                """,
+                pg_app.alice.user_id,
+                pg_app.alice.namespace,
+            )
+
+        assert memory_count == 0
+        assert delivery_count == 0
+    finally:
+        await _cleanup(pg_app)

--- a/tests/test_migration_lists_sync.py
+++ b/tests/test_migration_lists_sync.py
@@ -53,6 +53,7 @@ EXPECTED_MIGRATIONS = [
     "migrations_v3_5_state_journal_namespace.sql",
     "migrations_v3_5_session_compression_ratio_drop.sql",
     "migrations_v3_5_session_compression_legacy_drop.sql",
+    "migrations_v3_5_sessions_consultations_namespace.sql",
 ]
 
 
@@ -247,6 +248,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "/docker-entrypoint-initdb.d/37-session-compression-legacy-drop.sql"
         ) in text, compose_name
         assert (
+            "./db/migrations_v3_5_sessions_consultations_namespace.sql:"
+            "/docker-entrypoint-initdb.d/38-sessions-consultations-namespace.sql"
+        ) in text, compose_name
+        assert (
             "./db/migrations_v3_5_trigger_same_memory_parent.sql:"
             "/migrations/24-trigger-same-memory-parent.sql:ro"
         ) in text, compose_name
@@ -302,6 +307,10 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
             "./db/migrations_v3_5_session_compression_legacy_drop.sql:"
             "/migrations/37-session-compression-legacy-drop.sql:ro"
         ) in text, compose_name
+        assert (
+            "./db/migrations_v3_5_sessions_consultations_namespace.sql:"
+            "/migrations/38-sessions-consultations-namespace.sql:ro"
+        ) in text, compose_name
         assert "psql -h postgres -U mnemos_user -d mnemos" in text, compose_name
         assert "-v ON_ERROR_STOP=1" in text, compose_name
         assert "-f /migrations/24-trigger-same-memory-parent.sql" in text, compose_name
@@ -318,6 +327,7 @@ def test_compose_files_run_v3_5_upgrades_for_existing_volumes():
         assert "-f /migrations/35-state-journal-namespace.sql" in text, compose_name
         assert "-f /migrations/36-session-compression-ratio-drop.sql" in text, compose_name
         assert "-f /migrations/37-session-compression-legacy-drop.sql" in text, compose_name
+        assert "-f /migrations/38-sessions-consultations-namespace.sql" in text, compose_name
         assert "postgres-upgrade:\n        condition: service_completed_successfully" in text, compose_name
 
 

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -7,9 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
-from api.auth import UserContext
+from api.auth import UserContext, get_current_user
 from api.handlers import openai_compat
 
 
@@ -1033,22 +1034,34 @@ def test_unknown_model_returns_404(monkeypatch):
     assert exc.value.detail == "model not found"
 
 
-def test_chat_completion_unknown_model_returns_model_not_found(monkeypatch):
+def test_chat_completion_unknown_model_returns_model_not_found_on_wire(monkeypatch):
     async def _unknown_model(model: str):
         return None
 
     monkeypatch.setattr(openai_compat, "_search_mnemos_context", _no_context)
     monkeypatch.setattr(openai_compat, "_resolve_provider_for_model", _unknown_model)
-    req = openai_compat.ChatCompletionRequest(
-        model="nonexistent-model",
-        messages=[openai_compat.ChatMessage(role="user", content="hello")],
-    )
 
-    with pytest.raises(HTTPException) as exc:
-        asyncio.run(openai_compat.chat_completions(req, authorization=None, user=_user()))
+    from api_server import app
 
-    assert exc.value.status_code == 404
-    assert exc.value.detail == {
+    async def _override_user():
+        return _user()
+
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "nonexistent-model",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        client.close()
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 404
+    assert response.json() == {
         "error": {
             "message": "The model `nonexistent-model` does not exist or you do not have access to it.",
             "type": "invalid_request_error",

--- a/tests/test_sessions_namespace_isolation.py
+++ b/tests/test_sessions_namespace_isolation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.test_namespace_isolation import NamespaceHarness, PG_URL
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not PG_URL, reason="set MNEMOS_TEST_DB=postgres://... to run integration tests"),
+    pytest.mark.asyncio,
+]
+
+
+async def _cleanup(pg_app: NamespaceHarness) -> None:
+    async with pg_app.pool.acquire() as conn:
+        await conn.execute("DELETE FROM sessions WHERE user_id LIKE $1", f"{pg_app.prefix}%")
+
+
+async def test_sessions_are_isolated_by_owner_and_namespace(pg_app: NamespaceHarness):
+    try:
+        resp = await pg_app.client.post(
+            "/v1/sessions",
+            json={"model": "gpt-4o", "initial_context": "alice context"},
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        alice_session = resp.json()["session_id"]
+
+        resp = await pg_app.client.post(
+            "/v1/sessions",
+            json={"model": "gpt-4o", "initial_context": "bob context"},
+            headers=pg_app.bob.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        bob_session = resp.json()["session_id"]
+
+        resp = await pg_app.client.get(f"/v1/sessions/{bob_session}", headers=pg_app.alice.headers)
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.get(f"/v1/sessions/{bob_session}/history", headers=pg_app.alice.headers)
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.post(
+            f"/v1/sessions/{bob_session}/messages",
+            json={"role": "user", "content": "cross namespace write"},
+            headers=pg_app.alice.headers,
+        )
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.delete(f"/v1/sessions/{bob_session}", headers=pg_app.alice.headers)
+        assert resp.status_code == 404
+
+        resp = await pg_app.client.get(f"/v1/sessions/{alice_session}", headers=pg_app.alice.headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["session_id"] == alice_session
+
+        async with pg_app.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, user_id, namespace FROM sessions WHERE id = ANY($1::text[])",
+                [alice_session, bob_session],
+            )
+        by_id = {row["id"]: row for row in rows}
+        assert by_id[alice_session]["namespace"] == pg_app.alice.namespace
+        assert by_id[bob_session]["namespace"] == pg_app.bob.namespace
+    finally:
+        await _cleanup(pg_app)


### PR DESCRIPTION
## Summary
Third super-sweep audit (`task-moiydd1l-y1brdu`, `/tmp/audit-pass3.md`) overturned the GA hypothesis with new product-surface gaps. Slice 14 closes all six per Primary Directive #8 (Codex fixes its own findings).

### Gaps closed
- **A. `POST /ingest/session` ownership-model bypass** — `api/handlers/ingest.py` now requires `UserContext`, applies `_rls_context`, writes canonical memory fields with caller `owner_id`+`namespace`, and dispatches `memory.created` webhooks via the in-transaction outbox connection (matching slice 13 single+bulk shape).
- **B. OpenAI 404 envelope on the wire** — refactored `api/handlers/openai_compat.py` to return `JSONResponse(status_code=404, content={"error": {...}})` directly instead of `HTTPException(detail=...)`. Body now matches OpenAI's top-level `{"error": ...}` shape, not FastAPI's wrapped `{"detail": {"error": ...}}`. `tests/test_openai_compat.py` upgraded to assert wire-level body via TestClient.
- **C. `EntityManager.create_entity()` UUID return bug** — `INSERT ... RETURNING id` so the returned id is always the row's actual id (whether new or existing on conflict). Slice 13 missed this in the categorization-module refactor.
- **D. `DEPLOYMENT.md` migration tail stale** — existing-volume + production-upgrade sections enumerate migrations 24–38 inclusive; v3.4.1→v3.5 upgrade text now lists every migration operators must apply.
- **E. `deploy.sh` cleanup** — removed `|| true` masks from gating verification checks; dropped stale `modules.compression` / `modules.bundles` references.
- **F. Sessions + consultations namespace scoping** (doctrine extension) — `db/migrations_v3_5_sessions_consultations_namespace.sql` (prefix 38) adds `namespace` columns + indexes to `sessions` and `graeae_consultations`. Handlers (`sessions.py`, `consultations.py`) thread namespace through INSERT/SELECT/UPDATE/DELETE matching the slice 10 `_scope_namespace` pattern. Brings sessions and consultations into uniform tenancy with memories/state/journal/entities/KG/webhooks — the bar for v3.5.0 GA.

### New tests
- `tests/test_ingest_owner_namespace.py` (178 lines) — cross-tenant isolation on `/ingest/session`, outbox emission, transaction rollback
- `tests/test_sessions_namespace_isolation.py` (66 lines) — same shape for sessions
- `tests/test_consultations_namespace_isolation.py` (109 lines) — same shape for consultations
- `tests/test_entity_manager.py` (66 lines) — conflict-update returns existing row id, not generated UUID
- `tests/test_openai_compat.py` — wire-level 404 envelope shape regression

### Wiring
- `install.py` + `installer/db.py` + `docker-compose.yml` + `docker-compose.staging.yml` + `.gitlab-ci.yml` integration tier — new migration wired in all five canonical sites.

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_*namespace_isolation.py --ignore=tests/test_ingest_owner_namespace.py` — **913 passed**, 18 skipped, 0 regressions on unit subset
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [ ] GitLab integration tier — runs the 4 new isolation tests against real Postgres + applies new migration
- [ ] GitHub `pr-check.yml`

After merge, fourth super-sweep audit pass to verify v3.5.0 GA readiness.

Audit reference: `/tmp/audit-pass3.md`, Codex `task-moiydd1l-y1brdu`.

Authored-By: Codex