### PR TITLE
v3.5.1: comprehensive doc triage — squash v3.5.0, retire stale references, surface v3.2-v3.5 features

### DIFF
--- a/ANTI_MEMORY_POISONING.md
+++ b/ANTI_MEMORY_POISONING.md
@@ -59,8 +59,7 @@ memory_versions:
   - metadata: {distillation_attempts, source_model, source_provider, ...}
 session_memory_injections:
   - which memory was used in which session
-  - relevance_score, compression_ratio
-  - exact timestamp
+  - relevance_score and injection timestamp
 ```
 
 ### Protection Against Common Scenarios
@@ -71,21 +70,23 @@ session_memory_injections:
 - Create new memory entry with updated endpoint
 - Old memory remains in history (readable via git log)
 - Agents must explicitly query current version
-- Diff shows when/what changed: `GET /memories/{id}/diff?from=1&to=2`
+- Diff shows when/what changed: `GET /v1/memories/{id}/diff?from=1&to=2`
 
 #### Scenario 2: Model Rename
 **Problem:** Memory references model that no longer exists.
 **Solution:**
 - Memory is immutable; old versions preserved
 - New versions created with corrected model name
-- Version log shows exact transition point: `GET /memories/{id}/log`
+- Version log shows exact transition point: `GET /v1/memories/{id}/log`
 - Agents can query timestamp-specific versions
 
 #### Scenario 3: Configuration Drift
 **Problem:** Infrastructure changed; memory contradicts current state.
 **Solution:**
 - Session memory injections are logged (session_memory_injections table)
-- Each injection records: memory_id, relevance_score, compression_ratio, timestamp
+- Each injection records memory_id, relevance_score, and timestamp; v3.5 removed
+  the legacy session compression-ratio columns because they were not the real
+  compression store
 - Audit trail shows which memories were used and when
 - Can trace decision back to specific memory version via commit_hash
 - Revert to known-good configuration by checking out stable commit
@@ -119,35 +120,35 @@ create_memory(
 #### When Infrastructure Changes
 ```bash
 # 1. Create new memory with updated information
-curl -X POST http://localhost:5002/memories \
+curl -X POST http://localhost:5002/v1/memories \
   -d '{"content": "NEW: API endpoint is https://api.example.com/v3/auth", ...}'
 
 # 2. Review history to understand drift
-curl http://localhost:5002/memories/{id}/log?branch=main
+curl http://localhost:5002/v1/memories/{id}/log?branch=main
 
 # 3. If memory is actively used, create bugfix branch
-curl -X POST http://localhost:5002/memories/{id}/branch \
+curl -X POST http://localhost:5002/v1/memories/{id}/branch \
   -d '{"name": "bugfix-api-v2-to-v3", "from_commit": "<hash>"}'
 
 # 4. Make correction on bugfix branch
-curl -X POST http://localhost:5002/memories/{id}/versions/123/revert \
+curl -X POST http://localhost:5002/v1/memories/{id}/revert/123 \
   -d '{"branch": "bugfix-api-v2-to-v3"}'
 
 # 5. Merge back to main after validation
-curl -X POST http://localhost:5002/memories/{id}/merge \
+curl -X POST http://localhost:5002/v1/memories/{id}/merge \
   -d '{"source_branch": "bugfix-api-v2-to-v3", "strategy": "latest-wins"}'
 ```
 
 #### Detecting Poisoning
 ```bash
 # List all memories injected into a session
-curl http://localhost:5002/sessions/{id}/history
+curl http://localhost:5002/v1/sessions/{id}/history
 
 # Check if specific memory caused a problem
-curl http://localhost:5002/memories/{id}/log | jq '.commits[] | select(.snapshot_at > "2026-04-19T00:00:00")'
+curl http://localhost:5002/v1/memories/{id}/log | jq '.commits[] | select(.snapshot_at > "2026-04-19T00:00:00")'
 
 # Diff old vs new to spot drift
-curl 'http://localhost:5002/memories/{id}/diff?from=1&to=10'
+curl 'http://localhost:5002/v1/memories/{id}/diff?from=1&to=10'
 ```
 
 ### Best Practices

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,7 +1,7 @@
 # MNEMOS API Documentation
 
 **Base URL**: `http://localhost:5002`
-**Version**: v3.5-dev branch (unreleased; latest tag v3.4.1)
+**Version**: v3.5.x current; v3.5.0 shipped 2026-04-28, v3.5.1 is the 2026-04-28 documentation-triage patch
 **Format**: JSON
 
 ---
@@ -20,15 +20,18 @@ The unified `/v1/` namespace is the supported API surface.
 1. [Authentication](#authentication)
 2. [Health & Status](#health--status)
 3. [Memory Operations](#memory-operations)
-4. [Consultations (GRAEAE)](#consultations-graeae)
-5. [Providers & Models](#providers--models)
-6. [OpenAI-Compatible Gateway](#openai-compatible-gateway)
-7. [Sessions](#sessions)
-8. [Webhooks](#webhooks)
-9. [OAuth / OIDC](#oauth--oidc)
-10. [Federation](#federation)
-11. [Error Handling](#error-handling)
-12. [Examples](#examples)
+4. [Knowledge Graph](#knowledge-graph)
+5. [Consultations (GRAEAE)](#consultations-graeae)
+6. [Providers & Models](#providers--models)
+7. [OpenAI-Compatible Gateway](#openai-compatible-gateway)
+8. [Sessions](#sessions)
+9. [MORPHEUS](#morpheus)
+10. [Webhooks](#webhooks)
+11. [OAuth / OIDC](#oauth--oidc)
+12. [Federation](#federation)
+13. [Portability (MPF)](#portability-mpf)
+14. [Error Handling](#error-handling)
+15. [Examples](#examples)
 
 ---
 
@@ -60,7 +63,7 @@ Liveness + readiness check (no auth required).
   "status": "healthy",
   "timestamp": "2026-04-21T14:30:00.000Z",
   "database_connected": true,
-  "version": "3.2.3"
+  "version": "3.5.1"
 }
 ```
 
@@ -94,7 +97,11 @@ remain owner+namespace scoped.
 
 ### POST /v1/memories
 
-Create a memory. Distillation is triggered asynchronously.
+Create a memory. This writes the memory row and emits a transactional
+`memory.created` webhook event. Compression is operator-batched in v3.5.x:
+root users enqueue memories through `/admin/compression/enqueue` or
+`/admin/compression/enqueue-all`; the distillation worker then drains
+`memory_compression_queue`.
 
 **Request Body**:
 ```json
@@ -135,6 +142,21 @@ Semantic + keyword search.
 { "query": "infrastructure", "limit": 5 }
 ```
 
+Search hits update `recall_count` and `last_recalled_at` in the background.
+`compression_applied` and `compression_metadata` are reserved response fields
+on `MemoryListResponse`; v3.5.x search responses set
+`compression_applied=false`. Use `/v1/memories/rehydrate` to receive compressed
+variants when present, or `/v1/memories/{id}/compression-manifests` to inspect
+contest output.
+
+### Compression manifests and rehydration
+
+- `GET /v1/memories/{id}/compression-manifests` — current winning variant plus
+  every historical contest candidate, score, manifest, and reject reason.
+- `POST /v1/memories/rehydrate` — token-budgeted context assembly. It prefers a
+  `memory_compressed_variants` winner when one exists and reports
+  `compression_applied=true` only when a variant was actually used.
+
 ### DAG versioning (git-like)
 
 - `GET /v1/memories/{id}/versions` — version summaries on a branch, filtered per snapshot by `version_visibility_predicate` (`api/visibility.py:99-137`).
@@ -149,6 +171,22 @@ Semantic + keyword search.
 
 See `ANTI_MEMORY_POISONING.md` for the rationale and drift-detection
 workflow.
+
+---
+
+## Knowledge Graph
+
+Structured triples live beside free-text memories and use the same
+owner+namespace tenancy model.
+
+- `POST /v1/kg/triples` — create a subject/predicate/object triple
+- `GET /v1/kg/triples` — list triples with filters
+- `GET /v1/kg/timeline/{subject}` — subject timeline
+- `PATCH /v1/kg/triples/{triple_id}` — update a triple
+- `DELETE /v1/kg/triples/{triple_id}` — delete a triple
+
+KG tenancy columns were added in v3.1.x and namespace parity became the
+standard across memory and entity surfaces in v3.2-v3.5.
 
 ---
 
@@ -231,10 +269,26 @@ Memory injection can be enabled per-request via header
 
 Stateful multi-turn chat with memory injection at turn boundaries.
 
-- `POST /sessions` — create
+- `POST /v1/sessions` — create
 - `POST /v1/sessions/{id}/messages` — post a turn
 - `GET /v1/sessions/{id}` — retrieve transcript
+- `GET /v1/sessions/{id}/history` — full history
 - `DELETE /v1/sessions/{id}` — close
+
+---
+
+## MORPHEUS
+
+Dream-state generation is operator-triggered and append-only in v3.5.x.
+Generated memories are tagged with `morpheus_run_id`; rollback deletes
+generated memories for that run.
+
+- `GET /v1/morpheus/runs` — list runs
+- `GET /v1/morpheus/runs/{run_id}` — run detail
+- `GET /v1/morpheus/runs/{run_id}/clusters` — cluster membership and
+  synthesized memory IDs
+- `POST /admin/morpheus/runs` — trigger a synchronous run (root only)
+- `DELETE /admin/morpheus/runs/{run_id}` — roll back a run (root only)
 
 ---
 
@@ -291,6 +345,22 @@ are read-only by convention. Loop prevention via
 - `GET /v1/federation/feed` — outbound feed (requires `role IN ('federation','root')`)
 
 Background sync runs every 60 seconds.
+
+---
+
+## Portability (MPF)
+
+MNEMOS Portability Format (MPF) is the native import/export envelope.
+
+- `GET /v1/export` — export MPF v0.1.x envelope. `include_sidecars=true`
+  includes KG triples, memory-version DAGs, and compression manifests where
+  available.
+- `POST /v1/import` — import an MPF envelope. Root plus
+  `preserve_owner=true` is for authoritative restore/migration; non-root
+  imports are scoped to the caller's owner+namespace.
+
+CLI helpers: `tools/memory_export.py`, `tools/memory_import.py`, and
+`tools/mpf_validate.py`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,36 @@
 
 All notable changes to MNEMOS are documented here.
 
-## [3.5-dev] — in flight on `v3.5-dev` (unreleased)
+## [3.5.1] — 2026-04-28 (doc-triage patch)
 
-v3.5 is being built as a branch sequence after v3.4.1. Do not treat this
-as a release tag. Merged slices cover audit quick wins, memory-read tenancy
-and DAG integrity, webhook retry hardening, RLS group-select parity, the
-federation compound-cursor tie-breaker, consultation audit endpoint scoping,
-MCP transport parity, faithful OpenAI-compatible gateway controls, and the
-single-site HA replication doctrine.
+Documentation and version-state reconciliation only. No product behavior
+changes from v3.5.0.
+
+### Changed
+
+- Bump package/runtime version metadata from 3.4.1 to 3.5.1.
+- Reframe README, deployment, specification, API, roadmap, evolution, and
+  release-charter docs around the shipped v3.5.x state.
+- Preserve historical LETHE / ANAMNESIS / ALETHEIA references, but remove or
+  reframe current-state docs that still described retired compression engines,
+  `CompressionManager`, the `DistillationEngine` compatibility wrapper, or
+  vestigial session compression columns as active.
+- Surface shipped v3.2-v3.5 features in user-facing docs: two-dimensional
+  owner+namespace tenancy, MORPHEUS, recall tracking, MPF portability,
+  CHARON schema preflight, webhook retry leases/outbox hardening, MCP registry
+  parity, faithful OpenAI-compatible gateway handling, PostgreSQL streaming
+  replication doctrine, and namespace-uniform audit closure.
+
+## [3.5.0] — 2026-04-28
+
+v3.5.0 is the audit-driven hardening and uniform-tenancy release. It shipped
+the branch sequence that began after v3.4.1: session-history ordering,
+memory-read tenancy and DAG integrity, webhook retry hardening, RLS
+group-select parity, the federation compound-cursor tie-breaker, consultation
+audit endpoint scoping, MCP transport parity, faithful OpenAI-compatible
+gateway controls, namespace-uniform tenancy across remaining product surfaces,
+bulk webhook parity, and the single-site PostgreSQL streaming-replication
+doctrine.
 
 ### Added
 
@@ -101,9 +123,19 @@ single-site HA replication doctrine.
 - **Slice 12 — compression semantics** — drop session-layer always-NULL
   `compression_ratio` fiction columns from `session_messages` +
   `session_memory_injections`; document operator-batched compression doctrine in
-  `docs/COMPRESSION.md`. Real compression layer (`compression_artifacts` /
-  contests, `StatsResponse`, `RehydrationResponse`, admin batch endpoints)
-  unchanged.
+  `docs/COMPRESSION.md`. Real compression layer
+  (`memory_compression_queue`, `memory_compression_candidates`,
+  `memory_compressed_variants`, `StatsResponse`, `RehydrationResponse`, admin
+  batch endpoints) unchanged.
+- **Namespace-uniform product surfaces.** State, journal, entities, sessions,
+  and GRAEAE consultations now carry the same owner+namespace discipline as
+  memory rows. Entity uniqueness is widened to
+  `(owner_id, namespace, entity_type, name)`; state keys are scoped by
+  `(owner_id, namespace, key)`.
+- **Bulk memory create webhook parity.** `POST /v1/memories/bulk` now emits
+  `memory.created` through the same transactional outbox path as single
+  memory creation for every successful item and rolls back the batch if outbox
+  enqueue fails.
 
 ### Fixed
 
@@ -248,7 +280,7 @@ single-site HA replication doctrine.
   now roll back the ACK record and partial cleanup, leaving the lease-owned
   attempt retryable. The rare tradeoff is a bounded duplicate POST after
   lease expiry, logged for observability, instead of a committed succeeded
-  predecessor with live successors that old v3.5-dev workers could replay.
+  predecessor with live successors that old pre-GA workers could replay.
   Round 24 adds
   `db/migrations_v3_5_webhook_succeeded_terminal_trigger.sql`, making
   `status='succeeded'` terminal at the database layer. Old id-only writers
@@ -264,11 +296,11 @@ single-site HA replication doctrine.
   `memory_branches` against `memory_versions` for that memory before
   retrying the write.
 
-### Still open on the v3.5 backlog
+### Deferred after v3.5.0
 
-- #23 entity namespace conflict-key migration.
-- #19 bulk webhook parity.
-- #15 deletion-log refactor.
+- Dedicated per-memory deletion-log table and GDPR wipe workflow remain v4
+  scope. v3.5.0 keeps the DELETE tombstone snapshot path live in the version
+  DAG, but it does not add a separate deletion-log subsystem.
 
 ## [3.4.1] — 2026-04-26
 
@@ -401,7 +433,7 @@ retiring ALETHEIA from the default contest.
   pass (LLM-mediated synthesis of cross-memory patterns into
   derived facts). Three audit-log items closed: namespace scope on
   cluster output, cluster introspection endpoint, FastAPI
-  deprecation cleanup. 31 tests in `tests/test_knossos.py` cover
+  deprecation cleanup. 31 tests in `tests/test_knossos_phase1.py` cover
   the phase-1 tool surface (0.46s).
 - **`recall_count` + `last_recalled_at` on memory search hits.**
   Every search result increments the recall counter and updates

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # MNEMOS Deployment & Configuration Guide
 
-**Status**: v3.4.1 latest tag; v3.5-dev in flight on branch
+**Status**: v3.5.x current. v3.5.0 shipped 2026-04-28; v3.5.1 is the 2026-04-28 documentation-triage patch.
 
 ---
 
@@ -10,7 +10,7 @@
 - PostgreSQL 12+ (for memory storage, audit logs, sessions, DAG versioning)
 - Python 3.10+
 - LLM provider API keys (Together AI or Groq free tier recommended)
-- (Optional) GPU for enhanced compression speeds (Tier 2-3)
+- (Optional) GPU or local inference endpoint for APOLLO's LLM fallback and self-hosted LLMs
 
 ### Installation
 
@@ -186,7 +186,7 @@ GROQ_API_KEY=your_key         # Free tier available
 No GPU needed. No inference server needed. Just these 5 variables and you're running MNEMOS in production with full reasoning capability via GRAEAE.
 
 ### Full configuration
-See `.env.example` for complete options including GPU setup, compression tiers, rate limiting, etc.
+See `.env.example` for complete options including GPU setup, compression contests, rate limiting, webhooks, OAuth, federation, and observability.
 
 ---
 
@@ -274,12 +274,12 @@ existing volumes.
 Postgres image init scripts under `/docker-entrypoint-initdb.d` only run
 when the data directory is first initialized. They do not re-run when an
 existing `postgres_data` volume starts with newer migration files mounted.
-For v3.5-dev, `docker-compose.yml` and `docker-compose.staging.yml`
+For v3.5.x, `docker-compose.yml` and `docker-compose.staging.yml`
 therefore include `postgres-upgrade`, which waits for Postgres health and
 then applies the v3.5 upgrade tail before the MNEMOS service starts.
 
 The canonical order lives in `install.py` and `installer/db.py`; compose must
-mirror those loaders. Current v3.5-dev upgrade tail is prefixes 24-38, in
+mirror those loaders. Current v3.5.x upgrade tail is prefixes 24-38, in
 order:
 `trigger-same-memory-parent`, `rls-group-select-unix-bits`,
 `webhook-retry-terminal-state`, `webhook-attempt-lease`,
@@ -315,12 +315,33 @@ SQLite-based laptop/local-replica mode.
 | PostgreSQL streaming replication | Same site / same LAN / same datacenter | Sub-ms latency expected | Single writer; async or sync standby | Postgres-native WAL shipping | Automatic WAL shipping; no MNEMOS app-level config |
 | MNEMOS federation | Cross-site, multi-org, laptop replica, or curated remote feed | High latency tolerated | Opt-in per-memory, peer-to-peer | MNEMOS-level (post-write) | Needs `MNEMOS_FEDERATION_PEERS` configuration or registered federation peers |
 
-**Anti-pattern:** Dont use federation between same-LAN nodes — Postgres
+**Anti-pattern:** Don't use federation between same-LAN nodes — Postgres
 streaming replication is faster, simpler, and avoids multi-master dedup work.
 
 See [`docs/STREAMING_REPLICATION.md`](./docs/STREAMING_REPLICATION.md) for the
 single-primary + N-standby runbook using `pg_basebackup`, WAL streaming,
 promotion, and HAProxy/PgBouncer-style writer endpoints.
+
+---
+
+## Portability, MORPHEUS, and Compression Operations
+
+MPF portability is available through `GET /v1/export` and `POST /v1/import`.
+Use root plus `preserve_owner=true` only for authoritative restores or
+migrations; non-root imports are scoped to the caller's owner+namespace. The
+CLI helpers are `tools/memory_export.py`, `tools/memory_import.py`, and
+`tools/mpf_validate.py`.
+
+MORPHEUS dream-state runs are operator-triggered through
+`POST /admin/morpheus/runs` and inspected through `/v1/morpheus/runs*`.
+Runs are synchronous in v3.5.x, append generated memories tagged with
+`morpheus_run_id`, and roll back by deleting memories from that run.
+
+Compression is operator-batched. Use `POST /admin/compression/enqueue` or
+`POST /admin/compression/enqueue-all` to feed the contest worker. The active
+built-in engines are APOLLO and ARTEMIS; the retired LETHE / ANAMNESIS /
+ALETHEIA engines and the legacy session compression columns are not part of
+the v3.5.x runtime.
 
 ---
 
@@ -421,8 +442,8 @@ curl -X GET http://localhost:5002/v1/models \
 
 ### Sessions (Stateful Chat)
 ```bash
-# POST /sessions - Create session
-curl -X POST http://localhost:5002/sessions \
+# POST /v1/sessions - Create session
+curl -X POST http://localhost:5002/v1/sessions \
   -H "Authorization: Bearer $MNEMOS_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "auto"}'
@@ -501,7 +522,7 @@ GROQ_API_KEY=xxx           # Recommended free tier
 OPENAI_API_KEY=xxx         # Optional, paid
 ANTHROPIC_API_KEY=xxx      # Optional, paid
 
-# GPU provider (OPTIONAL — only if using Tier 2-3 compression)
+# GPU provider (OPTIONAL — only for APOLLO LLM fallback or local LLM backends)
 # GPU_PROVIDER_HOST=http://gpu.example.com
 # GPU_PROVIDER_PORT=8000
 
@@ -603,7 +624,7 @@ psql -d mnemos -c "REINDEX TABLE memories;"
 
 ### 409: Memory branch state is inconsistent
 
-v3.5-dev maps trigger SQLSTATE `MN001` to HTTP 409 when
+v3.5.x maps trigger SQLSTATE `MN001` to HTTP 409 when
 `memory_branches` is missing, has `NULL head_version_id`, or points at a
 `memory_versions` row from another memory. Inspect and reconcile the
 branch rows before retrying:

--- a/EVOLUTION.md
+++ b/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 The version numbers on releases are tidy. The actual path was not. This
 document is the honest version — decisions, refactors, mistakes, and the
-reasoning that got us from the original prototype to the current v3.5-dev branch. If you
+reasoning that got us from the original prototype to the current v3.5.x release line. If you
 are considering MNEMOS for your own stack, you should know where it came
 from; if you are contributing, you should know which doors have been closed
 and why.
@@ -28,7 +28,7 @@ codebase took along the way.
 | 2026-03 | Knowledge graph schema design — subject / predicate / object with temporal validity windows. Memory versioning trigger drafted. Cryptographic audit chain (SHA-256) prototyped. Multi-user RLS foundation via PostgreSQL session variables. The first attempt at the column-naming convention that the v2.3 release would later force a five-bug cleanup of. |
 | 2026-04-12 | **v2.3.0** — knowledge graph (`/kg/triples`, `/kg/timeline/{subject}`), journal, key-value state, entity tracking, model registry, LETHE compression (Tier 1, CPU), full audit chain, multi-user RLS, memory versioning with diff/revert. The painful release — five `created_at` column bugs, missing `kg_triples` migration on fresh installs, FK type mismatch (`UUID` vs `TEXT`) caught at first insert, port 5000 → 5002 move. |
 | 2026-04-19 | **v2.4.0** (consolidation, not public) — OpenAI-compatible gateway (`/v1/chat/completions`, `/v1/models`) with optional memory injection. Stateful session management (`/sessions/*`). DAG versioning — git-like branch / merge / revert on memory history. MOIRAI compression triad (LETHE / ALETHEIA / ANAMNESIS) with quality manifests on every transformation. The shape of v3 is locked. |
-| 2026-04-22 | **v3.0.0-beta** — MNEMOS + GRAEAE unify on port 5002. Webhooks (HMAC-SHA256, SSRF defense, durable retry log). OAuth / OIDC (Google / GitHub / Azure AD / generic) with `email_verified` cross-provider linking guard. Cross-instance federation with `permission_mode` per-memory opt-in and `federation_source` loop prevention. Self-maintaining model registry (`provider_sync` daily, Arena.ai Elo quarterly). Per-owner multi-tenant scoping on memories / consultations / state / journal / entities. Atomic consultation persistence under `pg_advisory_xact_lock`. Twenty-two FK edges with explicit `ON DELETE`. Two-pass release-gate audit (self + Codex re-audit) catches five P0 issues including a hardcoded production bearer in the Docling export tool. |
+| 2026-04-22 | **v3.0.0-beta** — MNEMOS + GRAEAE unify on port 5002. Webhooks (HMAC-SHA256, SSRF defense, durable retry log). OAuth / OIDC (Google / GitHub / Azure AD / generic) with `email_verified` cross-provider linking guard. Cross-instance federation with `permission_mode` per-memory opt-in and `federation_source` loop prevention. Model registry sync foundations (`provider_sync` and Arena.ai/LMArena weighting). Per-owner multi-tenant scoping on memories / consultations / state / journal / entities. Atomic consultation persistence under `pg_advisory_xact_lock`. Twenty-two FK edges with explicit `ON DELETE`. Two-pass release-gate audit (self + Codex re-audit) catches five P0 issues including a hardcoded production bearer in the Docling export tool. |
 | 2026-04-22 | OpenClaw PR #70224 merged — first upstream contribution from the MNEMOS testing surface. The "we give as well as take" principle starts being load-bearing instead of aspirational. |
 | 2026-04-23 | **v3.1.0** — Plugin `CompressionEngine` ABC + competitive contest framework + persisted audit log across three built-in engines. GPU circuit breaker. Admin enqueue endpoints. First real benchmark on 49 PYTHIA memories with `gemma-4-E4B` as judge on CERBERUS reveals ALETHEIA scored 0/49 contest wins — its index-list prompt doesn't survive instruction-tuned generalist LLMs. ALETHEIA retired from default contest the same day. Benchmark write-up: `docs/benchmarks/compression-2026-04-23.md`. |
 | 2026-04-23 | Federation → fault-tolerance pivot. The cross-instance feed model from v3.0.0-beta turns out to be the wrong primitive for a single operator running multiple boxes; what was actually needed was HA. Move to `pg_auto_failover` (TYPHON monitor, PYTHIA primary, CERBERUS standby). ARGONAS reconciled against public master via 156-commit Codex triage (6 KEEP / 137 SKIP / 13 DROP). |
@@ -36,8 +36,10 @@ codebase took along the way.
 | 2026-04-24 | **v3.3.0-alpha** — MORPHEUS dream-state subsystem slice 1 lands (begin / finish / rollback runs, replay phase real, cluster + synthesise as stubs). MCP HTTP/SSE bridge (`mcp_http_server.py`) for ChatGPT Pro Developer Mode + any remote MCP client that needs an HTTPS URL. KNOSSOS / CHARON positioning as *gifts to other memory systems* (MemPalace, Mem0, Letta, Graphiti, Cognee) with concrete upstream-PR commitments. The compression stack settles to two engines (APOLLO + ARTEMIS); LETHE / ANAMNESIS / ALETHEIA become evolutionary history. `EVOLUTION.md`, `ROADMAP.md`, and `docs/connectors/` written for the first public release. |
 | 2026-04-26 | **v3.3.0 / v3.4.0** — MORPHEUS slice 2 fills in real cluster + synthesise, recall tracking, cluster introspection, and namespace scoping. CHARON v0.2 turns MPF into a sidecar-capable portability surface for KG triples, documents, facts, events, compression manifests, and memory-version DAGs. The v3.4 audit work spends forty-four Codex rounds on sidecar attachment and restore correctness. |
 | 2026-04-26 | **v3.4.1** — federation schema-compat preflight lands before peers sync. Strict peers refuse schema mismatch with HTTP 409 unless an operator opts into `compat_mode=permissive`. The dev↔prod MPF restore drill is written and validated on PYTHIA → PROTEUS data. |
-| 2026-04-26 | **v3.5-dev slice 1** — audit quick wins: session history returns the newest rows instead of the oldest, system rows are pinned/capped deterministically, and project URLs move to `mnemos-os/mnemos` (`a62a099`). |
-| 2026-04-26 | **v3.5-dev slice 2** — memory-read tenancy and DAG-integrity hardening (`d42c475`). Shared read visibility moves into `api/visibility.py`; version history becomes per-snapshot visible; merge/revert/branch writers serialize around branch heads; the v3.5 trigger raises `MN001` rather than accepting missing, NULL, or cross-memory branch heads. |
+| 2026-04-26 | **v3.5.0 slice 1** — audit quick wins: session history returns the newest rows instead of the oldest, system rows are pinned/capped deterministically, and project URLs move to `mnemos-os/mnemos` (`a62a099`). |
+| 2026-04-26 | **v3.5.0 slice 2** — memory-read tenancy and DAG-integrity hardening (`d42c475`). Shared read visibility moves into `api/visibility.py`; version history becomes per-snapshot visible; merge/revert/branch writers serialize around branch heads; the v3.5 trigger raises `MN001` rather than accepting missing, NULL, or cross-memory branch heads. |
+| 2026-04-28 | **v3.5.0 GA** — the hardening branch ships: webhook retry leases/outbox discipline, federation compound cursor, consultation audit scoping, MCP stdio/HTTP registry parity, faithful OpenAI-compatible gateway behavior, PostgreSQL streaming-replication doctrine, namespace-uniform state/journal/entities/sessions/consultations, bulk webhook parity, compression cleanup, and audit closure. |
+| 2026-04-28 | **v3.5.1** — documentation-triage patch. Version metadata moves to 3.5.1 and docs are reconciled with the shipped v3.5.x state; no product behavior changes from v3.5.0. |
 
 Roughly five months. One developer with three reviewers (Codex, GRAEAE
 multi-LLM consensus, occasional Sonnet / Opus passes for design). Several
@@ -437,7 +439,7 @@ renamed; they get retired and the history gets recorded here.
 
 ---
 
-## v3.4.1 and v3.5-dev — April 2026 — "the branch learns to distrust its own history"
+## v3.4.1 and v3.5.x — April 2026 — "the branch learns to distrust its own history"
 
 v3.4.1 was the federation-safety release. CHARON v0.2 already made
 memory portable across systems, but portability created a new problem:
@@ -496,6 +498,16 @@ The final documented mismatch is closed by
 `mnemos_group_select` RLS policy and application predicate now both
 test the Unix group-read bit directly with
 `((permission_mode / 10) % 10) >= 4`.
+
+The later v3.5.0 passes made the same posture broader. Webhook delivery
+became lease-owned and retry-chain aware, with one terminal succeeded row
+enforced at the database layer. MCP stdio and HTTP/SSE now expose the same
+18-tool registry. The OpenAI-compatible gateway became pass-or-reject instead
+of silently dropping controls. State, journal, entities, sessions, and
+consultations picked up namespace-uniform tenancy. The old compression stack
+was cut down to the active APOLLO + ARTEMIS contest path; LETHE, ANAMNESIS,
+ALETHEIA, `CompressionManager`, the `DistillationEngine` wrapper, and the
+session compression fiction columns became history rather than live API.
 
 ---
 

--- a/QUICK_START_REQUIREMENTS.md
+++ b/QUICK_START_REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # MNEMOS Quick Start Requirements
 
-**Applies to**: latest tag v3.4.1 and current v3.5-dev branch
+**Applies to**: current v3.5.x release line
 **TL;DR**: Python 3.11+, PostgreSQL 16, 8GB RAM, 50GB disk
 **Full Details**: See `SYSTEM_REQUIREMENTS.md`
 
@@ -73,8 +73,8 @@ curl http://localhost:5002/health
 
 For existing Docker volumes, `docker compose up -d` also runs the
 one-shot `postgres-upgrade` service before MNEMOS starts. This applies
-the v3.5 trigger migration because Postgres initdb scripts do not rerun
-on already-initialized volumes.
+the v3.5.x migration tail because Postgres initdb scripts do not rerun on
+already-initialized volumes.
 
 ---
 
@@ -312,6 +312,6 @@ kill -9 <PID>
 
 ---
 
-**Version**: v3.5-dev branch; latest tag v3.4.1
-**Updated**: 2026-04-26
+**Version**: v3.5.x; v3.5.1 documentation-triage patch
+**Updated**: 2026-04-28
 **Accuracy**: Production-verified

--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ The distinction matters. A *storage provider* gives you a place to put bytes. An
 
 MNEMOS is the second thing. It is the operating system for agent memory: a runtime composed of named subsystems that cooperate to manage the full lifecycle of memory across multiple agents, providers, and time horizons — **write, embed, compress, version, reason-over, audit, federate, archive** — each one a first-class citizen of the runtime, not a feature bolted onto a vector store.
 
-- **MNEMOS** is the memory kernel and the overall system name. Storage, versioning, tiered compression, and lifecycle sit here.
+- **MNEMOS** is the memory kernel and the overall system name. Storage, versioning, operator-batched compression, and lifecycle sit here.
 - **GRAEAE** is the reasoning bus — a multi-provider consensus layer that scores and selects across live LLM backends with a cryptographic audit chain on every decision.
 - **THE MOIRAI** is the compression subsystem. The current built-in stack is **APOLLO + ARTEMIS**, with a written receipt on every transformation.
-- A **self-maintaining model registry** keeps itself current from provider APIs and Arena.ai Elo rankings, so the kernel always knows what models exist, what they cost, and how good they currently are.
+- A **self-maintaining model registry**, when the shipped sync timer is enabled, keeps itself current from provider APIs and Arena.ai Elo rankings, so the kernel knows what models exist, what they cost, and how good they currently are.
 - **Federation**, **webhooks**, **OAuth**, **RLS**, **DAG versioning**, and the **/v1/** REST surface are services built on top of that kernel, not retrofits onto a library.
 
 This is not vocabulary borrowed from a dictionary of compelling words. Each of those names is a subsystem with an actual code path, an actual SQL table, an actual lifecycle worker, and an actual failure mode. Read the source tree; it's laid out that way.
 
-You can treat MNEMOS like a memory storage provider if you want — `POST /v1/memories`, `GET /v1/memories/{id}`, you're done. The system will happily oblige. But the reason it holds up in production is that everything underneath that surface is operating-system-shaped: write-ahead transactions on the audit chain, supervised workers for distillation, per-provider circuit breakers, hash-chained reasoning logs, named compression tiers with quality manifests, advisory-locked DAG merges, SSRF-hardened outbound webhooks, a dynamically-weighted model registry that updates itself. It is infrastructure built to operate, not a demo feature built to demo.
+You can treat MNEMOS like a memory storage provider if you want — `POST /v1/memories`, `GET /v1/memories/{id}`, you're done. The system will happily oblige. But the reason it holds up in production is that everything underneath that surface is operating-system-shaped: write-ahead transactions on the audit chain, supervised workers for distillation, per-provider circuit breakers, hash-chained reasoning logs, operator-triggered compression contests with quality manifests, advisory-locked DAG merges, SSRF-hardened outbound webhooks, and a dynamically-weighted model registry maintained by the shipped sync job. It is infrastructure built to operate, not a demo feature built to demo.
 
 **What it is, concretely:**
 
 - A FastAPI service (port 5002), PostgreSQL + pgvector backed. Python 3.11+. Apache-2.0.
 - A single `/v1/*` REST surface covering memories, consultations, providers, sessions, webhooks, federation, and an OpenAI-compatible chat-completions gateway.
 - A multi-LLM consensus reasoning layer (GRAEAE) that distributes one prompt across multiple providers, scores the responses, and writes a tamper-evident SHA-256 hash-chained audit entry — every time.
-- Git-like DAG versioning on memory: `log`, `branch`, `merge`, `revert`. Every mutation snapshots. On the v3.5-dev branch, history reads are filtered per snapshot and branch writers refuse cross-memory parent edges.
-- Tiered compression pipeline (APOLLO schema-aware dense encoding + ARTEMIS extractive compression) with a written quality manifest on every transformation. Runs in the background distillation worker through the plugin `CompressionEngine` ABC, competitive per-memory selection, and a persisted audit log of winners and losers.
-- Per-owner multi-tenant isolation, Bearer API keys + OAuth/OIDC session cookies, SSRF-hardened webhooks, cross-instance federation with per-memory opt-in. The v3.5-dev read path uses the shared `read_visibility_predicate` in `api/visibility.py:40-96` across memory list/get/search/rehydrate/gateway surfaces.
+- Git-like DAG versioning on memory: `log`, `branch`, `merge`, `revert`. Every mutation snapshots. In v3.5.x, history reads are filtered per snapshot and branch writers refuse cross-memory parent edges.
+- Operator-batched compression contest (APOLLO schema-aware dense encoding + ARTEMIS extractive compression) with a written quality manifest on every transformation. Runs in the background distillation worker through the plugin `CompressionEngine` ABC, competitive per-memory selection, and a persisted audit log of winners and losers.
+- Per-owner multi-tenant isolation, Bearer API keys + OAuth/OIDC session cookies, SSRF-hardened webhooks, cross-instance federation with per-memory opt-in. The v3.5.x read path uses the shared `read_visibility_predicate` in `api/visibility.py:40-96` across memory list/get/search/rehydrate/gateway surfaces.
 - Runs alongside your applications the way Redis, PostgreSQL, or a message bus would. Deploy once, every agent in your stack shares the same memory substrate.
 
-The latest tagged release is **v3.4.1**: CHARON federation schema-compat preflight plus the dev↔prod MPF restore drill. The current development branch is **v3.5-dev** and is not tagged yet. v3.5 slices have landed there for session-history ordering, memory-read tenancy + DAG-integrity hardening, webhook retry hardening, the federation compound-cursor tie-breaker, MCP transport parity, and faithful OpenAI-compatible gateway controls. The going-forward compression stack is **APOLLO + ARTEMIS**.
+The current release line is **v3.5.x**. **v3.5.0 shipped on 2026-04-28** with audit-driven hardening, uniform owner+namespace tenancy, webhook retry and outbox repairs, the federation compound-cursor tie-breaker, MCP transport parity, faithful OpenAI-compatible gateway controls, and the PostgreSQL streaming-replication doctrine. **v3.5.1 is the 2026-04-28 documentation-triage patch**: no product behavior changes, just version metadata and documentation reconciliation. The active built-in compression stack is **APOLLO + ARTEMIS**.
 
 ## Works with
 
@@ -77,7 +77,7 @@ MNEMOS was built to solve those problems in a way that reflects real platform ex
 
 Its design is informed by years of enterprise platform work, large-vendor systems thinking, open-source infrastructure experience, and current work in the AI industry, without assuming that professional users want marketing language where they really need operational clarity.
 
-**MNEMOS has been in daily production use since December 2025**, backing multiple active agentic systems simultaneously. By early 2026 the running install was holding thousands of memories and had performed thousands of compressions, each with a written quality manifest. The v3.0 release line unified that production codebase into the single-service FastAPI shape shipped here; **v3.4.1 is the latest tagged release**, and **v3.5-dev** carries the current unreleased hardening slices. See [`CHANGELOG.md`](./CHANGELOG.md) for the release history and the in-flight v3.5-dev section.
+**MNEMOS has been in daily production use since December 2025**, backing multiple active agentic systems simultaneously. By early 2026 the running install was holding thousands of memories and had performed thousands of compressions, each with a written quality manifest. The v3.0 release line unified that production codebase into the single-service FastAPI shape shipped here; **v3.5.0 is the current shipped GA line**, and **v3.5.1** is its documentation-triage patch. See [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
 
 For the longer story — the original catalyzing moment, the architectural decisions (and mistakes) that took MNEMOS from a single-file prototype to a unified runtime, and the scrubs, refactors, and release-gate audits that landed the public cut — see [`EVOLUTION.md`](./EVOLUTION.md). Written for future contributors as much as for future readers who want to know what they're inheriting.
 
@@ -184,7 +184,7 @@ The shared premise — that agent memory deserves first-class treatment — is t
 
 ## What works now
 
-This is the current state of the repo on v3.5-dev. The latest release tag remains v3.4.1; v3.5 is still being built as a sequence of slices on the branch. Features described here are implemented in the branch unless explicitly called out as forward-looking in [`ROADMAP.md`](./ROADMAP.md).
+This is the current state of the v3.5.x release line. Features described here are implemented unless explicitly called out as forward-looking in [`ROADMAP.md`](./ROADMAP.md).
 
 The API surface is namespaced under `/v1/*`.
 
@@ -199,7 +199,7 @@ The API surface is namespaced under `/v1/*`.
 | `POST /v1/memories/bulk` | Bulk create memories |
 | `PATCH /v1/memories/{id}` | Update memory content or metadata |
 | `DELETE /v1/memories/{id}` | Delete a memory |
-| `POST /v1/memories/rehydrate` | Token-budgeted context load for prompt injection (v3.2 wires the compression contest's winner variants into this path) |
+| `POST /v1/memories/rehydrate` | Token-budgeted context load for prompt injection; uses the compression contest's winning variant when present |
 | `POST /ingest/session` | Ingest a session transcript |
 | `GET /v1/memories/{id}/log` | DAG commit history for a memory |
 | `POST /v1/memories/{id}/branch` | Create a branch from a specific commit |
@@ -213,7 +213,7 @@ Read access for `GET /v1/memories`, `GET /v1/memories/{id}`, search, rehydrate, 
 
 ### Multi-user and provenance (v1, shipped)
 
-Each memory carries full ownership and LLM provenance:
+Each memory carries full ownership and LLM provenance. Since v3.2, tenancy is two-dimensional: `owner_id` names the account and `namespace` names the caller's logical workspace. Non-root writes require both to match the caller context; root can override for import, repair, and audit work.
 
 - `owner_id` — which user owns this memory
 - `group_id` — optional group for shared access
@@ -224,7 +224,7 @@ Each memory carries full ownership and LLM provenance:
 - `source_session` — session ID at time of creation
 - `source_agent` — agent name or identifier
 
-**Row Level Security** is defined in PostgreSQL but inactive for personal installs. Team/enterprise installs activate it via `install.py`, which enforces per-row access at the database layer. The application layer mirrors the RLS read contract so personal-mode and RLS-backed installs behave consistently. v3.5-dev closes task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
+**Row Level Security** is defined in PostgreSQL but inactive for personal installs. Team/enterprise installs activate it via `install.py`, which enforces per-row access at the database layer. The application layer mirrors the RLS read contract so personal-mode and RLS-backed installs behave consistently. v3.5.x closes task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
 
 **Deployment profiles** — selected at install time via `python install.py`:
 
@@ -233,6 +233,8 @@ Each memory carries full ownership and LLM provenance:
 | Personal | off | off | Single developer, localhost |
 | Team | API key | on | 2–20 users, shared PostgreSQL |
 | Enterprise | API key | on | 20+ users, full namespace isolation |
+
+Search hits update recall telemetry in the background: `recall_count` increments and `last_recalled_at` is set for the returned memory IDs. The counters are observability and future archival input, not authorization state; failures are logged and do not block the user-visible search response.
 
 ### Admin API (v1)
 
@@ -294,15 +296,27 @@ Gateway field support is pass-or-reject: OpenAI-style providers receive `tempera
 
 ### Stateful sessions (v3, shipped)
 
-Multi-turn conversation state with memory injection at turn boundaries. Sessions carry accumulated context across requests.
+Multi-turn conversation state with memory injection at turn boundaries. Sessions carry accumulated context across requests and are scoped by the same owner+namespace pair as memories. v3.5 removed the legacy per-session compression columns; session history is ordered by deterministic pinned system rows plus recent turns, and compression output comes from `memory_compressed_variants` when a read path explicitly asks for compressed memory.
 
 | Endpoint | What it does |
 |----------|-------------|
-| `POST /sessions` | Start a new session |
+| `POST /v1/sessions` | Start a new session |
 | `GET /v1/sessions/{id}` | Retrieve session state |
 | `POST /v1/sessions/{id}/messages` | Post a turn; memory injection at turn boundary |
 | `GET /v1/sessions/{id}/history` | Full message history |
 | `DELETE /v1/sessions/{id}` | End a session |
+
+### MORPHEUS — dream-state generator (v3.3, shipped)
+
+MORPHEUS is the append-only dream-state subsystem: it scans a time window of existing memories, clusters related records, synthesises per-cluster summary memories, tags every generated memory with `morpheus_run_id`, and records run state in `morpheus_runs`. It is operator-triggered, not an automatic mutation daemon; rollback deletes memories generated by a run and marks the run `rolled_back`.
+
+| Endpoint | What it does |
+|----------|-------------|
+| `GET /v1/morpheus/runs` | List runs newest-first |
+| `GET /v1/morpheus/runs/{id}` | Inspect one run |
+| `GET /v1/morpheus/runs/{id}/clusters` | Inspect cluster membership and synthesized memory IDs |
+| `POST /admin/morpheus/runs` | Trigger a run (root only, synchronous in this release) |
+| `DELETE /admin/morpheus/runs/{id}` | Roll back a run (root only) |
 
 ### Webhooks (v3, shipped)
 
@@ -361,6 +375,12 @@ application-level dedup work that PostgreSQL WAL streaming already solves below
 the app. See [`DEPLOYMENT.md`](./DEPLOYMENT.md#high-availability-and-replication)
 and [`docs/STREAMING_REPLICATION.md`](./docs/STREAMING_REPLICATION.md).
 
+### Portability — MPF import/export (v3.4, shipped)
+
+MNEMOS Portability Format (MPF) is the native envelope for moving memories between MNEMOS instances and across compatible external systems. `GET /v1/export` writes an MPF v0.1.x envelope; `POST /v1/import` reads the envelope back. Root callers may use `preserve_owner=true` for authoritative restore and migration work; non-root imports are scoped to the caller's owner+namespace.
+
+CLI helpers live in [`tools/memory_export.py`](./tools/memory_export.py), [`tools/memory_import.py`](./tools/memory_import.py), and [`tools/mpf_validate.py`](./tools/mpf_validate.py). The schema is documented in [`docs/MEMORY_EXPORT_FORMAT.md`](./docs/MEMORY_EXPORT_FORMAT.md), and v3.4.1 added CHARON schema-compat preflight so federating peers can refuse incompatible migration sets before sync.
+
 ### Federation — cross-instance memory sync (v3, shipped)
 
 Pull-based one-way federation between genuinely remote MNEMOS instances. Remote peer exposes `/v1/federation/feed`; local instance pulls on a configurable interval, storing remote memories with ids of the form `fed:{peer_name}:{remote_id}` and `federation_source = peer_name`. Federated memories are read-only by application convention.
@@ -397,22 +417,22 @@ The reasoning engine behind `/v1/consultations` provides:
 - **Rate limiter** — single-level request rate limit with graceful backoff
 - **Audit chain** — SHA-256 hash-chained prompt/response log for compliance
 
-### Model registry and dynamic provider weighting (self-maintaining)
+### Model registry and dynamic provider weighting
 
-Most multi-LLM routers hardcode a provider list. MNEMOS ships a **self-populating PostgreSQL-backed model registry** that keeps itself current.
+Most multi-LLM routers hardcode a provider list. MNEMOS ships a **self-populating PostgreSQL-backed model registry** that keeps itself current when the sync job is installed.
 
 **What's in the registry.** Every known model from every configured provider — OpenAI, Groq, xAI, Together, Nvidia, Gemini, Anthropic — with per-model metadata: provider + model_id, display name, family (grok-4, gpt-5, gemini-3, …), capabilities (`chat`, `vision`, `code`, `reasoning`, `web_search`), context window, max output tokens, input / output / cache pricing (USD per million tokens), availability, deprecation flag, **Arena.ai Elo score**, **Arena.ai rank**, and the normalized `graeae_weight` (0.50–1.00) actually used by the consensus scorer.
 
 **How it populates.**
 
-- **Daily provider sync** — `graeae.provider_sync` hits each provider's `/v1/models` endpoint (Gemini uses `/v1beta/models`; Anthropic uses a static list because Anthropic does not expose a public `/models` surface) and upserts into `model_registry`. New models appear automatically; deprecated ones get flagged. No manual curation required.
-- **Quarterly Elo sync** — `scripts/refresh_elo_weights.py` (systemd: `graeae-elo-sync.timer`) fetches the Arena.ai leaderboard, maps ranks back to providers + models, and writes `arena_score`, `arena_rank`, and `graeae_weight` into the registry.
+- **Daily provider sync** — `scripts/sync_provider_models.py` (systemd: `graeae-model-sync.timer`) calls `graeae.provider_sync`, hits each provider's model-list endpoint where one exists (Gemini uses `/v1beta/models`; Anthropic uses a static list because Anthropic does not expose a public `/models` surface), and upserts into `model_registry`. New models appear automatically when the timer is installed and provider keys are configured; deprecated ones get flagged.
+- **Arena.ai ranking sync** — the same sync script refreshes Arena.ai/LMArena ranking data unless run with `--skip-arena`, maps ranks back to providers + models, and writes `arena_score`, `arena_rank`, and `graeae_weight` into the registry. `scripts/refresh_elo_weights.py` remains available for an Elo-cache-only refresh.
 - **Online quality signals** — the GRAEAE engine tracks per-provider success / failure / latency in memory; those signals combine with the registry's Elo-derived `graeae_weight` to pick the winning response on each consultation.
 
 **What it's used for.**
 
 - **`/v1/providers/recommend?task_type=...&budget=...`** — returns the cheapest available model that meets the task's capability + quality floor. Uses `graeae_weight` as the quality signal and `input_cost_per_mtok + output_cost_per_mtok` as the cost signal.
-- **GRAEAE consensus scoring** — provider responses are weighted by `graeae_weight` before the consensus pick. A provider that drops on Arena.ai also drops in MNEMOS's internal routing on the next timer tick, without any human touching a config file.
+- **GRAEAE consensus scoring** — provider responses are weighted by `graeae_weight` before the consensus pick. A provider that drops on Arena.ai also drops in MNEMOS's internal routing after the sync timer updates the registry, without code changes.
 - **OpenAI-compatible gateway model routing** — when a caller passes `model="auto"`, `model="best-coding"`, `model="best-reasoning"`, `model="fastest"`, `model="cheapest"`, the gateway resolves against the registry rather than a hardcoded alias table.
 - **OpenAI-compatible model discovery** — `/v1/models` and `/v1/models/{model_id}` expose registry rows only; chat routing can still fall back to provider-name heuristics for explicit requests, but discovery does not invent synthetic models.
 
@@ -437,7 +457,7 @@ A lot of the v3.x surface is held up by background work that doesn't show up in 
 - **Full-text search operator filtering** — `/v1/memories/search` uses `plainto_tsquery` rather than `to_tsquery`, so `|`, `&`, `!` and friends get treated as literal text instead of tsquery operators. User input cannot construct adversarial FTS queries.
 - **Federation size caps** — an abusive peer cannot fill your disk: pulled content capped at 1 MB per memory, metadata at 64 KB, name fields at 256 chars.
 - **Rate-limited audit endpoints** — `/v1/consultations/audit/verify` walks the entire chain from genesis for root callers and verifies only the caller's consultation audit rows for non-root callers; capped at 5/min so an authenticated caller cannot force O(N) scans on a large log. `/audit` list is owner-scoped for non-root callers and capped at 30/min.
-- **Quality manifest on every compression** — every compression engine in the stack writes a receipt: `{what_was_removed, what_was_preserved, quality_rating, risk_factors, safe_for, not_safe_for}`. Compression-as-data, not compression-as-side-effect.
+- **Quality manifest on every compression** — every compression engine in the active stack writes a receipt: `{what_was_removed, what_was_preserved, quality_rating, risk_factors, safe_for, not_safe_for}`. Compression-as-data, not compression-as-side-effect.
 
 ### Referential integrity (the -ism, spelled out)
 
@@ -470,9 +490,9 @@ This is the part most projects that call themselves "memory" skip, because if th
 
 The constraints are enforced at the database level. Application bugs cannot violate them. Migration bugs cannot silently create orphan rows. The constraint travels with the row.
 
-### Compression — the MOIRAI tiers
+### Compression — the MOIRAI contest
 
-Tiered compression pipeline, each tier named after a Greek figure of memory.
+Compression is operator-batched in v3.5.x. It is not an automatic session-column flag and it no longer uses the retired LETHE / ANAMNESIS / ALETHEIA engines. Operators enqueue work through the admin endpoints; the distillation worker runs a competitive contest over the active engines and persists the winner plus the losing candidates for audit.
 
 - **ARTEMIS** — CPU-only extractive compression with identifier preservation, labeled-block handling, and evidence-based self-scoring.
 - **APOLLO** — schema-aware dense encoding for LLM-to-LLM wire use. Rule-based schema detection with optional LLM fallback for fact-shaped content that misses a known schema.
@@ -480,15 +500,11 @@ Tiered compression pipeline, each tier named after a Greek figure of memory.
 - Original content always retained; compressed and original stored independently.
 - Configurable quality thresholds per task type (security review: 95%, architecture: 90%, general: 80%).
 - The plugin `CompressionEngine` ABC is open to operator-registered engines. The contest logs the winner plus every loser with its score and rejection reason.
+- `/v1/memories/search` still carries reserved `compression_applied` / `compression_metadata` response fields from the v3.2 API shape; in v3.5.x search responses set `compression_applied=false`. Use `/v1/memories/rehydrate` or `/v1/memories/{id}/compression-manifests` when you need to know whether a compressed variant was used.
 
-### Memory tiers (4-tier system)
+### Memory tier selector (advisory)
 
-| Tier | Description | Compression ratio |
-|------|-------------|------------------|
-| 1 | Recent / active | 20% |
-| 2 | Short-term | 35% |
-| 3 | Medium-term | 50% |
-| 4 | Long-term / archive | task-type dependent |
+The `modules/memory_categorization` package still exposes a hot/warm/cold/archive selector for hook-side prompt budgeting. It is advisory metadata used by integrations; it is not the removed `sessions.compression_tier` database column and does not drive automatic background compression.
 
 ### Versioning and audit
 
@@ -524,16 +540,26 @@ Landed with the v3.0 release line:
 - ✅ **CHARON federation schema preflight** — peers exchange schema signatures before sync and return 409 on incompatible strict-mode pairings.
 - ✅ **Dev↔prod MPF restore drill** — `docs/RESTORE-DRILL.md` is validated on the PYTHIA → PROTEUS path.
 
-### Landed on v3.5-dev (not tagged)
+### Shipped in v3.5.0
 
 - ✅ **Slice 1: audit quick wins** (`a62a099`) — session history returns the most recent messages first with deterministic system-row pinning, and project URLs now point at `mnemos-os/mnemos`.
 - ✅ **Slice 2: memory-read tenancy + DAG integrity** (`d42c475`) — shared memory read visibility, per-snapshot history visibility, same-memory DAG guards, race-safe branch creation, `MN001` to HTTP 409 reconciliation guidance, and a compose `postgres-upgrade` service for existing volumes.
+- ✅ **Webhook retry state machine + leases + outbox discipline** — persisted leases, one-success-per-chain guards, repair worker separation, bulk-create parity, and terminal success trigger.
+- ✅ **MCP unified registry** — stdio and HTTP/SSE expose the same 18 tools from `api/mcp_tools.py`, including CRUD, KG, DAG, bulk create, stats, and model recommendation.
+- ✅ **Faithful OpenAI-compatible gateway** — propagated generation controls, OpenAI-format SSE, registry-honest model discovery, and explicit 400/404 responses when the selected provider cannot honor a requested feature.
+- ✅ **Namespace-uniform tenancy** — state, journal, entities, sessions, consultations, webhooks, and memory read/history paths use the owner+namespace discipline.
+- ✅ **PostgreSQL streaming-replication doctrine** — single-site HA uses Postgres primary/standby replication; MNEMOS federation is for remote or curated data flows.
+- ✅ **Compression cleanup** — live compression is APOLLO + ARTEMIS through the contest worker; retired compatibility shims and vestigial session compression columns are gone.
 
-### Beyond v3.5-dev
+### v3.5.1
 
-Forward-looking scope is maintained in [`ROADMAP.md`](./ROADMAP.md), which lists committed v3.1 scope, the v3.2–v3.4 Apollo Program staged rollout, and items explicitly deferred with rationale.
+v3.5.1 is a documentation-triage patch shipped on 2026-04-28. It bumps package/runtime version metadata to 3.5.1 and reconciles release-state docs with the v3.5.0 GA tag; it does not change product behavior from v3.5.0.
 
-Near-term not-yet-scoped candidates (v3.5+):
+### Beyond v3.5.x
+
+Forward-looking scope is maintained in [`ROADMAP.md`](./ROADMAP.md), which lists shipped v3.x scope and items explicitly deferred with rationale.
+
+Near-term not-yet-scoped candidates:
 
 - Distributed consensus for multi-writer federation
 - Server-push streaming API for long-lived subscriptions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ This document is kept intentionally narrow. It lists what the next release will 
 
 **Headline:** plugin-interfaced compression platform with competitive per-memory engine selection, a persisted audit log on every compression decision, and a first-class GPU batcher that works across integrated graphics, discrete GPUs, and remote OpenAI-compatible endpoints.
 
-Three engines shipped under the platform in v3.1: LETHE (extractive, CPU), ALETHEIA (LLM-assisted token importance, GPU-required), and ANAMNESIS (LLM fact extraction, GPU-optional). The going-forward stack is LETHE + ANAMNESIS + APOLLO — ALETHEIA was retired from the default contest in the v3.2 tail on the back of the 2026-04-23 benchmark (0 contest wins, index-list prompt incompatible with instruction-tuned generalist LLMs) and is scheduled for v4.0 removal. The `CompressionEngine` ABC is open: operators can register additional engines, and the first-party third engine of the going-forward stack (APOLLO — schema-aware dense encoding for LLM-to-LLM consumption) is staged across v3.3–v3.4 (see "Apollo Program" below).
+Three engines shipped under the platform in v3.1: LETHE (extractive, CPU), ALETHEIA (LLM-assisted token importance, GPU-required), and ANAMNESIS (LLM fact extraction, GPU-optional). That is historical release context, not the active v3.5.x runtime. ALETHEIA was retired from the default contest in the v3.2 tail after the 2026-04-23 benchmark, ARTEMIS and APOLLO became the active built-ins, and v3.5 removed the LETHE / ANAMNESIS / ALETHEIA modules plus the old manager/compatibility shims. The `CompressionEngine` ABC remains open for operator-registered engines.
 
 ### Tier 1 — small fixes that unblock real surfaces (shipped on master)
 
@@ -73,7 +73,7 @@ Rolled out in stages, Saturn V-style — each stage delivers a usable payload on
 - ✅ **MORPHEUS dream-state subsystem (slice 1: foundation).** v3.3.0-alpha.1 ships `morpheus_runs` table + per-row `morpheus_run_id` tagging + admin/observability API + rollback contract. Synthesis logic stubbed; slice 2 fills it in. Architecture per GRAEAE consensus 2026-04-25: append-only synthesis first, mutation paths (CONSOLIDATE / EXTRACT / ARCHIVE) deferred to v3.6+.
 - ✅ **MORPHEUS slice 2** — real cluster + synthesise phases, cron timer at 03:17 UTC, recall-frequency tracking columns (absorbed from OpenClaw dreaming patterns), per-cluster introspection artifact, per-namespace dream scoping. Landed before the v3.3 stable cut.
 
-### v3.4 — S-IVB (third stage: trans-lunar injection) — **READY TO TAG 2026-04-26**
+### v3.4 — S-IVB (third stage: trans-lunar injection) — **SHIPPED 2026-04-26**
 
 **Headline: "CHARON v0.2 — agent memory now travels."** The portability surface that turns MNEMOS into something other systems can interop with.
 
@@ -92,37 +92,40 @@ Rolled out in stages, Saturn V-style — each stage delivers a usable payload on
 - ✅ Audit-remediation log responses to the 2026-04-25 GPT critical review (8 of 13 findings closed, 1 partial, 4 deferred-by-design or carried to v4.0 — see audit log section below).
 
 **Carried forward (originally bundled with v3.4):**
-- Distill-on-ingest as default write path → **v3.5** (see `docs/V3_5_CHARTER.md`).
-- ANAMNESIS deprecation path → stays importable until **v4.0**.
-- Full round-trip fidelity benchmark as GA gate → **v3.5** (paired with embedding migration plan).
-- KNOSSOS solidify (phase 2) → **v3.5**.
-- First wave of goodwill PRs to MemPalace → **v3.5** (subject to the 3-4 PRs/24h-per-upstream rate-limit constraint per `~/.claude/rules/github-behavior.md`).
+- Distill-on-ingest as default write path → deferred after v3.5.0; compression remains operator-batched.
+- Historical ANAMNESIS deprecation path → superseded by v3.5 slice 5 removal of LETHE / ANAMNESIS / ALETHEIA modules and compatibility shims.
+- Full round-trip fidelity benchmark as GA gate → deferred after v3.5.0; MPF restore drills and schema-compat preflight shipped first.
+- KNOSSOS phase 2 and MemPalace re-engagement → deferred after v3.5.0; v3.5.x keeps the phase-1 stdio shim.
+- First wave of goodwill PRs to MemPalace → deferred after v3.5.0 (subject to the 3-4 PRs/24h-per-upstream rate-limit constraint per `~/.claude/rules/github-behavior.md`).
 
 **See:** `docs/V3_5_CHARTER.md`, `docs/V3_6_CHARTER.md`, `docs/V4_PLAN.md`, `docs/OPERATIONS.md` for locked scopes downstream of this tag.
 
-### v3.5-dev — branch build-up after v3.4.1 (not tagged)
+### v3.5.0 — audit hardening and uniform tenancy — **SHIPPED 2026-04-28**
 
-v3.5 is in flight on `v3.5-dev`. Closed items below are merged into the branch; open items remain candidates for later v3.5 slices or explicit deferral.
+v3.5.0 shipped the audit-driven hardening branch that followed v3.4.1. It is not the PANTHEON/IRIS feature release originally sketched in `docs/V3_5_CHARTER.md`; that charter is now historical and its unshipped feature ideas move to later roadmap work.
 
 - ✅ **Slice 1: audit quick wins** (`a62a099`). Session history now returns the most recent rows first, pins/caps system rows deterministically, and project metadata points at `mnemos-os/mnemos`.
 - ✅ **Slice 2: memory-read tenancy + DAG integrity** (`d42c475`). Shared `read_visibility_predicate` gates memory list/get/search/rehydrate/gateway context; `version_visibility_predicate` gates version/log/commit/diff paths per snapshot; DAG writers use same-memory parent checks, target-head visibility gates, advisory-lock-before-row-lock ordering, race-safe branch creation, and `MN001` to HTTP 409 reconciliation.
 - ✅ **Docker existing-volume migration path** (`86f1532`, `19229d7`). `docker-compose.yml` and `docker-compose.staging.yml` run `postgres-upgrade` after Postgres is healthy so `db/migrations_v3_5_trigger_same_memory_parent.sql` applies to existing volumes, not only fresh initdb volumes.
-- ✅ **#25 RLS Unix-bit fix** (`pending commit`). `db/migrations_v3_5_rls_group_select_unix_bits.sql` replaces `mnemos_group_select` so RLS and `read_visibility_predicate` both use `((permission_mode / 10) % 10) >= 4` for group-readable rows.
-- ✅ **#20 webhook retry state machine** (`pending commit`). `api/webhook_dispatcher.py` now terminalizes superseded failed attempts as `retry_scheduled`, recovery excludes retry rows that already have successors, and `db/migrations_v3_5_webhook_retry_terminal_state.sql` repairs existing superseded rows.
-- ✅ **#21 federation stable cursor tie-breaker** (`pending commit`). `/v1/federation/feed` now uses an opaque `(updated, id)` cursor and `ORDER BY updated, id` so page boundaries inside identical timestamps do not skip rows. Per-peer ACL scope remains split to a later slice.
-- ✅ **#22 audit endpoint scoping** (`pending commit`). Consultation audit list and verify routes are owner-scoped for non-root callers, with root retaining global audit visibility.
-- ✅ **#24 MCP registry split-brain** (`pending commit`). `api/mcp_tools.py` is the canonical MCP registry for stdio and HTTP/SSE; DAG log/branch/diff/checkout and `recommend_model` are exposed through the live MCP transports, and HTTP/SSE supports per-user token maps instead of one shared backend principal.
-- ✅ **OpenAI compat honesty must-fix #5/#6/#7** (`pending commit`). Generation controls propagate through `graeae.route`, SSE streaming is implemented, tools/response_format/multimodal fields are pass-or-400 by provider capability, and `/v1/models/{model_id}` returns 404 for unregistered models.
-- 🔵 **#23 entity namespace conflict-key migration.** Namespace-aware conflict key for entity rows; still open.
-- 🔵 **#19 bulk webhook parity.** Bulk-create webhook behavior still differs from single-create.
-- 🔵 **#15 deletion-log refactor.** Parked; restore-drill cleanup still uses explicit `memory_branches` / `memory_versions` deletes.
+- ✅ **#25 RLS Unix-bit fix.** `db/migrations_v3_5_rls_group_select_unix_bits.sql` replaces `mnemos_group_select` so RLS and `read_visibility_predicate` both use `((permission_mode / 10) % 10) >= 4` for group-readable rows.
+- ✅ **#20 webhook retry state machine.** Persisted attempt leases, writer revisions, repair/recovery split, terminal-state repair, one-success-per-chain guards, and terminal success trigger.
+- ✅ **#21 federation stable cursor tie-breaker.** `/v1/federation/feed` uses an opaque `(updated, id)` cursor and `ORDER BY updated, id` so page boundaries inside identical timestamps do not skip rows. Per-peer ACL scope remains later work.
+- ✅ **#22 audit endpoint scoping + lifespan teardown.** Consultation audit list and verify routes are owner-scoped for non-root callers, root retains global audit visibility, and lifecycle shutdown drains tracked webhook send tasks.
+- ✅ **#24 MCP registry split-brain.** `api/mcp_tools.py` is the canonical MCP registry for stdio and HTTP/SSE; DAG log/branch/diff/checkout and `recommend_model` are exposed through both transports, and HTTP/SSE supports per-user token maps instead of one shared backend principal.
+- ✅ **OpenAI compat honesty must-fix #5/#6/#7.** Generation controls propagate through `graeae.route`, SSE streaming is implemented, tools/response_format/multimodal fields are pass-or-400 by provider capability, and `/v1/models/{model_id}` returns 404 for unregistered models.
+- ✅ **#23 entity namespace conflict-key migration.** Entity uniqueness includes namespace, so the same owner can use the same entity name/type in different namespaces.
+- ✅ **#19 bulk webhook parity.** `POST /v1/memories/bulk` emits the same transactional `memory.created` outbox events as single-create for successful rows.
+- ✅ **Compression cleanup.** LETHE / ANAMNESIS / ALETHEIA modules, `CompressionManager`, and the `DistillationEngine` compatibility wrapper are removed; APOLLO + ARTEMIS remain the built-in contest engines.
+- ✅ **Session compression cleanup.** Always-NULL `compression_ratio` columns and legacy `compression_tier` / `compressed` columns are dropped from session tables.
+- ✅ **Namespace-uniform tenancy.** State, journal, entities, sessions, consultations, memory reads/history, and webhook outbox writes follow owner+namespace scoping.
+- ✅ **PostgreSQL streaming-replication doctrine.** Single-site HA uses Postgres primary/standby replication; federation is reserved for remote/curated data flows.
 
-Remaining v3.5 charter work:
+Remaining after v3.5.0:
 
-- 🔵 **PANTHEON + IRIS.** Next-bound feature set: unified LLM facade and MCP model discovery layer.
+- 🔵 **Dedicated deletion-log / GDPR wipe workflow.** v3.5 keeps DELETE tombstone snapshots live in the version DAG, but no separate deletion-log table ships.
+- 🔵 **PANTHEON + IRIS.** Unified LLM facade and MCP model discovery layer, deferred from the historical v3.5 charter.
 - 🔵 **RFC-002 / MemPalace re-engagement.** Re-open with v3.4 CHARON evidence and KNOSSOS interop framing.
-- 🔵 **Compression hot-path expansion.** More read paths consume `memory_compressed_variants` instead of raw `memories.content`; still needs per-surface audit.
-- 🔵 **Search response `compression_applied` / `compression_metadata` decision.** Either wire a real summary path for large-result-set compression or document the fields as reserved.
+- 🔵 **Compression hot-path expansion.** More read paths can consume `memory_compressed_variants`; `/v1/memories/search` documents `compression_applied` / `compression_metadata` as reserved false fields in v3.5.x.
 - 🔵 **Design paper draft.** Git-like DAG + LLM-synthesized distillation/narration + judge-verified fidelity, carried from the v3.4 charter.
 
 ### v3.6 — PERSEPHONE + MORPHEUS mutation paths
@@ -197,12 +200,12 @@ Deliverables:
 
 Every Codex / GRAEAE / stop-hook audit finding from the v3.2.x and v3.3.x cycles, with status. Maintained release-by-release; new findings append. ✅ = remediated, 🔵 = planned, ⏳ = deferred.
 
-### v3.5-dev slice 1 — audit quick wins
+### v3.5.0 slice 1 — audit quick wins
 
 - ✅ Session history returned the oldest 10 messages instead of the most recent 10 — fixed in `f9ea8d9`; deterministic system-row pinning refined through `e3c884c`.
 - ✅ Repository metadata still pointed at `perlowja/mnemos` after the org move — swept to `mnemos-os/mnemos` in `c3092c6`.
 
-### v3.5-dev slice 2 — memory-read tenancy + DAG integrity
+### v3.5.0 slice 2 — memory-read tenancy + DAG integrity
 
 - ✅ `list_memories` / `get_memory` used narrower owner+namespace checks than the intended read contract — closed by shared `read_visibility_predicate` (`api/visibility.py:40-96`) and handler adoption in `api/handlers/memories.py`.
 - ✅ Search/rehydrate cache keys could collide across `None`, empty string, and caller group variation — closed with JSON serialization and group IDs in the key.
@@ -246,7 +249,7 @@ Every Codex / GRAEAE / stop-hook audit finding from the v3.2.x and v3.3.x cycles
 - ✅ `/v1/documents/import` bypass: now uses `mem_<hex12>` ids, populates `verbatim_content` / `quality_rating` / `permission_mode`, dispatches `memory.created` webhooks per chunk, invalidates search cache (v3.2.3).
 - ✅ Stale docs: README current-version paragraph rewritten to v3.2.3; SPECIFICATION endpoint count 91→96; release-history extended (v3.2.3).
 - 🔵 MPF portability partial (`kind=memory` only) — deferred to v3.4 CHARON v0.2.
-- ⏳ `/v1/memories/search` `compression_applied` / `compression_metadata` reserved-but-always-false — decision pending: implement or formally document as reserved. Carried into v3.5.
+- ✅ `/v1/memories/search` `compression_applied` / `compression_metadata` reserved-but-always-false — formally documented as reserved in v3.5.1. Real compressed reads use `/v1/memories/rehydrate` and compression manifests.
 
 ### Codex round-2 portability + APOLLO audit (after v3.2.3)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,11 +3,13 @@
 ## Supported versions
 
 The most recently maintained release branch is supported. The current
-development branch is `v3.5-dev`; it is not a release tag.
+release line is `v3.5.x`. v3.5.0 shipped on 2026-04-28; v3.5.1 is the
+2026-04-28 documentation-triage patch with no product behavior changes from
+v3.5.0.
 
 ## Current security invariants
 
-As of v3.5-dev slice 6:
+As of v3.5.x:
 
 - Memory read visibility is symmetric across list/get/search/rehydrate,
   OpenAI-compatible gateway context, version history, DAG history, and MCP
@@ -33,7 +35,14 @@ As of v3.5-dev slice 6:
   `/v1/consultations/audit` returns only the caller's consultation audit
   rows, and `/v1/consultations/audit/verify` verifies only that caller's
   rows. Root keeps the global operational audit view. This closes the
-  v3.4.x cross-tenant audit metadata leak in v3.5-dev.
+  v3.4.x cross-tenant audit metadata leak in v3.5.0.
+- Webhook delivery uses persisted leases, retry-chain convergence, terminal
+  success guards, and SSRF checks at subscription and delivery time.
+- MCP stdio and HTTP/SSE use the same registry in `api/mcp_tools.py`, with
+  per-user HTTP token mapping available through `MNEMOS_MCP_TOKENS`.
+- The OpenAI-compatible gateway passes supported generation controls through
+  to providers and rejects unsupported tool, response-format, or multimodal
+  requests instead of silently ignoring them.
 
 ## Reporting a vulnerability
 

--- a/SYSTEM_REQUIREMENTS.md
+++ b/SYSTEM_REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # MNEMOS System Requirements
 
-**Applies to**: latest tag v3.4.1 and current v3.5-dev branch
-**Updated**: 2026-04-26
+**Applies to**: current v3.5.x release line
+**Updated**: 2026-04-28
 **Applies To**: Bare Metal, Docker, and Cloud Deployments
 
 ---
@@ -94,10 +94,9 @@ psql -U postgres -d mnemos -c "CREATE EXTENSION IF NOT EXISTS uuid-ossp;"
 ```
 
 **Migration note for Docker volumes**: fresh volumes run all mounted
-`/docker-entrypoint-initdb.d` SQL. Existing volumes do not. The v3.5-dev
+`/docker-entrypoint-initdb.d` SQL. Existing volumes do not. The v3.5.x
 compose files therefore include a one-shot `postgres-upgrade` service
-that applies `db/migrations_v3_5_trigger_same_memory_parent.sql` before
-MNEMOS starts.
+that applies the v3.5 migration tail before MNEMOS starts.
 
 **Storage Requirements**:
 - Initial database: ~50 MB (empty schema)
@@ -509,10 +508,10 @@ Example: DigitalOcean Performance, AWS c5.2xlarge, Linode Linode 32GB
 | Operation | Time | Notes |
 |-----------|------|-------|
 | `/health` | 10/20ms | Always fast |
-| `POST /memories` | 50/200ms | Disk I/O bound |
-| `/memories/search` | 100/500ms | Depends on index size |
-| `POST /consultations` | 2-5s/10s | LLM network latency |
-| `/consultations/audit/verify` | 500/2000ms | Hash chain length |
+| `POST /v1/memories` | 50/200ms | Disk I/O bound |
+| `/v1/memories/search` | 100/500ms | Depends on index size |
+| `POST /v1/consultations` | 2-5s/10s | LLM network latency |
+| `/v1/consultations/audit/verify` | 500/2000ms | Hash chain length |
 
 ### Memory Per Query
 
@@ -682,6 +681,6 @@ Solution: Check disk usage: df -h
 
 ---
 
-**Last Updated**: 2026-04-26
-**Version**: v3.5-dev branch; latest tag v3.4.1
-**Status**: Production-ready for tagged releases; v3.5-dev remains unreleased
+**Last Updated**: 2026-04-28
+**Version**: v3.5.x; v3.5.1 documentation-triage patch
+**Status**: Production-ready for tagged releases

--- a/_version.py
+++ b/_version.py
@@ -11,4 +11,4 @@ without a re-install. A literal Python constant is what every runtime
 caller imports — no install-state coupling.
 """
 
-__version__ = "3.4.1"
+__version__ = "3.5.1"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,8 @@
 # Compression benchmarks
 
-Real-inference benchmarks of the v3.3 S-II compression stack
-(LETHE + ANAMNESIS + APOLLO, with optional judge-LLM and cross-
-encoder scorer). Purpose: answer the empirical question "is
+Real-inference benchmarks of the current compression stack
+(ARTEMIS + APOLLO, with optional judge-LLM and cross-encoder
+scorer). Purpose: answer the empirical question "is
 APOLLO effective, and under what conditions?" with enough data
 to be more than directional.
 
@@ -18,7 +18,7 @@ seven categories:
 | person | 8 | APOLLO PersonSchema (labeled + loose forms) |
 | event | 8 | APOLLO EventSchema (date + type) |
 | technical | 10 | APOLLO LLM fallback (prose) |
-| fact | 6 | APOLLO LLM fallback vs ANAMNESIS fact extraction |
+| fact | 6 | APOLLO LLM fallback vs ARTEMIS extractive compression |
 | short | 4 | min-content-length gate behavior |
 
 Hand-curated to give each engine's default-case a fair sample.
@@ -59,11 +59,11 @@ Report sections:
 - **Win distribution by category** — per-category winners so you
   can see "APOLLO wins portfolio but loses decision" patterns.
 - **Judge fidelity distribution** — per-engine mean/median/p5/p95.
-  A judge that's harsh on LETHE (p5 < 0.70 quality floor) is
+  A judge that's harsh on ARTEMIS (p5 < 0.70 quality floor) is
   what lets APOLLO's LLM-fallback wins materialize.
 - **Per-engine latency** — for Gemma-class models the floor is
-  ~3s for ANAMNESIS and ~1s for APOLLO fallback; LETHE schema-
-  path is microseconds.
+  roughly microseconds to milliseconds for ARTEMIS and APOLLO schema paths,
+  and ~1s+ for APOLLO fallback when it calls the GPU endpoint.
 - **APOLLO execution-path breakdown** — schema-matches by schema,
   fallback invocations, parse errors.
 - **Cross-judge correlation** (ensemble mode only) — Spearman +
@@ -81,7 +81,7 @@ Report sections:
   that its dense form is better for LLM-to-LLM wire use than
   prose. The benchmark measures whether the judge likes APOLLO's
   output; it does NOT measure whether a downstream LLM actually
-  performs better when fed APOLLO's dense form vs LETHE's extract.
+  performs better when fed APOLLO's dense form vs ARTEMIS's extract.
   That requires a separate task-based evaluation (retrieval QA,
   agent tool-use accuracy, etc.).
 - Real-corpus distribution. 50 hand-curated memories is enough to

--- a/docs/COMPRESSION.md
+++ b/docs/COMPRESSION.md
@@ -2,8 +2,8 @@
 
 Compression is opt-in and operator-batched through the admin endpoints:
 
-- `POST /v1/admin/compression/enqueue`
-- `POST /v1/admin/compression/enqueue-all`
+- `POST /admin/compression/enqueue`
+- `POST /admin/compression/enqueue-all`
 
 Memory creation does not auto-enqueue contest jobs. This is deliberate:
 compression is expensive work. It can involve LLM-judged contests and GPU

--- a/docs/DREAM_STATE_DESIGN.md
+++ b/docs/DREAM_STATE_DESIGN.md
@@ -1,6 +1,8 @@
 # MNEMOS Dream State — Design Scoping
 
-**Status**: Draft (v3.3 / v3.4 candidate)
+**Status**: Historical design draft. MORPHEUS shipped in v3.3/v3.5.x as an
+operator-triggered, append-only dream-state subsystem; mutation paths and the
+full dream-branch contract in this document remain forward-looking.
 **Owner**: Jason Perlow (`jperlow@gmail.com`)
 **Origin**: Dreamt up 2026-04-23, sprung from MEMORY_PSYCHOLOGY.md's Jungian framing:
 
@@ -104,7 +106,7 @@ becomes a private diary nobody reads.
 
 Therefore:
 
-- Dreams are **returned** by `POST /memories/search` and by the
+- Dreams are **returned** by `POST /v1/memories/search` and by the
   gateway's `_search_mnemos_context` inject path.
 - Dreams are **labeled** in the response envelope so the consuming
   agent can tell the register: this is speculative, generated, with
@@ -283,7 +285,7 @@ single-parent dreams this is trivially the seed's category. For
 multi-parent (octopus) dreams, the dream version row carries the
 **dominant** category (most common across seeds) in `category`, and
 the full set in `metadata.category_mix`. This keeps
-`GET /memories?category=X` working uniformly — it surfaces main-branch
+`GET /v1/memories?category=X` working uniformly — it surfaces main-branch
 facts plus any dream branches whose dream version row carries that
 category.
 
@@ -425,7 +427,7 @@ Mechanical implementation of §2 (surfaceability).
 ### 8.1 Search API
 
 ```
-POST /memories/search
+POST /v1/memories/search
 {
   "query": "...",
   "limit": 10,
@@ -495,7 +497,7 @@ The `search_memories` MCP tool gains a `dream_mode` parameter:
 ### 8.4 DAG endpoints
 
 The existing DAG endpoints (`/v1/memories/{id}/branches`,
-`/v1/memories/{id}/versions`, `/v1/versions/{id}`) gain a
+`/v1/memories/{id}/versions`, `/v1/memories/{id}/commits/{commit}`) gain a
 `kind='dream'` response field. "Show me the dream RFCs attached to
 memory M" is just `GET /v1/memories/M/branches?prefix=dream/` — no new
 endpoint.
@@ -639,7 +641,7 @@ in v3.4.
 - Dream worker + queue drain reusing `process_contest_queue` shape.
 - Seed strategies: `random`, `category_scoped`, `recent`. (No
   schema-aware `cluster_gap` yet — that needs APOLLO-typed seeds.)
-- Retrieval surfacing: `POST /memories/search` facts/dreams split.
+- Retrieval surfacing: `POST /v1/memories/search` facts/dreams split.
 - Manual promotion via merge commit (single-parent dreams only).
 - Manual trigger endpoint (`/admin/dreams/run`); no idle scheduler.
 - Prose-form seeds only *[provisional — replaced by APOLLO dense in

--- a/docs/GRAEAE_FEATURES.md
+++ b/docs/GRAEAE_FEATURES.md
@@ -1,448 +1,64 @@
-# GRAEAE: 16 Feature Implementation Complete
-
-## Overview
-All 16 features for MNEMOS and GRAEAE have been implemented with production-ready code, comprehensive tests, and documentation. This document covers the 6 GRAEAE features.
-
----
-
-## GRAEAE Features (6 Features)
-
-### Feature 1: Request Persistence & Resumability
-**Module**: `graeae/core/queue.py`
-
-Provides SQLite-backed persistent queue for crash-safe request handling and recovery.
-
-#### Key Capabilities:
-- **Persistent Queue**: All requests stored in SQLite, survives restarts
-- **Resumability**: Interrupted requests automatically retried
-- **Status Tracking**: PENDING → PROCESSING → COMPLETED/FAILED/RETRYING/ABANDONED
-- **Automatic Recovery**: Stuck processing requests detected and recovered
-- **Cleanup**: Old completed/abandoned requests automatically purged
-
-#### Usage:
-```python
-from graeae.core.queue import PersistentQueue
-
-queue = PersistentQueue(max_retries=3)
-
-# Enqueue request
-queue.enqueue(
-    request_id="req-123",
-    muse_id="claude-instant",
-    query="What is Python?",
-    metadata={"user_id": "u-456"}
-)
-
-# Dequeue for processing
-request = queue.dequeue()
-if request:
-    # Process request
-    result = process_muse(request)
-    
-    # Mark complete or retry
-    if success:
-        queue.mark_completed(request.request_id)
-    else:
-        queue.mark_failed(request.request_id, "error message")
-
-# Recovery
-queue.recover_stuck_requests(timeout_minutes=30)
-queue.cleanup_old_requests(days=30)
-
-# Status
-status = queue.get_queue_status()
-# {'pending': 5, 'processing': 2, 'completed': 100, ...}
-```
-
-#### Benefits:
-✅ Zero request loss during crashes
-✅ Automatic retry on temporary failures
-✅ Prevents duplicate processing
-✅ Audit trail via recovery_log table
-
----
-
-### Feature 2: Muse Failover & Circuit Breaker
-**Module**: `graeae/core/circuit_breaker.py`
-
-Prevents cascading failures by auto-disabling failing muses with 5-minute cooldown.
-
-#### Key Capabilities:
-- **Circuit States**: CLOSED (normal) → OPEN (disabled) → HALF_OPEN (testing)
-- **Failure Tracking**: Consecutive failures trigger circuit opening
-- **Auto-Recovery**: Muses transition to HALF_OPEN after cooldown
-- **Cascade Prevention**: Disabled muses excluded from routing
-- **Health Metrics**: Real-time metrics for all muses
-
-#### Usage:
-```python
-from graeae.core.circuit_breaker import CircuitBreakerPool
-
-pool = CircuitBreakerPool(
-    failure_threshold=5,
-    cooldown_minutes=5
-)
-
-# Check availability before routing
-if pool.is_muse_available("gpt-4"):
-    result = query_muse("gpt-4", query)
-    pool.record_success("gpt-4")
-else:
-    # Try fallback
-    result = query_fallback(query)
-
-# On failure
-on_error = lambda e: pool.record_failure("gpt-4", str(e))
-
-# Filter available muses
-all_muses = ["gpt-4", "claude", "palm"]
-available = pool.get_available_muses(all_muses)
-# May return: ["claude", "palm"] if gpt-4 circuit open
-
-# Health dashboard
-health = pool.health_report()
-# {
-#   'total_muses': 3,
-#   'healthy': 2,
-#   'disabled': 1,
-#   'availability_pct': 66.7,
-#   'failure_rate': 12.3
-# }
-```
-
-#### States Explained:
-- **CLOSED**: Normal operation, requests routed normally
-- **OPEN**: Circuit tripped, muse disabled for cooldown period
-- **HALF_OPEN**: Testing recovery, some requests allowed
-- **Transitions**: 
-  - CLOSED → OPEN (failure threshold reached)
-  - OPEN → HALF_OPEN (cooldown expired)
-  - HALF_OPEN → CLOSED (success threshold reached)
-
-#### Benefits:
-✅ Prevents thundering herd on failing services
-✅ Automatic fallback to healthy muses
-✅ Quick recovery when services stabilize
-✅ Observable failure patterns
-
----
-
-### Feature 3: Response Quality Scoring
-**Module**: `graeae/core/quality_scorer.py`
-
-Automated QA metrics for relevance, coherence, toxicity per-muse.
-
-#### Key Capabilities:
-- **Multi-Metric Scoring**: Relevance, coherence, toxicity, completeness
-- **Per-Muse Tracking**: Individual metrics for each muse
-- **User Feedback Integration**: Incorporate user ratings
-- **Best Muse Ranking**: Identify top performers
-- **Quality Aggregates**: 7-day rolling averages
-
-#### Usage:
-```python
-from graeae.core.quality_scorer import ResponseQualityScorer, QualityScore
-
-scorer = ResponseQualityScorer()
-
-# Compute quality
-score = scorer.compute_quality(
-    query="What is machine learning?",
-    response="ML is a subset of AI where systems learn from data",
-    query_embedding=query_emb,  # Optional
-    response_embedding=response_emb  # Optional
-)
-# Returns: QualityScore(
-#   relevance=0.92,
-#   coherence=0.88,
-#   toxicity=0.01,
-#   completeness=0.85
-# )
-
-# Record quality score
-scorer.record_score(
-    muse_id="claude-instant",
-    request_id="req-123",
-    query="What is ML?",
-    response="ML is...",
-    score=score,
-    user_feedback=0.95  # User rated 95%
-)
-
-# Get muse metrics
-metrics = scorer.get_muse_metrics("claude-instant")
-# {
-#   'avg_relevance': 0.89,
-#   'avg_coherence': 0.86,
-#   'avg_toxicity': 0.02,
-#   'avg_overall': 0.87,
-#   'response_count': 1523
-# }
-
-# Rank best muses
-top_muses = scorer.get_best_muses(count=5, min_samples=100)
-# Returns top 5 muses with 100+ samples
-```
-
-#### Metrics:
-- **Relevance** (0-1): How well response answers query
-  - Uses keyword matching + embedding similarity
-- **Coherence** (0-1): Logical flow and structure
-  - Sentence count, length, vocabulary diversity
-- **Toxicity** (0-1): Harmful/offensive language
-  - Keyword detection + caps ratio analysis
-- **Completeness** (0-1): Fully addresses query
-  - Response length + conclusion phrases
-- **Overall**: Weighted combination (35% relevance, 35% coherence, 20% anti-toxicity, 10% completeness)
-
-#### Benefits:
-✅ Objective quality measurement
-✅ Identify best-performing muses automatically
-✅ Detect quality regressions
-✅ Support A/B testing with quality metrics
-
----
-
-### Feature 4: Semantic Caching Layer
-**Module**: `graeae/core/semantic_cache.py`
-
-Embeddings-based similarity matching beyond exact-match, 24-hour window.
-
-#### Key Capabilities:
-- **Semantic Matching**: Similar queries hit cache via embeddings
-- **Similarity Threshold**: Configurable (default 0.85)
-- **24-Hour TTL**: Automatic expiration
-- **Hit Tracking**: Metrics on cache effectiveness
-- **Per-Muse Caching**: Separate caches for each muse
-
-#### Usage:
-```python
-from graeae.core.semantic_cache import SemanticCache
-
-cache = SemanticCache(ttl_hours=24)
-
-# Try to get from cache
-cached_response = cache.get(
-    query="What is Python programming?",
-    query_embedding=query_emb,
-    muse_id="gpt-4",
-    similarity_threshold=0.85
-)
-
-if cached_response:
-    # Cache hit! Return immediately
-    return cached_response
-else:
-    # Cache miss, query muse
-    response = query_muse("gpt-4", query)
-    
-    # Store for future use
-    cache.put(
-        query="What is Python programming?",
-        response=response,
-        query_embedding=query_emb,
-        muse_id="gpt-4",
-        response_embedding=response_emb  # Optional
-    )
-
-# Maintenance
-cache.cleanup_expired()  # Remove expired entries
-
-# Stats
-stats = cache.get_stats()
-# {
-#   'total_entries': 5432,
-#   'valid_entries': 4100,
-#   'expired_entries': 1332,
-#   'total_hits': 23451
-# }
-```
-
-#### Benefits:
-✅ Dramatically faster response times for similar queries
-✅ Reduced load on muses
-✅ Cost savings by avoiding duplicate processing
-✅ Better user experience
-
----
-
-### Feature 5: Rate Limiting & Backpressure
-**Module**: `graeae/core/rate_limiter.py`
-
-Per-muse limits, queue backpressure, graceful degradation.
-
-#### Key Capabilities:
-- **Per-Muse Limits**: Individual RPM limits per muse
-- **Exponential Backoff**: Adaptive rate limiting
-- **Queue Backpressure**: Monitors queue depth
-- **Graceful Degradation**: Reduces quality when queue full
-- **Burst Support**: Allow temporary spikes
-
-#### Usage:
-```python
-from graeae.core.rate_limiter import RateLimiterPool, QueueBackpressure
-
-# Rate limiting per muse
-limiter_pool = RateLimiterPool()
-
-for query in incoming_queries:
-    if limiter_pool.is_allowed("gpt-4"):
-        result = query_muse("gpt-4", query)
-        limiter_pool.record_request("gpt-4")
-    else:
-        # Queue or reject
-        queue_request(query)
-
-# Check metrics
-metrics = limiter_pool.get_all_metrics()
-# {
-#   'gpt-4': {
-#     'requests_in_window': 45,
-#     'limit_per_minute': 60,
-#     'backoff_active': False
-#   }
-# }
-
-# Queue backpressure
-backpressure = QueueBackpressure(max_queue_size=10000)
-
-# Monitor queue
-queue_size = get_queue_depth()
-backpressure.update_queue_depth(queue_size)
-
-# Route based on backpressure
-if backpressure.should_accept_request('normal'):
-    queue_for_processing(query)
-elif backpressure.should_accept_request('cache'):
-    return_from_cache_if_available(query)
-else:
-    reject_request("System overloaded")
-
-# Get recommended batch size
-batch_size = backpressure.get_batch_size(default=100)
-```
-
-#### Backpressure Levels:
-- **Level 0** (0-50% queue): Normal operation
-- **Level 1** (50-75% queue): Prefer cache results
-- **Level 2** (75-90% queue): Reject non-essential, reduce batch size
-- **Level 3** (90%+ queue): Cache-only, reject new requests
-
-#### Benefits:
-✅ Prevents API rate limit violations
-✅ Automatic queue management
-✅ Graceful degradation under load
-✅ Fair distribution across muses
-
----
-
-### Feature 6: Audit Logging & Compliance
-**Module**: `shared/audit.py`
-
-Immutable audit trail for GDPR compliance, 90-day retention.
-
-#### Key Capabilities:
-- **Immutable Trail**: Hash-chained entries prevent tampering
-- **Cryptographic Integrity**: SHA-256 checksums
-- **GDPR Support**: Data deletion and retention policies
-- **90-Day Retention**: Automatic cleanup
-- **Detailed Audit**: who/when/what/result tracking
-
-#### Usage:
-```python
-from shared.audit import AuditLog
-
-audit = AuditLog(db_config=PG_CONFIG, retention_days=90)
-
-# Log action
-audit_id = audit.log_action(
-    action="create",
-    resource_type="memory",
-    resource_id="mem-123",
-    user_id="user-456",
-    request_id="req-789",
-    status="success",
-    details={'content': 'User memory', 'size': 512},
-    result_summary="Memory created successfully"
-)
-
-# Get audit trail
-trail = audit.get_audit_trail(
-    resource_type="memory",
-    resource_id="mem-123",
-    days=7,
-    limit=100
-)
-
-# Verify integrity (detects tampering)
-is_valid = audit.verify_integrity()
-if not is_valid:
-    alert("Audit trail may have been tampered with!")
-
-# Cleanup old entries (90-day retention)
-deleted = audit.cleanup_old_entries()
-
-# Audit trail structure:
-# {
-#   'id': 12345,
-#   'timestamp': '2026-02-18T22:45:00',
-#   'user_id': 'user-456',
-#   'action': 'create',
-#   'resource': 'memory:mem-123',
-#   'status': 'success',
-#   'details': {...},
-#   'checksum': 'abc123def456...'
-# }
-```
-
-#### Hash Chain:
-Each audit entry includes:
-- **checksum**: SHA-256 of current entry + previous hash
-- **previous_hash**: Chain pointer to previous entry
-
-If anyone modifies an entry, the checksum becomes invalid and the chain breaks—**tampering is instantly detectable**.
-
-#### Compliance:
-- ✅ GDPR: Audit trails prove data handling
-- ✅ SOC2: Immutable audit for compliance
-- ✅ Retention: 90-day automatic purge
-- ✅ Integrity: Cryptographic protection
-
-#### Benefits:
-✅ Prove compliance to regulators
-✅ Detect security incidents
-✅ Accountability for all actions
-✅ Legal protection
-
----
-
-## Cross-System Implementation Notes
-
-### Database Setup
-All GRAEAE features use SQLite (queue, cache, metrics, limits) for portability. No PostgreSQL required for new features.
-
-### Backward Compatibility
-- All changes are **additive**, no breaking changes
-- Existing APIs unchanged
-- Features opt-in via environment variables:
-  - `GRAEAE_QUEUE_DB`: Enable request persistence
-  - `GRAEAE_CACHE_DB`: Enable semantic caching
-  - `OTEL_ENABLED`: Enable tracing
-
-### Performance Overhead
-- Queue: <1ms per operation
-- Circuit breaker: <0.1ms
-- Quality scoring: ~10-20ms (depends on embeddings)
-- Semantic cache: <5ms lookup
-- Rate limiting: <0.1ms
-- **Total**: Minimal impact on latency
-
-### Testing
-See `tests/test_graeae_features.py` for 40+ comprehensive test cases.
-
----
-
-## Next Steps: MNEMOS Features
-6 MNEMOS features implementing memory management, deduplication, importance scoring, backups, knowledge graphs, and privacy policies.
-
-See `MNEMOS_FEATURES.md` for details.
+# GRAEAE Feature Surface
+
+**Status:** current v3.5.x documentation. v3.5.0 shipped on 2026-04-28;
+v3.5.1 is the documentation-triage patch.
+
+GRAEAE is MNEMOS's multi-provider reasoning bus. It fans a prompt out to live
+LLM providers, scores the responses, persists consultations, and writes a
+hash-chained audit record for each committed consultation.
+
+## Runtime Modules
+
+| Capability | Current module | Notes |
+|---|---|---|
+| Provider routing | `graeae/engine.py` | Config-driven providers with OpenAI-compatible, Anthropic, and Gemini adapter paths. |
+| Circuit breaking | `graeae/_circuit_breaker.py` | Per-provider CLOSED / OPEN / HALF_OPEN guard; process-local. |
+| Rate limiting | `graeae/_rate_limiter.py` | Sliding-window requests-per-minute guard; process-local. |
+| Concurrency limiting | `graeae/_concurrency.py` | Per-provider async slot limiter; skips saturated providers instead of queueing them. |
+| Quality weighting | `graeae/_quality.py` | Rolling success-rate and latency tracker used to adjust provider weights. |
+| Response cache | `graeae/_cache.py` | In-memory normalized prompt cache with TTL; not a persistent semantic cache. |
+| Model registry sync | `graeae/provider_sync.py`, `graeae/elo_sync.py`, `scripts/sync_provider_models.py` | Provider model discovery plus Arena.ai/LMArena weighting when the sync job is installed. |
+
+The reliability state above is intentionally process-local in v3.5.x. MNEMOS
+therefore remains pinned to one API worker for production correctness; moving
+these guards to shared/external coordination is future horizontal-scaling work.
+
+## API Surface
+
+- `POST /v1/consultations` — run a consultation and persist the consensus,
+  provider responses, cost, latency, and optional memory references.
+- `GET /v1/consultations/{id}` — retrieve one consultation visible to the
+  caller.
+- `GET /v1/consultations/{id}/artifacts` — retrieve stored request/response
+  artifacts for one consultation.
+- `GET /v1/consultations/audit` — list GRAEAE audit rows; non-root callers are
+  scoped to their own consultation rows, root can inspect globally.
+- `GET /v1/consultations/audit/verify` — verify the visible hash chain. Root
+  verifies the full global chain; non-root verifies the caller-scoped view.
+- `GET /v1/consultations/muses` and `GET /v1/consultations/modes` — expose the
+  configured reasoning options.
+- `GET /v1/providers`, `GET /v1/providers/health`, and
+  `GET /v1/providers/recommend` — provider inventory, status, and cost-aware
+  recommendation.
+
+OpenAI-compatible access is separate but uses the same routing engine:
+`POST /v1/chat/completions`, `GET /v1/models`, and `GET /v1/models/{model_id}`.
+In v3.5.x, generation controls propagate when the selected provider supports
+them; unsupported tools, response formats, and multimodal requests are rejected
+instead of silently ignored.
+
+## Audit Model
+
+Committed consultations write three related records in one transaction:
+
+- `graeae_consultations` — prompt, consensus, cost, latency, owner, namespace,
+  and audit metadata columns.
+- `graeae_audit_log` — hash-chain entry with `prev_hash` and `chain_hash`.
+- `consultation_memory_refs` — memories injected or referenced by the
+  consultation, when applicable.
+
+If the audit write fails, consultation persistence fails too. This is the
+current compliance boundary for GRAEAE. MNEMOS does not have one generic
+`audit_log` table for every memory operation in v3.5.x; memory integrity is
+tracked through the version DAG, webhook delivery rows, compression contest
+records, and subsystem-specific audit tables.

--- a/docs/KNOSSOS.md
+++ b/docs/KNOSSOS.md
@@ -28,8 +28,9 @@ is yours alone; it becomes a wall when a team needs:
   tooling
 - **Federation** — pull memories across MNEMOS instances with
   provenance intact
-- **Audit + compliance** — signed audit chain on every memory
-  mutation
+- **Audit + compliance** — version DAG snapshots for memory changes,
+  hash-chained GRAEAE consultation audit rows, and webhook/compression
+  audit records where those subsystems participate
 
 MNEMOS has all of these in its core. KNOSSOS is the glue that lets a
 team adopt them without changing how their agents talk to memory.
@@ -73,18 +74,18 @@ the MemPalace tool-response shape.
 
 ## What you gain by moving
 
-| Capability | MemPalace 3.3.x | MNEMOS 3.2.x via KNOSSOS |
+| Capability | MemPalace 3.3.x | MNEMOS v3.5.x via KNOSSOS |
 |---|---|---|
 | Multi-user memory | ❌ | ✅ — `owner_id`, `group_id`, `permission_mode` |
 | HTTP API | ❌ | ✅ — `/v1/memories/*`, `/v1/kg/*`, `/v1/export`, `/v1/import` |
 | Bulk ingest speed | ~2 memories/sec (local, one-at-a-time) | ~200 memories/sec via `/v1/import` (MPF envelope, batched) |
 | Cross-instance portability | ❌ (no native export) | ✅ — Memory Portability Format (MPF) round-trip |
 | Version DAG (diff/revert/branch) | ❌ | ✅ — memory_versions table + commit_hash |
-| Audit chain | ❌ | ✅ — every mutation hashed, verifiable |
+| Version/audit trail | ❌ | ✅ — memory DAG snapshots, consultation hash chain, webhook/compression audit rows |
 | Compression (APOLLO/ARTEMIS contest) | AAAK only (~30× on a subset) | Full contest — APOLLO schema + ARTEMIS extractive, judge-scored |
 | Federation across instances | ❌ | ✅ — `/v1/federation/*`, pull-based |
 | Knowledge graph (temporal) | ✅ — SQLite-backed | ✅ — Postgres-backed, same temporal semantics |
-| MCP surface | 29 native tools | 29 via KNOSSOS + MNEMOS-native MCP tools |
+| MCP surface | 29 native tools | 16 MemPalace-compatible phase-1 tools via KNOSSOS, plus the native 18-tool MNEMOS MCP surface |
 | Retrieval benchmark R@5 (LongMemEval) | 96.6% raw / 98.4% hybrid | (see `benchmarks/compression_corpus_v3_3.jsonl`) |
 
 MemPalace is not wrong for its use case. KNOSSOS exists for the
@@ -98,7 +99,7 @@ moment your use case grew out of it.
 
 Point MNEMOS at your team's datastore (Postgres + optional phi-server
 for embeddings). Canonical quickstart: `docker-compose up` against
-the MNEMOS repo root. Full deployment notes in [DEPLOYMENT_GUIDE.md](./DEPLOYMENT_GUIDE.md).
+the MNEMOS repo root. Full deployment notes are in [DEPLOYMENT.md](../DEPLOYMENT.md).
 
 ### 2. Point KNOSSOS at it
 
@@ -106,7 +107,6 @@ the MNEMOS repo root. Full deployment notes in [DEPLOYMENT_GUIDE.md](./DEPLOYMEN
 export MNEMOS_BASE=http://mnemos.internal:5002
 export MNEMOS_API_KEY=$TEAM_API_KEY           # bearer token, issued per user
 export KNOSSOS_WING_AXIS=namespace             # default; 'owner_id' is also accepted
-                                               # (MNEMOS /v1/memories/search only scopes by namespace today)
 
 python -m tools.knossos_mcp                   # stdio MCP server
 ```
@@ -139,7 +139,7 @@ drawer IDs and metadata are kept.
 
 ## Tool coverage (v0.1)
 
-Implemented:
+Implemented in the current phase-1 shim:
 
 - `mempalace_status`
 - `mempalace_list_wings`
@@ -158,7 +158,7 @@ Implemented:
 - `mempalace_kg_timeline`
 - `mempalace_kg_stats`
 
-Phase 2 (issue-tracked):
+Deferred phase-2 surface:
 
 - `mempalace_create_tunnel` / `mempalace_list_tunnels` /
   `mempalace_delete_tunnel` / `mempalace_find_tunnels` /
@@ -197,7 +197,7 @@ Phase 2 (issue-tracked):
 KNOSSOS is one spoke; CHARON is the hub. KNOSSOS translates the
 MemPalace MCP tool surface. CHARON handles bulk import/export via
 MPF envelopes (`tools/memory_import.py`, `tools/memory_export.py`,
-`docs/mpf_v0.1.json`). A full MemPalace → MNEMOS migration uses both:
+`docs/MEMORY_EXPORT_FORMAT.md`). A full MemPalace → MNEMOS migration uses both:
 
 1. CHARON one-time bulk import of the existing palace (via
    `tools.knossos_mcp migrate --from-palace`).

--- a/docs/MEMORY_EXPORT_FORMAT.md
+++ b/docs/MEMORY_EXPORT_FORMAT.md
@@ -120,7 +120,7 @@ know about. This is deliberate forward/backward compatibility.
 {
   "mpf_version": "0.1.0",
   "source_system": "mnemos",
-  "source_version": "3.1.0",
+  "source_version": "3.5.1",
   "source_instance": "pythia.internal",         // optional diagnostic
   "source_commit": "1838507",                   // optional diagnostic
   "exported_at": "2026-04-23T15:00:00Z",
@@ -221,7 +221,7 @@ know about. This is deliberate forward/backward compatibility.
   "compression_manifest": [                      // record-ID-keyed
     {
       "record_id": "mem_01JAB2",
-      "engine_id": "anamnesis",
+      "engine_id": "apollo",
       "compressed_content": "<condensed form>",
       "compression_ratio": 0.28,
       "composite_score": 0.61,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -41,7 +41,7 @@ What this doc does NOT cover:
                      /         \
                     /           \
               PYTHIA (.67)    CERBERUS (.96)
-              v3.4.1 prod     dark prod / GPU host
+              v3.5.x prod     dark prod / GPU host
               pg17 primary    standby + inference
               11,756 memories + Apollo Gemma 4 (ports 8080/8081)
               5,045 compressions
@@ -64,14 +64,14 @@ What this doc does NOT cover:
 
 | Host | IP | OS | CPU | RAM | GPU | Role | MNEMOS version | Status |
 |---|---|---|---|---|---|---|---|---|
-| **PYTHIA** | 192.168.207.67 | Ubuntu 22.04 | 12-core | 30GB | — | Primary (prod) + GRAEAE + CNXN | v3.4.1 tag | ✅ Operational |
-| **CERBERUS** | 192.168.207.96 | Debian 12 | 24-core (Threadripper) | 125GB | RTX 4500 ADA 24GB | Secondary/dark prod + Apollo GPU inference | v3.4.x family | ✅ Operational |
-| **PROTEUS** | 192.168.207.25 | Debian 12 | Intel i7-6700 | 60GB | — | Staging + restore-drill target | latest cut / v3.5-dev during branch work | ✅ Used for drills |
+| **PYTHIA** | 192.168.207.67 | Ubuntu 22.04 | 12-core | 30GB | — | Primary (prod) + GRAEAE + CNXN | v3.5.x stable target | ✅ Operational |
+| **CERBERUS** | 192.168.207.96 | Debian 12 | 24-core (Threadripper) | 125GB | RTX 4500 ADA 24GB | Secondary/dark prod + Apollo GPU inference | v3.5.x stable target | ✅ Operational |
+| **PROTEUS** | 192.168.207.25 | Debian 12 | Intel i7-6700 | 60GB | — | Staging + restore-drill target | latest cut / release drills | ✅ Used for drills |
 | **ARGONAS** | 192.168.207.101 | TrueNAS | — | — | — | NFS + git origin (planned: LB) | nginx 1.26 (TrueNAS UI proxy only) | ✅ Running |
 
 ### 2.3 Network & authentication
 
-> **⚠️ Current-state caveat (verified 2026-04-26):** The nginx running on ARGONAS today is the TrueNAS web UI proxy, **NOT** a MNEMOS HTTP load balancer. All `proxy_pass` entries route to `127.0.0.1:6000` (TrueNAS middleware). There is **no HTTP LB in front of MNEMOS today** — clients hit PYTHIA at `192.168.207.67:5002` directly. CERBERUS `:5003` is currently *dark prod* (running but not externally routed). Standing up a real LB on ARGONAS (or elsewhere) is a **v3.5 prerequisite** for the blue-green deploy pattern below to function. Until that's done, "drain a node" means "stop sending it traffic from clients you control" — there's no upstream pool to manipulate.
+> **Current-state caveat (verified 2026-04-26):** The nginx running on ARGONAS today is the TrueNAS web UI proxy, **NOT** a MNEMOS HTTP load balancer. All `proxy_pass` entries route to `127.0.0.1:6000` (TrueNAS middleware). There is **no HTTP LB in front of MNEMOS today** — clients hit PYTHIA at `192.168.207.67:5002` directly. CERBERUS `:5003` is currently *dark prod* (running but not externally routed). Standing up a real LB on ARGONAS (or elsewhere) is a **production rollout prerequisite** for the blue-green deploy pattern below to function. Until that's done, "drain a node" means "stop sending it traffic from clients you control" — there's no upstream pool to manipulate.
 
 - **External (planned):** ARGONAS nginx LB listens on :80 (http) and :443 (https); backends are PYTHIA + CERBERUS on private :5002 + :5003. Status: NOT YET CONFIGURED.
 - **External (today):** Clients hit PYTHIA `192.168.207.67:5002` directly. No fronting LB.
@@ -88,8 +88,8 @@ Production MNEMOS runs on a **canary + ratchet** model: new features bake in sta
 
 | Tier | Host(s) | Version target | Stability | Deployment source |
 |---|---|---|---|---|
-| **Prod** | PYTHIA + CERBERUS | *latest stable* (v3.4.1 tag) | GA, no alpha/beta | git tag, N+1 weeks after staging bake |
-| **Staging** | PROTEUS | *latest cut* (`v3.5-dev` while in flight) | alpha/rc, real federation | release branch, merged + tagged |
+| **Prod** | PYTHIA + CERBERUS | *latest stable* (v3.5.x) | GA, no alpha/beta | git tag, N+1 weeks after staging bake |
+| **Staging** | PROTEUS | *latest cut* / next release branch | alpha/rc, real federation | release branch, merged + tagged |
 | **Test** | docker-compose + mnemos-test-pg on CERBERUS | *feature branches* | ephemeral, parallel | PR builds via CI, cleaned up post-merge |
 
 **Promotion path:**
@@ -389,7 +389,7 @@ pg_dump -U postgres mnemos | gzip > \
 
 ### 6.3 Restore procedure (quarterly drill)
 
-**Status:** Dev↔prod MPF restore drill documented and run for v3.4.1.
+**Status:** Dev↔prod MPF restore drill documented and last run for v3.4.1; repeat before high-risk v3.5.x schema work.
 Repeat quarterly and before high-risk schema work.
 
 To restore from backup to PROTEUS (test/staging host):
@@ -461,12 +461,9 @@ Response (JSON):
 ```json
 {
   "status": "healthy",
-  "version": "v3.4.1",
-  "uptime_seconds": 345600,
-  "database": "connected",
-  "replication_lag_seconds": 0.5,
-  "memory_count": 11756,
-  "compression_count": 5045
+  "version": "3.5.1",
+  "database_connected": true,
+  "distillation_worker": "healthy"
 }
 ```
 
@@ -477,9 +474,9 @@ Response (JSON):
 Simple dashboard (Grafana or custom HTML) that queries each node's `/health` and shows:
 
 ```
-PYTHIA:   v3.4.1        (uptime: 45d 3h)
-CERBERUS: v3.4.x        (dark prod / GPU host)
-PROTEUS:  v3.5-dev      (staging cut)
+PYTHIA:   3.5.1         (prod target)
+CERBERUS: 3.5.1         (dark prod / GPU host)
+PROTEUS:  next cut      (staging / restore-drill target)
 ```
 
 Update frequency: 5 minutes (sufficient for drift detection).
@@ -589,9 +586,9 @@ Implement `scripts/ops/version_check.sh` (to be written, v3.5 target):
 #!/bin/bash
 # Check each node's version vs. declared target
 
-PYTHIA_DECLARED="v3.4.1"
-CERBERUS_DECLARED="v3.4.1"
-PROTEUS_DECLARED="v3.5-dev"
+PYTHIA_DECLARED="3.5.1"
+CERBERUS_DECLARED="3.5.1"
+PROTEUS_DECLARED="next-cut"
 
 PYTHIA_ACTUAL=$(curl -s -H "Authorization: Bearer $TOKEN" \
   http://192.168.207.67:5002/health | jq -r .version)
@@ -655,14 +652,14 @@ See `~/.claude/rules/github-behavior.md` for full rate-limit rules and the ratio
 
 ## 11. Federation health
 
-### 11.1 Architecture (v3.5-dev current)
+### 11.1 Architecture (v3.5.x current)
 
 Federation (peer-to-peer memory sync) is specified in `api/handlers/federation.py:280-390`. Key points:
 
 - Each MNEMOS node maintains a `federation_peers` table (schema in `db/migrations_v3_federation.sql`)
 - Sync is **pull-based:** node A asks node B for updates since the last sync point
-- Cursor-based pagination (not full-dump on every sync)
-- **Status as of 2026-04-26:** Schema-compat preflight and restore drills validated against PROTEUS; peer heartbeat and per-peer ACL/stable cursor remain open v3.5 items.
+- Compound-cursor pagination over `(updated, id)` (not full-dump on every sync)
+- **Status as of 2026-04-28:** Schema-compat preflight, restore drills, and the stable compound cursor are validated. Peer heartbeat and per-peer ACL remain future work.
 
 ### 11.2 What happens when a peer is unreachable
 
@@ -724,7 +721,7 @@ Use this checklist before **any** deployment, upgrade, or migration on PYTHIA or
 - [ ] **Rollback path documented:** Write down exact git sha/tag to revert to
   ```bash
   # Save for rollback:
-  ROLLBACK_TAG=v3.4.1
+  ROLLBACK_TAG=v3.5.0
   ```
 
 - [ ] **Migration path selected:** For Docker existing volumes, confirm

--- a/docs/PANTHEON.md
+++ b/docs/PANTHEON.md
@@ -24,8 +24,8 @@ Every existing tool keeps working — PANTHEON is OpenAI-shape. The win is the c
 
 ## CHARON v0.2 contract note (related work)
 
-The CHARON v0.2 portability subsystem (which ships with this v4
-cut) restricts the trigger-suppressed `memory_versions` sidecar
+The CHARON v0.2 portability subsystem (shipped in the v3.4 line and available
+to later PANTHEON work) restricts the trigger-suppressed `memory_versions` sidecar
 import path to the **root + preserve_owner=true** admin/migration
 path. Non-root callers can ship `kg_triples` and
 `compression_manifest` sidecars without restriction, but

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -106,12 +106,11 @@ the imported records to avoid bidirectional pollution (e.g. the target
 later acts as a federation source for another node and re-emits the
 test data as native).
 
-**⚠️ Schema gotcha**: `memory_versions` and `memory_branches` still
-lack a FK cascade to `memories`. v3.5 slice 2 added same-memory branch
-HEAD guards, but it did not change restore cleanup semantics; the
-deletion-log refactor is parked as task #15. Until that changes, the
-cleanup needs three explicit DELETEs in dependency order, plus an
-orphan sweep:
+**Schema gotcha**: `memory_versions` and `memory_branches` still lack a FK
+cascade to `memories`. v3.5.0 added same-memory branch HEAD guards and DELETE
+tombstone snapshots, but it did not add a dedicated deletion-log/GDPR wipe
+subsystem or change restore cleanup semantics. Cleanup still needs explicit
+DELETEs in dependency order, plus an orphan sweep:
 
 ```sql
 BEGIN;

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,7 +1,7 @@
 # MNEMOS Specification
 
-**Version**: v3.5-dev branch (unreleased; latest tag v3.4.1)
-**Status**: Authoritative for the checked-out branch. Behavior not
+**Version**: v3.5.x current; v3.5.0 shipped 2026-04-28, v3.5.1 is the 2026-04-28 documentation-triage patch
+**Status**: Authoritative for the checked-out v3.5.x tree. Behavior not
 described here is either undefined (report as a bug) or scoped to a
 future release via `ROADMAP.md`.
 **Purpose**: supply enough structural detail that a scoping tool
@@ -40,7 +40,7 @@ been externalized.
 
 ## 2. System Scope
 
-### 2.1 In scope at v3.5-dev
+### 2.1 In scope at v3.5.x
 
 - **Memory**: CRUD, search (FTS + pgvector), DAG versioning with
   branch/merge, knowledge-graph triples, categories + namespaces,
@@ -54,33 +54,43 @@ been externalized.
   compressed memory context injection, propagated generation controls,
   SSE streaming, and explicit pass-or-400 handling for provider-specific
   tool/format/multimodal support.
-- **Sessions**: multi-turn conversation state with per-tier memory
-  injection.
+- **Sessions**: multi-turn conversation state with memory injection at turn
+  boundaries. Legacy session compression columns were removed in v3.5.
 - **Tenancy**: per-user `owner_id` + `namespace` two-axis gate; root
   role bypasses both. Live memory reads use owner/federation/world/group
   visibility; version and DAG history use per-snapshot visibility.
 - **Auth**: Bearer API keys (`/admin/users/{id}/apikeys`), OAuth /
   OIDC browser login (authlib), RLS-capable schema.
 - **Federation**: pull-based cross-instance sync with Bearer-auth
-  peers, per-memory opt-in, loop-prevention via `federation_source`.
-- **Webhooks**: SSRF-hardened outbound delivery with HMAC signing.
+  peers, schema-compat preflight, compound feed cursor, per-memory opt-in,
+  and loop-prevention via `federation_source`.
+- **Webhooks**: SSRF-hardened outbound delivery with HMAC signing, persisted
+  leases, retry-chain convergence, and terminal-success database guard.
 - **Portability**: MPF v0.1.x export + import with sidecars, Docling-based document
   ingest (optional extra).
 - **Observability**: request-ID ContextVar, Prometheus `/metrics`,
   OpenTelemetry spans (opt-in), structured JSON logs (opt-in).
-- **Two-protocol surface**: REST over HTTP (101 route declarations in
-  the current handlers) + MCP
-  stdio server (13 tools).
+- **MORPHEUS**: operator-triggered dream-state runs with REPLAY / CLUSTER /
+  SYNTHESISE / COMMIT phases, cluster introspection, namespace scoping, and
+  rollback by `morpheus_run_id`.
+- **Recall tracking**: search hits increment `recall_count` and stamp
+  `last_recalled_at` asynchronously.
+- **Two-protocol surface**: REST over HTTP (102 mounted application routes,
+  excluding FastAPI's generated docs/openapi routes) + MCP over stdio and
+  HTTP/SSE from one registry (18 tools).
 
-### 2.2 Explicitly out of scope at v3.5-dev
+### 2.2 Explicitly out of scope at v3.5.x
 
 - Horizontal scaling past `workers=1`. GRAEAE reliability primitives
   (circuit breakers, rate limiters, concurrency guards) are
   process-local singletons; shared-state refactor remains future work.
-- Webhook retry state machine (#20), bulk webhook parity (#19), audit
-  endpoint scoping/lifespan teardown (#22), federation per-peer ACL +
-  stable cursor (#21), entity namespace conflict-key migration (#23),
-  and deletion-log refactor (#15).
+- Full per-memory deletion-log / GDPR wipe subsystem. v3.5 keeps DELETE
+  tombstone snapshots live in the version DAG, but it does not add a separate
+  deletion-log table.
+- Federation per-peer ACL beyond the current peer credentials, namespace
+  filters, category filters, and feed role gate.
+- PERSEPHONE archival and MORPHEUS mutation paths (consolidate / archive /
+  extract). These remain v3.6+ work.
 - SQLite backend. Current backend is Postgres-only; SQLite +
   sqlite-vec for embedded tier is v4/lite-profile work.
 
@@ -128,7 +138,7 @@ semaphore. Reliability primitives are process-local; see §7.
 | ID | REST router | DB tables | Role |
 |----|-------------|-----------|------|
 | openai_compat | `api/handlers/openai_compat.py` | (reads `model_registry`, writes `session_messages`) | OpenAI-compatible `/v1/chat/completions` + registry-honest `/v1/models` with compression-aware memory injection, SSE streaming, and provider capability validation |
-| sessions     | `api/handlers/sessions.py`     | `sessions`, `session_messages`, `session_memory_injections` | Multi-turn conversation state, per-tier memory injection |
+| sessions     | `api/handlers/sessions.py`     | `sessions`, `session_messages`, `session_memory_injections` | Multi-turn conversation state, owner+namespace scoped, memory injection at turn boundaries |
 | health       | `api/handlers/health.py`       | (reads `memory_stats`) | Liveness + readiness + statistics |
 
 ### 3.4 Tenancy + auth (4 subsystems)
@@ -144,8 +154,8 @@ semaphore. Reliability primitives are process-local; see §7.
 
 | ID | REST router | DB tables | Role |
 |----|-------------|-----------|------|
-| federation | `api/handlers/federation.py` | `federation_peers`, `federation_sync_log` | Pull-based cross-instance memory sync; `owner_id='federation'` sentinel + `federation_source` loop guard |
-| webhooks   | `api/handlers/webhooks.py`   | `webhook_subscriptions`, `webhook_deliveries` | Outbound delivery with SSRF-hardened URL allowlist, HMAC signing, retry queue |
+| federation | `api/handlers/federation.py` | `federation_peers`, `federation_sync_log` | Pull-based cross-instance memory sync; schema preflight; compound cursor; `owner_id='federation'` sentinel + `federation_source` loop guard |
+| webhooks   | `api/handlers/webhooks.py`   | `webhook_subscriptions`, `webhook_deliveries` | Outbound delivery with SSRF-hardened URL allowlist, HMAC signing, persisted leases, repair/recovery workers, retry-chain guards |
 
 ### 3.6 Portability (3 subsystems)
 
@@ -173,7 +183,7 @@ Tracing → Prometheus → BodySizeLimit → handler.
 | ID | Module | Role |
 |----|--------|------|
 | distillation_worker | `distillation_worker.py` | Drains `memory_compression_queue` via `process_contest_queue`; runs ARTEMIS + APOLLO engines in parallel per memory; writes winner to `memory_compressed_variants` + full audit to `memory_compression_candidates`; stranded-running sweep at batch head |
-| registry_sync      | `modules/registry_sync.py` | Scheduled pull from provider APIs + Arena.ai Elo rankings into `model_registry` |
+| registry_sync      | `scripts/sync_provider_models.py` + `systemd/graeae-model-sync.timer` | Scheduled pull from provider APIs + Arena.ai/LMArena rankings into `model_registry` |
 
 ### 3.9 Compression platform (2 active engines + plugin ABC)
 
@@ -192,8 +202,8 @@ GPU circuit breaker (per-endpoint, process-local): `compression/gpu_guard.py`.
 
 | Protocol | Entry point | Tools / endpoints |
 |----------|-------------|-------------------|
-| REST over HTTP | `api_server.py` (uvicorn on port 5002) | 101 route declarations across 21 routers |
-| MCP stdio      | `mcp_server.py`                         | 13 tools (§5.2) |
+| REST over HTTP | `api_server.py` (uvicorn on port 5002) | 102 mounted application routes across 21 routers, excluding generated docs/openapi routes |
+| MCP stdio + HTTP/SSE | `mcp_server.py`, `mcp_http_server.py` | 18 tools (§5.2) from `api/mcp_tools.py::TOOL_REGISTRY` |
 
 ## 4. Data Model
 
@@ -211,7 +221,7 @@ GPU circuit breaker (per-endpoint, process-local): `compression/gpu_guard.py`.
 | 8 | `kg_triples`                     | owner_id, namespace | Subject/predicate/object with embeddings on each leg |
 | 9 | `entities`                       | owner_id, namespace | Named entity registry |
 | 10 | `state`                         | owner_id, namespace | Arbitrary k/v |
-| 11 | `journal`                       | owner_id            | Append-only operational log |
+| 11 | `journal`                       | owner_id, namespace | Append-only operational log |
 | 12 | `users`                         | —                   | Accounts (role: user / root / federation), `namespace` column |
 | 13 | `api_keys`                      | (FK user_id)        | Hashed Bearer tokens |
 | 14 | `groups`                        | —                   | Group memberships |
@@ -219,10 +229,10 @@ GPU circuit breaker (per-endpoint, process-local): `compression/gpu_guard.py`.
 | 16 | `oauth_providers`               | —                   | OIDC provider configuration |
 | 17 | `oauth_identities`              | (FK user_id)        | Linked external identities |
 | 18 | `oauth_sessions`                | (FK user_id)        | Active OIDC sessions |
-| 19 | `sessions`                      | owner_id            | Chat session metadata |
+| 19 | `sessions`                      | user_id, namespace  | Chat session metadata |
 | 20 | `session_messages`              | (FK session)        | Per-turn messages |
 | 21 | `session_memory_injections`     | (FK session)        | Which memories were injected into which turn |
-| 22 | `graeae_consultations`          | owner_id            | GRAEAE consultation rows (prompt + consensus + cost + latency) |
+| 22 | `graeae_consultations`          | owner_id, namespace | GRAEAE consultation rows (prompt + consensus + cost + latency) |
 | 23 | `graeae_audit_log`              | (FK consultation)   | Hash-chained audit (prev_hash → current_hash) |
 | 24 | `consultation_memory_refs`      | (FK consultation)   | Memories referenced by a consultation |
 | 25 | `model_registry`                | —                   | Provider × model catalog with Elo, cost, deprecated flags |
@@ -245,7 +255,7 @@ extension). Default embedding dimension is 768; configurable via
 **Content-addressed column**: `memory_versions.commit_hash` (SHA-256
 of memory_id + version_num + content + snapshot_at). Unique index.
 
-### 4.2 Migrations (24 files)
+### 4.2 Migrations (38 files)
 
 SQL migrations in `db/` are idempotent. Canonical order is the ordered
 list in `install.py` and `installer/db.py`, mirrored by
@@ -275,6 +285,20 @@ list in `install.py` and `installer/db.py`, mirrored by
 22. `migrations_charon_trigger_guard.sql` (trigger suppression guard)
 23. `migrations_v3_4_federation_compat.sql` (schema preflight fields)
 24. `migrations_v3_5_trigger_same_memory_parent.sql` (same-memory branch HEAD guard; `MN001`)
+25. `migrations_v3_5_rls_group_select_unix_bits.sql` (RLS group-read parity)
+26. `migrations_v3_5_webhook_retry_terminal_state.sql` (retry terminal-state repair)
+27. `migrations_v3_5_webhook_attempt_lease.sql` (persisted webhook leases)
+28. `migrations_v3_5_webhook_writer_revision.sql` (current-writer marker)
+29. `migrations_v3_5_webhook_status_updated_at.sql` (status transition timestamp)
+30. `migrations_v3_5_webhook_superseded_marker.sql` (superseded audit marker)
+31. `migrations_v3_5_webhook_attempt_unique.sql` (live successor uniqueness)
+32. `migrations_v3_5_webhook_succeeded_unique.sql` (single succeeded chain peer)
+33. `migrations_v3_5_webhook_succeeded_terminal_trigger.sql` (terminal success guard)
+34. `migrations_v3_5_entities_namespace_unique.sql` (entity uniqueness includes namespace)
+35. `migrations_v3_5_state_journal_namespace.sql` (state/journal namespace columns)
+36. `migrations_v3_5_session_compression_ratio_drop.sql` (drop fiction ratio columns)
+37. `migrations_v3_5_session_compression_legacy_drop.sql` (drop legacy session compression fields)
+38. `migrations_v3_5_sessions_consultations_namespace.sql` (sessions/consultations namespace)
 
 All migrations pattern: `BEGIN; <add-column>/<backfill>/<set-default>
 /<set-not-null>/<add-constraint>; COMMIT;`. Idempotent via
@@ -295,8 +319,8 @@ belongs to the same memory before ordinary UPDATE/DELETE writes.
 | I1 | Every `memory_versions` row has a `commit_hash`; the hash is deterministic (same content → same hash). |
 | I2 | `memory_versions` has FK-less memory_id (versions survive memory deletion). |
 | I3 | `memory_branches` HEAD pointer on `main` is strictly increasing in `version_num` per memory. |
-| I4 | `memory_compressed_variants` has exactly one row per memory_id per engine_id (UNIQUE on `(memory_id, engine_id)`). |
-| I5 | `memory_compression_candidates` has exactly one `is_winner=TRUE` per `(memory_id, contest_run_id)`. |
+| I4 | `memory_compressed_variants` has at most one current winning row per memory_id (primary key on `memory_id`). |
+| I5 | `memory_compression_candidates` records every attempt per contest; a completed contest selects one winner into `memory_compressed_variants`, while historical winning candidates remain in the candidate log. |
 | I6 | `graeae_audit_log` is a hash-chain: each row's `prev_hash` equals the previous row's `commit_hash` within the same consultation. |
 | I7 | Non-root live-memory reads use the shared owner/federation/world/group predicate from `api/visibility.py:40-96`; writes remain owner+namespace scoped. |
 | I8 | Non-root historical reads use the snapshot's own `owner_id`, `namespace`, and `permission_mode`; live-memory visibility does not authorize hidden old snapshots. |
@@ -305,7 +329,8 @@ belongs to the same memory before ordinary UPDATE/DELETE writes.
 | I11 | `federation_source IS NOT NULL ⇒ owner_id='federation'`. |
 | I12 | Non-root writes on tenant-scoped tables filter by `owner_id = current_user.owner_id AND namespace = current_user.namespace`. Root role bypasses both. |
 | I13 | Webhook URLs are validated at subscribe time and delivery time, including DNS resolution and metadata-host denial. |
-| I14 | API keys persisted as `sha256(token)`; tokens never stored plaintext. |
+| I14 | Webhook retry chains have at most one live successor attempt per attempt number and one terminal succeeded row per `(subscription_id, event_type, payload_hash)` chain. |
+| I15 | API keys persisted as `sha256(token)`; tokens never stored plaintext. |
 
 ## 5. Interface Contracts
 
@@ -317,21 +342,22 @@ Surface breakdown:
 |------|-----------|---------------------|
 | Memories CRUD + search | 10 | `POST /v1/memories/search`, `GET /v1/memories/{id}`, `POST /v1/memories/rehydrate` |
 | Versioning + DAG | 9 | `GET /v1/memories/{id}/versions`, `POST /v1/memories/{id}/branch`, `POST /v1/memories/{id}/merge` |
-| Knowledge graph | 6 | `POST /v1/kg/triples`, `POST /v1/kg/search`, `GET /v1/kg/timeline` |
-| Entities | 5 | `POST /v1/entities`, `GET /v1/entities/{id}` |
-| State | 4 | `GET /v1/state/{key}`, `PUT /v1/state/{key}` |
-| Journal | 3 | `GET /v1/journal`, `POST /v1/journal/append` |
-| Sessions | 6 | `POST /v1/sessions`, `POST /v1/sessions/{id}/messages` |
-| Consultations (GRAEAE) | 8 | `POST /v1/consultations`, `GET /v1/consultations/audit/verify` |
-| Providers + registry | 6 | `GET /v1/providers`, `GET /v1/models`, `POST /v1/providers/{id}/health` |
-| Gateway (OpenAI-compat) | 3 | `POST /v1/chat/completions`, `GET /v1/models` |
-| Federation | 5 | `POST /v1/federation/peers`, `POST /v1/federation/pull` |
+| Knowledge graph | 5 | `POST /v1/kg/triples`, `GET /v1/kg/triples`, `GET /v1/kg/timeline/{subject}` |
+| Entities | 7 | `POST /entities`, `GET /entities/{id}`, `POST /entities/{id}/link` |
+| State | 4 | `GET /state/{key}`, `PUT /state/{key}` |
+| Journal | 3 | `GET /journal`, `POST /journal` |
+| Sessions | 5 | `POST /v1/sessions`, `POST /v1/sessions/{id}/messages` |
+| Consultations (GRAEAE) | 7 | `POST /v1/consultations`, `GET /v1/consultations/audit/verify` |
+| Providers + registry | 5 | `GET /v1/providers`, `GET /v1/providers/health`, `GET /v1/providers/recommend`, `GET /v1/models` |
+| Gateway (OpenAI-compat) | 1 | `POST /v1/chat/completions` |
+| Federation | 10 | `POST /v1/federation/peers`, `GET /v1/federation/feed`, `GET /v1/federation/schema` |
 | Webhooks | 5 | `POST /v1/webhooks`, `GET /v1/webhooks/{id}/deliveries` |
-| Ingest | 3 | `POST /v1/ingest/bulk`, `POST /v1/document-import` |
+| Ingest + documents | 3 | `POST /ingest/session`, `POST /v1/documents/import`, `POST /v1/documents/batch-import` |
 | Portability (MPF) | 2 | `GET /v1/export`, `POST /v1/import` |
-| Admin | 12 | `POST /admin/users`, `POST /admin/users/{id}/apikeys`, `POST /admin/compression/enqueue-all` |
-| OAuth | 4 | `GET /oauth/{provider}/authorize`, `GET /oauth/{provider}/callback` |
+| Admin | 15 | `POST /admin/users`, `POST /admin/users/{id}/apikeys`, `POST /admin/compression/enqueue-all` |
+| OAuth | 5 | `GET /auth/oauth/{provider}/login`, `GET /auth/oauth/{provider}/callback` |
 | Health + metrics | 3 | `GET /health`, `GET /stats`, `GET /metrics` |
+| MORPHEUS | 3 | `GET /v1/morpheus/runs`, `GET /v1/morpheus/runs/{id}`, `GET /v1/morpheus/runs/{id}/clusters` |
 
 All REST endpoints use Pydantic request/response models (defined in
 `api/models.py`). All non-public endpoints require Bearer auth or
@@ -343,14 +369,15 @@ Rate limiting: SlowAPI, opt-in via `RATE_LIMIT_ENABLED=true`.
 Body size: default 5 MB, `MAX_BODY_BYTES` override. Chunked-transfer
 aware streaming limiter (not just Content-Length check).
 
-### 5.2 MCP (stdio, 13 tools)
+### 5.2 MCP (stdio and HTTP/SSE, 18 tools)
 
-Entry point: `mcp_server.py`. Tool manifest:
+Entry points: `mcp_server.py` and `mcp_http_server.py`. Both use
+`api/mcp_tools.py::TOOL_REGISTRY`. Tool manifest:
 
 | Tool | Maps to REST |
 |------|--------------|
 | `create_memory`       | `POST /v1/memories` |
-| `bulk_create_memories`| `POST /v1/ingest/bulk` |
+| `bulk_create_memories`| `POST /v1/memories/bulk` |
 | `get_memory`          | `GET /v1/memories/{id}` |
 | `list_memories`       | `GET /v1/memories` |
 | `search_memories`     | `POST /v1/memories/search` |
@@ -358,10 +385,15 @@ Entry point: `mcp_server.py`. Tool manifest:
 | `delete_memory`       | `DELETE /v1/memories/{id}` |
 | `get_stats`           | `GET /stats` |
 | `kg_create_triple`    | `POST /v1/kg/triples` |
-| `kg_search`           | `POST /v1/kg/search` |
+| `kg_search`           | `GET /v1/kg/triples` |
 | `kg_timeline`         | `GET /v1/kg/timeline` |
 | `update_triple`       | `PATCH /v1/kg/triples/{id}` |
 | `delete_triple`       | `DELETE /v1/kg/triples/{id}` |
+| `log_memory`          | `GET /v1/memories/{id}/log` |
+| `branch_memory`       | `POST /v1/memories/{id}/branch` |
+| `diff_memory_commits` | DAG commit diff helper |
+| `checkout_memory`     | `GET /v1/memories/{id}/commits/{commit}` |
+| `recommend_model`     | `GET /v1/providers/recommend` |
 
 MCP contract-wire regression test: `tests/test_mcp_stdio_wire.py`.
 
@@ -663,12 +695,15 @@ Plus non-`MNEMOS_`-prefixed standards: `GPU_PROVIDER_HOST`,
   application visibility after
   `db/migrations_v3_5_rls_group_select_unix_bits.sql`.
 
-### 10.4 Known gaps (as of v3.5-dev)
+### 10.4 Known gaps (as of v3.5.x)
 
-- Webhook retry state machine (#20), federation per-peer ACL/stable
-  cursor (#21), audit endpoint scoping/lifespan teardown (#22), entity
-  namespace conflict-key migration (#23), bulk webhook parity (#19), and
-  deletion-log refactor (#15).
+- Horizontal process scaling still requires externalized circuit breakers,
+  rate limiters, dispatch semaphores, and recovery-worker coordination.
+- Full deletion-log/GDPR wipe workflow is not present. DELETE tombstone
+  snapshots exist in the version DAG when the delete trigger is attached, but
+  no separate deletion-log table ships in v3.5.x.
+- Federation per-peer ACLs beyond bearer identity, role gate, namespace
+  filters, and category filters remain future work.
 - No in-process secrets encryption layer (values read from env + config
   files directly).
 
@@ -693,8 +728,8 @@ Plus non-`MNEMOS_`-prefixed standards: `GPU_PROVIDER_HOST`,
 ### 11.3 Horizontal scaling
 
 **Currently pinned to `workers=1`.** GRAEAE circuit breakers, rate
-limiters, and concurrency semaphores are in-process state. Moving
-them to Redis-backed shared singletons is v3.3 work.
+limiters, dispatch semaphores, and recovery workers are in-process state.
+Moving them to shared/external coordination is v4 work.
 
 ### 11.4 Backup / restore
 
@@ -704,20 +739,20 @@ them to Redis-backed shared singletons is v3.3 work.
 
 ## 12. Complexity Indicators
 
-Raw metrics at v3.5-dev slice 2 (`d42c475`), measured from the checked-out tree unless noted.
+Raw metrics at v3.5.x (`d8a035b`), measured from the checked-out tree unless noted.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Total Python LOC | ~57,000 | Excludes virtualenvs; simple `wc -l` over Python files |
-| Production LOC | ~36,700 | api + compression + graeae + installer + modules + scripts/tools |
-| Test LOC | ~17,800 | tests/ only |
-| Python files | 176 | Primary modules + tests |
-| Test files | 60 | Unit + integration + live-gated E2E |
-| Test count | 768 passing on merged slice 2 | Reported by the v3.5-dev slice 2 merge context |
-| REST endpoints | 101 route declarations | Across 21 routers |
-| MCP tools | 13 | Memory CRUD + KG + stats |
+| Total Python LOC | ~67,000 | Excludes virtualenvs; simple `wc -l` over Python files |
+| Production LOC | ~40,800 | api + compression + graeae + installer + modules + scripts/tools + morpheus |
+| Test LOC | ~24,900 | tests/ only |
+| Python files | 185 | Primary modules + tests |
+| Test files | 74 | Unit + integration + live-gated E2E |
+| Test count | ~900 collected definitions | `rg "def test_|async def test_" tests` count; DB-gated tests are selectively ignored in CI/doc sweeps |
+| REST endpoints | 102 mounted application routes | Across 21 routers; excludes generated FastAPI docs/openapi routes |
+| MCP tools | 18 | Memory CRUD + KG + stats + DAG + model recommendation |
 | DB tables | 32 | See §4.1 |
-| Migrations | 24 SQL files | Idempotent, ordered |
+| Migrations | 38 ordered SQL migrations | Idempotent, ordered |
 | Named concepts | ~40 | See Appendix H |
 | External service protocols | 4 | Postgres wire, HTTP (providers + peers + webhooks + GPU), OAuth/OIDC, MCP stdio |
 | Required Python deps | 18 | See §8.2 |
@@ -769,9 +804,9 @@ A scoping tool estimating cost from scratch should bucket:
 | Install / config / ops | 1.0× baseline | Not trivial (profiles, migrations, service unit, Docker) |
 
 Roughly **11-14 full-bucket subsystems** at baseline equivalence. The
-current branch is about 36k LOC of production Python plus 18k LOC of
-tests; v3.5-dev slice 2 added focused tenancy/DAG regressions rather
-than a new user-facing subsystem.
+current branch is about 41k LOC of production Python plus 25k LOC of
+tests; v3.5.0 added hardening and tenancy closure rather than a new
+standalone user-facing subsystem.
 
 ## 13. Version history (summary)
 
@@ -789,8 +824,7 @@ See `CHANGELOG.md` for the authoritative list. Selected milestones:
   import, Custom Query mode on consultations, engine-consistent
   consultation persistence, middleware LIFO fix, probe-identity
   handshake on GPUGuard.
-- **v3.2 tail** — ALETHEIA retired; APOLLO S-IC + S-II landed;
-  going-forward stack is LETHE + ANAMNESIS + APOLLO.
+- **v3.2 tail** — ALETHEIA retired from default contests; APOLLO S-IC + S-II landed.
 - **v3.2.1** — registry-driven GRAEAE muse manifest with ELO-override
   + newer-version override + live-probe + n-1 fallback; non-blocking
   startup reload; gateway provider/model namespacing; gateway prefix-
@@ -822,13 +856,20 @@ See `CHANGELOG.md` for the authoritative list. Selected milestones:
   checks.
 - **v3.4.1** — federation schema-compat preflight and dev↔prod MPF
   restore drill.
-- **v3.5-dev slice 1** — session history DESC fix and
+- **v3.5.0 slice 1** — session history DESC fix and
   `mnemos-os/mnemos` URL sweep (`a62a099`).
-- **v3.5-dev slice 2** — shared live-memory read visibility,
+- **v3.5.0 slice 2** — shared live-memory read visibility,
   per-snapshot version visibility, same-memory DAG guards, race-safe
   branch creation, feature-branch revert as pure DAG insert, merge
   target-tenancy semantics, `MN001` → HTTP 409, and Docker
   `postgres-upgrade` for existing volumes (`d42c475`).
+- **v3.5.0 final hardening** — webhook retry leases/outbox discipline,
+  consultation audit scoping, MCP stdio/HTTP registry parity, faithful
+  OpenAI-compatible gateway handling, PostgreSQL streaming-replication
+  doctrine, namespace-uniform state/journal/entities/sessions/consultations,
+  bulk webhook parity, compression cleanup, and audit closure passes.
+- **v3.5.1** — documentation-triage patch and version metadata correction;
+  no product behavior changes from v3.5.0.
 
 ---
 
@@ -843,9 +884,9 @@ See `CHANGELOG.md` for the authoritative list. Selected milestones:
 13. admin          14. oauth          15. federation
 16. webhooks       17. ingest         18. portability
 19. document_import 20. distillation_worker 21. registry_sync
-22. MCP stdio server
+22. MCP stdio/HTTP server
 
-## B. REST endpoint inventory (101 route declarations, router-grouped)
+## B. REST endpoint inventory (102 mounted application routes, router-grouped)
 
 (see §5.1 for the count breakdown; full list in the router modules
 at `api/handlers/*.py`)
@@ -864,11 +905,11 @@ session_memory_injections, session_messages, sessions, state,
 user_groups, users, webhook_deliveries, webhook_subscriptions,
 memory_stats.
 
-## D. Migration inventory (24)
+## D. Migration inventory (38)
 
 Ordered as applied (see §4.2 for detail).
 
-## E. Test inventory (59 test files)
+## E. Test inventory (74 test files)
 
 Unit + integration + live-GPU-gated E2E:
 

--- a/docs/SYSTEM_REQUIREMENTS.md
+++ b/docs/SYSTEM_REQUIREMENTS.md
@@ -113,13 +113,13 @@ From real deployments as of 2026-04-23:
 These are operational rather than prescriptive — real workloads will
 differ. Use these as a sanity check when sizing a new host.
 
-## v3.5-dev deployment note
+## v3.5.x deployment note
 
 Docker fresh volumes run all mounted initdb migrations. Existing volumes
-do not. For v3.5-dev, the compose files include a one-shot
+do not. For v3.5.x, the compose files include a one-shot
 `postgres-upgrade` service so the trigger replacement migration applies
 to existing data directories before MNEMOS starts.
 
 ---
 
-*Last updated: 2026-04-26 (v3.5-dev docs sweep)*
+*Last updated: 2026-04-28 (v3.5.1 doc triage)*

--- a/docs/V3_5_CHARTER.md
+++ b/docs/V3_5_CHARTER.md
@@ -1,6 +1,13 @@
 # MNEMOS v3.5 Charter — PANTHEON v0.1 + IRIS Discovery Layer + Memory Operations Expansion
 
-**Status:** In flight on `v3.5-dev`; not tagged. Slice 1 merged as `a62a099`; slice 2 merged as `d42c475`.
+**STATUS: SHIPPED.** v3.5.0 shipped 2026-04-28 as an audit-hardening and
+uniform-tenancy release; v3.5.1 is the 2026-04-28 documentation-triage patch.
+No product behavior changed between v3.5.0 and v3.5.1.
+
+**Document status:** Historical charter. The original PANTHEON/IRIS feature
+pitch below did not ship in v3.5.0; it is preserved as planning record and
+moved to later roadmap work. The shipped v3.5.0 scope is the slice sequence
+listed in §0.
 **Position in roadmap:** Follows APOLLO S-IVB phases 1–2 (v3.2–v3.4); precedes full GPU stack (v4.0).
 **Theme:** *Unified LLM provider facade with MCP discovery + foundational memory operations hardening.*
 
@@ -8,30 +15,28 @@
 
 ## 0. Current branch status
 
-Closed on `v3.5-dev`:
+Closed in v3.5.0:
 
 - **DONE in slice 1 (`a62a099`)** — session history order and pinning fixes; repository URL sweep to `mnemos-os/mnemos`.
 - **DONE in slice 2 (`d42c475`)** — memory read visibility symmetry, per-snapshot version visibility, same-memory DAG parent guards, race-safe branch creation, merge/revert branch-writer serialization, target-tenancy merge semantics, `MN001` → HTTP 409 reconciliation, and Docker `postgres-upgrade` for existing volumes.
+- **DONE in later slices** — webhook retry leases/outbox discipline, federation compound cursor, consultation audit endpoint scoping, MCP stdio/HTTP registry parity, faithful OpenAI-compatible gateway handling, PostgreSQL streaming-replication doctrine, namespace-uniform state/journal/entities/sessions/consultations, bulk webhook parity, compression cleanup, and audit-closure passes.
 
-Open backlog still in scope or awaiting explicit deferral:
+Deferred after v3.5.0:
 
-- **#20** webhook retry state machine.
-- **#21** federation per-peer ACL + stable cursor.
-- **#22** audit endpoint scoping + lifespan teardown.
-- **#23** entity namespace conflict-key migration.
-- **#19** bulk webhook parity.
-- **#15** deletion-log refactor (parked).
-
-PANTHEON + IRIS remain the next-bound v3.5 feature set; they are not
-shipped by slices 1 or 2.
+- **PANTHEON + IRIS** — unified LLM facade and MCP model discovery layer.
+- **Dedicated deletion-log / GDPR wipe workflow** — v3.5 keeps DELETE tombstone
+  snapshots live in the version DAG, but it does not add a separate deletion-log
+  table.
+- **Federation per-peer ACL** beyond current bearer identity, role gate,
+  namespace filters, and category filters.
 
 ---
 
 ## 1. Headline Pitch
 
-MNEMOS v3.5 is the **integration & operations release**. It ships PANTHEON v0.1 — a unified LLM provider facade sitting above GRAEAE and every OpenAI-compatible backend — and IRIS, an MCP server that exposes PANTHEON's model registry so agents discover and select models by capability (not hardcoded names). Together, PANTHEON + IRIS eliminate the industry-wide problem of agents hardcoding model strings. Agents stop asking "what model should I use?" and start asking "what are my options for a tool-calling vision model?" IRIS responds with a ranked list including cost, latency, quality, and availability.
+Original pitch, not the shipped v3.5.0 outcome: MNEMOS v3.5 was drafted as the **integration & operations release**. It would ship PANTHEON v0.1 — a unified LLM provider facade sitting above GRAEAE and every OpenAI-compatible backend — and IRIS, an MCP server that exposes PANTHEON's model registry so agents discover and select models by capability (not hardcoded names). Together, PANTHEON + IRIS would eliminate the industry-wide problem of agents hardcoding model strings. Agents would stop asking "what model should I use?" and start asking "what are my options for a tool-calling vision model?" IRIS would respond with a ranked list including cost, latency, quality, and availability.
 
-Alongside, v3.5 hardens the core memory infrastructure: async distillation, embedding migration, reranking integration, and the closing out of APOLLO S-IVB phase 4 (EXTRACT latent KG triples from prose).
+What shipped instead: v3.5.0 hardened the core memory infrastructure and release docs around audit closure, uniform tenancy, webhook retry correctness, MCP registry parity, faithful OpenAI compatibility, and streaming-replication operations.
 
 The release is operationally driven: every item directly supports running MNEMOS at scale.
 
@@ -139,7 +144,7 @@ IRIS is the reference implementation of a broader capability-based model discove
 
 **Specification & standardization path:**
 
-- v3.5 ships IRIS + a draft specification at `docs/spec/MCP-MD-v0.1.md` (separate from MNEMOS feature docs to signal vendor-neutral intent).
+- Original plan: v3.5 would ship IRIS + a draft specification at `docs/spec/MCP-MD-v0.1.md` (separate from MNEMOS feature docs to signal vendor-neutral intent). This did not ship in v3.5.0.
 - The specification is explicitly draft-stage; breaking changes are possible through v3.6 and into v4.0 pending implementer feedback.
 - Over v3.5–v4.0, the goal is to build adoption signals from multiple implementers (MNEMOS as reference, zeroclaw, OpenClaw, ideally external partners). Once multi-implementer adoption demonstrates merit, the specification will be **proposed to the Linux Foundation AI & Data working group** as a Sandbox project for neutral standardization.
 - MNEMOS remains the reference implementation throughout; the specification itself may eventually graduate to LF-hosted neutral infrastructure once v1.0 stabilization is achieved and the proposal is accepted.
@@ -244,7 +249,7 @@ All items required for v3.5 to be production-ready at scale:
 - **Option A: augment-then-replace** — keep old embeddings until all new queries prefer new embeddings, then drop old columns.
 - **Option B: alter-and-backfill** — alter column type, backfill new embeddings (batch job, ~2 hours on PYTHIA), drop old immediately.
 
-**v3.5 ships:** NIM deployment Helm values + docs for CERBERUS. Reembedding logic stubbed; actual migration left to operator.
+**Original v3.5 plan:** NIM deployment Helm values + docs for CERBERUS. Reembedding logic stubbed; actual migration left to operator. This did not ship in v3.5.0.
 
 **Affected files:** `api/pantheon/workers/embedding_worker.py` (NIM endpoint), `api/models.py` (embedding config), `docs/EMBEDDING_MIGRATION.md` (to be created in v3.5).
 
@@ -295,7 +300,7 @@ All items required for v3.5 to be production-ready at scale:
 
 **The strategic shift:** v3.4 framed the problem as "seven frameworks, seven separate PRs to add PANTHEON support." v3.5 solves it by shipping IRIS, collapsing the problem to **one MCP server that all MCP-aware frameworks already know how to consume**. Frameworks don't need patches; they just need a config line.
 
-**v3.5 ships IRIS plus first-wave reference implementations:**
+**Original plan, deferred after v3.5.0: IRIS plus first-wave reference implementations:**
 
 ### 3.1 zeroclaw IRIS adoption (reference implementation — own repo, full control)
 
@@ -326,7 +331,7 @@ env = {PANTHEON_API_KEY = "pantheon-<tenant-token>"}
 
 **Agent behavior:** On startup, connect to IRIS via MCP. Call `find_model(capabilities=[tool_calling], max_cost_per_mtok=0.001)`. IRIS returns ranked models with metadata. User can see options, IRIS defaults to top-ranked. Runtime `/model query vision` dynamically re-queries and switches.
 
-**Effort:** ~2 hours (integrate IRIS MCP client + dynamic model selection logic). Ships as PR against `perlowja/zeroclaw:main`, merged before v3.5 GA.
+**Historical estimate:** ~2 hours (integrate IRIS MCP client + dynamic model selection logic). Did not ship in v3.5.0; carried forward with the deferred PANTHEON/IRIS scope.
 
 ### 3.2 OpenClaw IRIS adoption (medium difficulty — NVIDIA contributor, not owner)
 
@@ -334,7 +339,7 @@ env = {PANTHEON_API_KEY = "pantheon-<tenant-token>"}
 
 **Change shape:** Same as zeroclaw's IRIS config, applied to `~/.openclaw/config.toml`. Contributor-level PR to `zeroclaw-labs/openclaw`.
 
-**Effort:** ~3 hours including upstream coordination. Target: merged before v3.5 GA (stretch; may land v3.5.1 patch).
+**Historical estimate:** ~3 hours including upstream coordination. Did not ship in v3.5.0 or the v3.5.1 doc-triage patch.
 
 ### 3.2a Rate-limiting upstream PR donations
 
@@ -389,11 +394,11 @@ With IRIS in place, other MCP-aware frameworks (Hermes, Continue, AutoGPT, CrewA
 
 ## 6. Success criteria
 
-- [x] Slice 1 audit quick wins merged to `v3.5-dev` (`a62a099`).
-- [x] Slice 2 memory-read tenancy + DAG integrity merged to `v3.5-dev` (`d42c475`).
+- [x] Slice 1 audit quick wins shipped in v3.5.0 (`a62a099`).
+- [x] Slice 2 memory-read tenancy + DAG integrity shipped in v3.5.0 (`d42c475`).
 - [x] v3.5 trigger replacement wired into `install.py`, `installer/db.py`, `docker-compose.yml`, and `docker-compose.staging.yml`.
-- [ ] PANTHEON v0.1 running on PYTHIA, accessible at `http://pythia:5002/v1/chat/completions` with extended catalog.
-- [ ] **IRIS MCP server operational:** `iris://models` resource returns full catalog; `find_model()` tool ranks models by capability constraints; `get_model_health()` reflects PANTHEON health.
+- [ ] PANTHEON v0.1 running on PYTHIA, accessible at `http://pythia:5002/v1/chat/completions` with extended catalog. **Deferred after v3.5.0.**
+- [ ] **IRIS MCP server operational:** `iris://models` resource returns full catalog; `find_model()` tool ranks models by capability constraints; `get_model_health()` reflects PANTHEON health. **Deferred after v3.5.0.**
 - [ ] zeroclaw + OpenClaw both using IRIS for model discovery (MCP connection working; runtime model selection via `iris://models/recommendations/coding`).
 - [ ] Audit log table populated on memory create/update/delete + federation pulls.
 - [ ] Body-size cap + per-tenant rate limit enforced, 413/429 responses working as documented.
@@ -423,8 +428,8 @@ v3.5 GA gate:
 - **PANTHEON detailed design:** `docs/PANTHEON.md` (complete, decision-ready).
 - **APOLLO S-IVB phases 1–2:** Shipped v3.2–v3.4 (see `ROADMAP.md`).
 - **CHARON v0.2:** Shipped v3.4 (portability sidecar system).
-- **v3.5-dev slice 1:** `a62a099` audit quick wins.
-- **v3.5-dev slice 2:** `d42c475` memory-read tenancy + DAG integrity.
+- **v3.5.0 slice 1:** `a62a099` audit quick wins.
+- **v3.5.0 slice 2:** `d42c475` memory-read tenancy + DAG integrity.
 - **v3.4 artifacts:** Compression benchmark, APOLLO S-IVB slice 2, KNOSSOS phase 2.
 - **v3.6 followup:** PERSEPHONE archival, APOLLO S-IVB phases 3–4, Hermes/Continue/AutoGPT donations.
 
@@ -434,14 +439,14 @@ v3.5 GA gate:
 
 ## Appendix: Greek pantheon + IRIS subsystem naming
 
-| Subsystem | Greek | Role | v3.5 status |
+| Subsystem | Greek | Role | v3.5.0 status |
 |---|---|---|---|
 | MNEMOS | titaness of memory | core memory store | ✅ core |
 | APOLLO | sun god / oracle | convergent compression (S-IC, S-II, S-IVB) | ✅ current compression stack; mutation paths continue in v3.6 |
 | CHARON | ferryman | cross-system portability | ✅ v0.2 |
 | GRAEAE | gray sisters | multi-LLM consensus | ✅ core |
-| PANTHEON | temple of all gods | unified LLM gateway | 🔵 next-bound v3.5 feature |
-| **IRIS** | **messenger of the gods** | **MCP discovery layer over PANTHEON's catalog** | **🔵 next-bound v3.5 feature** |
+| PANTHEON | temple of all gods | unified LLM gateway | 🔵 deferred after v3.5.0 |
+| **IRIS** | **messenger of the gods** | **MCP discovery layer over PANTHEON's catalog** | **🔵 deferred after v3.5.0** |
 | PERSEPHONE | queen of the underworld | archival subsystem | 🔵 v3.6 |
 
-*Charter opened 2026-04-25. Current branch status updated 2026-04-26 after slice 2 merge.*
+*Charter opened 2026-04-25. Status reconciled 2026-04-28 after v3.5.0 GA and the v3.5.1 documentation patch.*

--- a/docs/V3_6_CHARTER.md
+++ b/docs/V3_6_CHARTER.md
@@ -1,7 +1,7 @@
 # MNEMOS v3.6 Charter — APOLLO S-IVB Evolution + IRIS Second-Wave Adoption + Mutation Paths
 
-**Status:** Specification (target: ships after v3.5 GA)
-**Position in roadmap:** Closes APOLLO S-IVB phases 1–4 (v3.2–v3.6); broadens IRIS adoption across frameworks; sets stage for v4.0 consolidation.
+**Status:** Forward-looking specification (target: ships after v3.5.x; not shipped in v3.5.0 or v3.5.1)
+**Position in roadmap:** Extends APOLLO S-IVB work after the v3.5.0 hardening release; broadens any shipped IRIS adoption across frameworks; sets stage for v4.0 consolidation.
 **Theme:** *Derivative-idea layers + memory state evolution + industry-wide IRIS adoption.*
 
 ---
@@ -43,7 +43,7 @@ MNEMOS v3.6 is the **APOLLO S-IVB maturity release**. It ships the final two pha
 
 ### 2.2 APOLLO S-IVB phase 4 completion: EXTRACT finishing touches
 
-**Status from v3.5:** Basic EXTRACT mines prose for triples via fast extractor + strong reasoner.
+**Status entering v3.6:** Basic EXTRACT did not ship in v3.5.0. This section is planned work carried forward from the historical v3.5 charter.
 
 **v3.6 refinement:**
 - **Batch optimization:** Accumulate extraction queue; send batches to fast extractor (amortizes LLM call overhead).
@@ -131,7 +131,7 @@ MNEMOS v3.6 is the **APOLLO S-IVB maturity release**. It ships the final two pha
 
 ### 2.7 Client-side IRIS adoption (second wave — configuration-driven, not code-donation)
 
-**Strategic shift from v3.5:** With IRIS proven and stable, v3.6 expands adoption across the agentic ecosystem. But the work pattern changes: instead of framework-specific code donations, adoption is now **config documentation + verification**.
+**Strategic intent:** Once IRIS exists and is stable, v3.6 expands adoption across the agentic ecosystem. The intended work pattern is **config documentation + verification** instead of framework-specific code donations.
 
 Each framework that speaks MCP (Hermes, Continue, AutoGPT, CrewAI) can start using IRIS by adding one line to their config:
 ```toml
@@ -238,11 +238,11 @@ v3.6 GA unlocks the v4.0 sprint:
 
 ## 8. Cross-references
 
-- **v3.5 PANTHEON + IRIS:** Released before v3.6; provides LLM routing foundation + model discovery MCP server.
-- **IRIS adoption strategy:** v3.5 ships IRIS + reference implementations (zeroclaw, OpenClaw); v3.6 expands to Hermes, Continue, AutoGPT, CrewAI, langchain.
+- **PANTHEON + IRIS:** Deferred from the historical v3.5 charter; must ship before the second-wave adoption work described here can be treated as executable.
+- **IRIS adoption strategy:** Reference implementations (zeroclaw, OpenClaw) precede second-wave adoption by Hermes, Continue, AutoGPT, CrewAI, and langchain.
 - **APOLLO program:** Phases 1–4 complete by end of v3.6 (shipped v3.2–v3.6).
 - **APOLLO S-IVB dream-state:** Foundation in v3.3, slice 2 in v3.3 (parallel), phases 3–4 in v3.6.
-- **PERSEPHONE archival:** Initial design + foundation in v3.5; full implementation v3.6.
+- **PERSEPHONE archival:** Planned for v3.6; no v3.5.0 archival foundation shipped beyond recall tracking already present from v3.3.
 - **Design papers:** Existing `PANTHEON.md`, new `IRIS_DISCOVERY.md`, `DREAM_STATE_DESIGN.md`, new `MEMORY_ARCHITECTURE.md` (v3.6).
 - **v4.0 next:** Modularization, GPU scaling, surface integrations, IRIS expansion to all ETLANTIS operations.
 
@@ -258,8 +258,8 @@ v3.6 GA unlocks the v4.0 sprint:
 | APOLLO | sun god / oracle | convergent compression (S-IC, S-II, S-IVB) | ✅ complete |
 | CHARON | ferryman | cross-system portability | ✅ v0.2 |
 | GRAEAE | gray sisters | multi-LLM consensus | ✅ core |
-| PANTHEON | temple of all gods | unified LLM gateway | ✅ v0.1 |
-| IRIS | messenger of the gods | MCP discovery layer + capability-based selection | ✅ v0.1 + second-wave adoption |
-| PERSEPHONE | queen of the underworld | archival subsystem | ✅ v3.6 |
+| PANTHEON | temple of all gods | unified LLM gateway | 🔵 prerequisite / planned |
+| IRIS | messenger of the gods | MCP discovery layer + capability-based selection | 🔵 prerequisite / planned |
+| PERSEPHONE | queen of the underworld | archival subsystem | 🔵 planned v3.6 |
 
 *Charter locked 2026-04-25. Changes via memo + MNEMOS memory update.*

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -1,7 +1,7 @@
 # MNEMOS v4.0 Plan — ETLANTIS Universe Consolidation + GPU Stack
 
 **Status:** Architecture specification (target: ships after v3.6 GA)
-**Position in roadmap:** Closes APOLLO program; opens horizontal scaling + GPU integration.
+**Position in roadmap:** Forward-looking v4 architecture plan after the v3.5.x hardening release and planned v3.6 work; opens horizontal scaling + GPU integration.
 **Theme:** *Structural refactoring + GPU-backed AI infrastructure + unified ETLANTIS Universe.*
 
 ---
@@ -160,7 +160,7 @@ contracts = [
 
 ## 3. Track 7: MCP-MD v1.0 stabilization + Linux Foundation AI & Data proposal track
 
-**Strategic context:** v3.5–v3.6 established MCP-MD (MCP Model Discovery) as a draft open specification with IRIS as the reference implementation. By v4.0, the specification has accumulated 6–9 months of multi-implementer feedback and is ready to graduate from draft v0.1.x to stable v1.0.
+**Strategic context:** This assumes MCP-MD (MCP Model Discovery) and IRIS have shipped before v4.0. They did not ship in v3.5.0 or v3.5.1; treat this section as conditional forward-looking scope.
 
 **v4.0 deliverables:**
 
@@ -191,7 +191,7 @@ The proposal follows LF's standard Sandbox project intake — no expedited track
 
 ## 3. Track 3: IRIS expansion to full ETLANTIS operations discovery
 
-**Strategic context:** v3.5 ships IRIS for model discovery (capability-based selection of PANTHEON models). v4.0 generalizes IRIS to expose **all ETLANTIS operations** — not just models, but also compression engines, dream-state generators, time-series forecasters, etc. Agents query IRIS for "show me anomaly detectors with <3s latency" or "which clustering algorithm is most memory-efficient?" instead of hardcoding operation names.
+**Strategic context:** Once IRIS exists for model discovery (capability-based selection of PANTHEON models), v4.0 generalizes IRIS to expose **all ETLANTIS operations** — not just models, but also compression engines, dream-state generators, time-series forecasters, etc. Agents query IRIS for "show me anomaly detectors with <3s latency" or "which clustering algorithm is most memory-efficient?" instead of hardcoding operation names.
 
 ### 3.1 Extend IRIS tools + resources beyond models
 
@@ -285,7 +285,7 @@ db/
 │       └── ...
 ```
 
-**Automation:** `tools/migrate_schema.py --dialect=sqlite --version=3.5.0` generates SQLite migrations from canonical Postgres.
+**Planned automation:** `tools/migrate_schema.py --dialect=sqlite --source-version=3.5.x` generates SQLite migrations from canonical Postgres once that future tool exists.
 
 **Effort:** 2–3 days (migrate 20 files, validate equivalence).
 
@@ -307,10 +307,13 @@ pyinstaller --onefile mnemos-cli.spec
 ### 4.1 MCP consolidation (unified tool source + IRIS integration)
 
 **Current state:**
-- `mcp_server.py` — stdio MCP server (13 tools, ~500 LOC).
-- `api/mcp_tools.py` — REST endpoints that correspond to MCP tools.
-- `api/iris/server.py` — separate MCP server for IRIS (model + operations discovery).
-- Drift risk: multiple MCP servers, separate tool implementations.
+- `mcp_server.py` and `mcp_http_server.py` — MNEMOS stdio and HTTP/SSE MCP
+  transports sharing the same 18-tool registry.
+- `api/mcp_tools.py` — current canonical MNEMOS MCP tool registry.
+- `api/iris/server.py` — planned separate MCP server for IRIS once IRIS exists
+  (model + operations discovery).
+- Drift risk: future IRIS work could reintroduce multiple MCP servers and
+  separate tool implementations if it is not consolidated deliberately.
 
 **Strategic decision:** Instead of two separate MCP servers (MNEMOS + IRIS), consolidate into **one canonical MCP server** with two tool families.
 
@@ -435,7 +438,7 @@ pyinstaller --onefile mnemos-cli.spec
 ### 5.2 MNEMOS audit log → KRONOS feed (with IRIS integration)
 
 **Pattern:**
-- Every memory operation (create, update, retrieval) records to `audit_log` (v3.5).
+- Every memory operation (create, update, retrieval) records to the planned v4 operational audit log. v3.5.x already has GRAEAE hash-chain audit, webhook delivery audit rows, compression contest audit, and version DAG snapshots, but not one generic `audit_log` table for every memory operation.
 - Every APOLLO/APOLLO S-IVB dream/archival operation records to `etlantis_operations_log` (v4.0, see §3.2).
 - KRONOS worker subscribes to both via NATS JetStream (or polls periodically; cheaper).
 - Per-tenant windows: `memory_creates_per_minute`, `memory_retrievals_per_minute`, `embedding_quality_score`, `compression_ratio_mean`, `dream_generation_cost_usd`, etc.
@@ -560,7 +563,7 @@ pyinstaller --onefile mnemos-cli.spec
 | Tool | Risk | Mitigation |
 |---|---|---|
 | `memories_search` | Info disclosure (peer tenant data) | Enforce owner_id filter; return 403 on cross-tenant. |
-| `memories_create` | Quota DOS | Rate-limit per tenant (already in v3.5 audit log). |
+| `memories_create` | Quota DOS | Rate-limit per tenant and record decisions in the planned v4 operational audit log. |
 | `memories_retrieve` | Info disclosure | Enforce owner_id; 404 on other tenant's memory. |
 | `memories_delete` | Data loss | Require confirmation token; soft-delete only. |
 | `kg_search` | Info disclosure | Enforce owner_id filter. |
@@ -769,8 +772,8 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 | APOLLO | sun god / oracle | convergent compression (S-IC, S-II, S-IVB) | ✅ complete + hot-paths |
 | CHARON | ferryman | cross-system portability | ✅ v0.2 |
 | GRAEAE | gray sisters | multi-LLM consensus | ✅ core |
-| PANTHEON | temple of all gods | unified LLM gateway | ✅ v0.1 |
-| IRIS | messenger of the gods | MCP discovery + capability-based selection (models + all ETLANTIS ops) | ✅ expanded operations discovery |
+| PANTHEON | temple of all gods | unified LLM gateway | 🔵 prerequisite / planned |
+| IRIS | messenger of the gods | MCP discovery + capability-based selection (models + all ETLANTIS ops) | 🔵 planned expansion |
 | KRONOS | titan of time | time-series anomaly + forecasting | ✅ Tesseract integrated |
 | PERSEPHONE | queen of the underworld | archival subsystem | ✅ v3.6 |
 
@@ -778,7 +781,7 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 
 ## 15. Cross-references
 
-- **v3.5 charter:** PANTHEON v0.1 + IRIS v0.1, operational hardening, APOLLO EXTRACT phase 4.
+- **v3.5 shipped reality:** audit hardening, uniform tenancy, webhook retry/outbox discipline, MCP registry parity, faithful OpenAI compatibility, streaming-replication doctrine, compression cleanup, and documentation triage in v3.5.1. PANTHEON/IRIS and APOLLO EXTRACT did not ship in v3.5.x.
 - **v3.6 charter:** CONSOLIDATE, PERSEPHONE, APOLLO S-IVB phases 3–4, IRIS second-wave adoption.
 - **v4.0 plan:** API consolidation, IRIS operations discovery expansion, unified MCP server, KRONOS integration.
 - **ROADMAP.md:** Full history + audit log.

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -5,7 +5,9 @@
 > tooling (Claude Desktop, Claude Code, ChatGPT Pro Developer Mode, Cursor,
 > Codex CLI). Defaults are off; configuration is opt-in; surface area is
 > intentionally narrow. APIs may change between minor releases without a
-> deprecation cycle until the surface is promoted to `stable` in v3.5+.
+> deprecation cycle until the surface is promoted to `stable` in a later
+> release. v3.5.0 shipped stdio/HTTP registry parity, but remote connector
+> packaging remains experimental.
 
 ## Audience
 
@@ -117,9 +119,10 @@ Each was specific, each was useful, each strengthened the mortal
 world rather than diminishing the giver. KNOSSOS and CHARON sit in
 that lineage:
 
-- **KNOSSOS** is a portal into MNEMOS's storage substrate that
+- **KNOSSOS** is a phase-1 portal into MNEMOS's storage substrate that
   speaks MemPalace's tool vocabulary (wings, rooms, drawers,
-  tunnels, diaries) byte-for-byte. Existing MemPalace-targeting
+  and KG basics today; tunnels and diaries remain deferred) byte-for-byte
+  where implemented. Existing MemPalace-targeting
   agents — every Claude Code prompt, every harness — keep working
   when their owner's workload outgrows what file-backed local-first
   storage can handle. No migration, no code changes in the agent.
@@ -150,9 +153,9 @@ open to them. Public evidence:
   side; PRs scoped where the runtime intersects MNEMOS's MCP surface.
 - **MemPalace, Mem0, Letta, Graphiti, Cognee**: bug reports and
   goodwill PRs as we encounter issues testing the CHARON adapters
-  against real instances. v3.4 charter commits to a first wave of
-  2–3 upstream MemPalace contributions before re-engaging on the
-  KNOSSOS bridge RFC there. See `ROADMAP.md` Track 3.
+  against real instances. The first wave of upstream MemPalace
+  contributions and KNOSSOS bridge RFC re-engagement is deferred after
+  v3.5.0. See `ROADMAP.md`.
 
 We'll grow this list as PRs land. The principle is simple: when
 KNOSSOS or CHARON adapters surface bugs in upstream memory systems,
@@ -166,11 +169,10 @@ While `experimental`:
 - Endpoints under `/admin/tunnels/*` may be renamed, restructured, or
   withdrawn in any minor release.
 - Default ports (5004 for the MCP HTTP/SSE bridge) may change.
-- Bearer-auth model is the v1 baseline; OAuth + per-user tokens come
-  in a later iteration without backwards compatibility for the v1
-  shared-token mode.
+- Bearer auth is the current baseline. Per-user token mapping exists on the
+  HTTP/SSE bridge; OAuth on the MCP edge remains later work.
 - The `mnemos-tunnel-setup` script's argument shape and config-file
   location (`~/.mnemos/tunnel.toml`) may change.
 
-When the connector subsystem promotes to `stable` (target: v3.5),
+When the connector subsystem promotes to `stable` in a later release,
 those guarantees flip — semver applies, deprecation cycles apply.

--- a/docs/connectors/chatgpt-pro-developer-mode.md
+++ b/docs/connectors/chatgpt-pro-developer-mode.md
@@ -47,7 +47,7 @@ service; everything stays in your MNEMOS.
 ```
 
 The MCP HTTP/SSE bridge (`mcp_http_server.py`) shares the exact same
-`Server("mnemos")` instance and 13 tool definitions as the stdio MCP
+`Server("mnemos")` instance and 18 tool definitions as the stdio MCP
 server. A memory written from Claude Desktop is queryable from
 ChatGPT and vice versa.
 
@@ -69,15 +69,17 @@ services:
     ports:
       - "5004:5004"
     environment:
-      MNEMOS_MCP_TOKEN: "${MNEMOS_MCP_TOKEN:?must be set}"
+      MNEMOS_MCP_TOKENS: "alice:${MNEMOS_MCP_TOKEN}:${MNEMOS_API_KEY}"
       MNEMOS_BASE: "http://mnemos:5002"
       MNEMOS_API_KEY: "<your existing MNEMOS bearer>"
     extra_hosts:
       - "host.docker.internal:host-gateway"
 ```
 
-Generate a bearer token (this is what ChatGPT will send on every
-request — independent from your MNEMOS API key):
+Generate a bearer token (this is what ChatGPT will send on every request).
+`MNEMOS_MCP_TOKENS` maps that edge token to a backend MNEMOS API key; the
+legacy single-user `MNEMOS_MCP_TOKEN` mode still exists but shares one backend
+principal for every client:
 
 ```bash
 export MNEMOS_MCP_TOKEN="$(openssl rand -hex 32)"
@@ -159,7 +161,8 @@ ChatGPT → Settings → Developer Mode → Connectors → Add custom
 
 Click Save. ChatGPT will hit the URL, complete the SSE handshake, and
 list the available tools (search_memories, create_memory, get_memory,
-list_memories, kg_create_triple, kg_search, etc. — all 13).
+list_memories, kg_create_triple, kg_search, DAG tools, recommend_model, etc. —
+all 18).
 
 ### 4. Use it
 
@@ -173,32 +176,29 @@ Ask things like:
 ChatGPT calls MNEMOS's MCP tools and folds the results into the
 conversation. Same memory is visible from your other agents.
 
-## Setup — assisted path (planned, v3.4)
+## Setup — assisted path (experimental helper)
 
-The `mnemos-tunnel-setup` helper (`scripts/mnemos_tunnel_setup.py` in
-the repo today, daemon-side endpoints land in v3.4) will collapse the
-above into:
+The `mnemos-tunnel-setup` helper (`scripts/mnemos_tunnel_setup.py`) is checked
+in as an experimental contract. It calls daemon-side `/admin/tunnels/*`
+endpoints; use the manual path above unless those endpoints are enabled in
+your deployment.
 
 ```bash
 mnemos-tunnel-setup chatgpt
 ```
 
-The script walks you through ngrok signup, opens the tunnel, generates
-the token, prints the connector config, and copies URL+token to your
-clipboard. The script is checked in now as the user-facing contract;
-the daemon-side `/admin/tunnels/*` endpoints it calls will ship in
-v3.4. Until then, use the manual path above.
+The script walks you through ngrok signup, opens the tunnel, generates the
+token, prints the connector config, and copies URL+token to your clipboard.
 
 ## Operational notes
 
 - **Token rotation**: change `MNEMOS_MCP_TOKEN`, restart the
   `mnemos-mcp-http` service, update the connector in ChatGPT.
   No coordination with stdio agents needed — they don't use this token.
-- **Single shared token model**: every ChatGPT user sharing this
-  connector URL uses the same bearer token, so they all write to the
-  same MNEMOS namespace. For multi-user separation, run separate
-  tunnels per user with separate tokens, OR wait for the v3.5 OAuth
-  + per-user attribution work.
+- **Per-user token model**: prefer `MNEMOS_MCP_TOKENS` so each connector
+  bearer maps to a backend user/API key. The legacy `MNEMOS_MCP_TOKEN`
+  mode is single-user only; every client sharing it writes as the same
+  backend principal.
 - **Audit trail**: every connector-driven write goes through
   `/v1/memories` exactly like a normal API call, so the version DAG,
   webhooks, MORPHEUS run tagging, and federation all observe it.
@@ -213,8 +213,9 @@ v3.4. Until then, use the manual path above.
 - **TLS is the tunnel's responsibility**: `mcp_http_server.py` listens
   on plain HTTP. Never bind it to a public IP without the tunnel
   providing TLS termination.
-- **No OAuth yet**: bearer auth only. Anyone with the token can
-  read/write your memory. Treat the token like an SSH private key.
+- **No OAuth on the MCP edge yet**: bearer auth only. Anyone with the token can
+  read/write as the mapped backend principal. Treat the token like an SSH
+  private key.
 - **Connector tool list updates require reconnect**: if MNEMOS adds
   new tools (e.g., MORPHEUS slice 2 endpoints), ChatGPT may need the
   connector removed and re-added to pick them up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemos-os"
-version = "3.4.1"
+version = "3.5.1"
 description = "MNEMOS-OS v3: Unified memory operating system with GRAEAE reasoning, DAG versioning, compression, and cost-aware routing"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -280,7 +280,7 @@ class TestDockerIntegration:
         pyproject_path = Path(__file__).parent.parent / 'pyproject.toml'
         assert pyproject_path.exists(), "pyproject.toml not found"
         content = pyproject_path.read_text()
-        assert 'version = "3.4.1"' in content, "Version not at 3.4.1"
+        assert 'version = "3.5.1"' in content, "Version not at 3.5.1"
 
     def test_pyproject_toml_has_uv_config(self):
         """pyproject.toml has uv configuration."""

--- a/tests/test_v3_integration.py
+++ b/tests/test_v3_integration.py
@@ -233,7 +233,7 @@ class TestVersions:
         resp = await client.get("/health")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["version"] == "3.4.1"
+        assert data["version"] == "3.5.1"
 
     async def test_api_version_in_responses(self, client: AsyncClient, auth_headers: dict):
         resp = await client.get("/v1/providers/health", headers=auth_headers)


### PR DESCRIPTION
## Summary
v3.5.0 was tagged briefly during release prep but pulled before public announcement when a metadata + doc-currency review surfaced inconsistencies (`pyproject.toml` still at `3.4.1`, `README` still framing `v3.5-dev` as unreleased, retired subsystems still surfaced as live features). v3.5.1 is the canonical v3.5 GA tag.

### What changed (30 files, +646/-807)

**Version metadata.** `pyproject.toml` and `_version.py` bumped to `3.5.1`. CHANGELOG split into shipped sections (v3.5.0 GA + v3.5.1 doc-triage patch) — though only v3.5.1 will be tagged publicly.

**Retired-subsystem cleanup** (slice 5 work). LETHE / ANAMNESIS / ALETHEIA / `CompressionManager` / `DistillationEngine` compatibility wrapper references stripped from current-state docs (README, SPECIFICATION, ROADMAP, GRAEAE_FEATURES — `docs/GRAEAE_FEATURES.md` alone shed 470+ lines of stale content). Historical references in CHANGELOG / EVOLUTION preserved as factual record.

**Underdocumented v3.2–v3.5 features surfaced.** Per-user namespace tenancy (v3.2), MORPHEUS dream-state generator (v3.3), recall tracking (v3.3), CHARON federation schema-compat preflight (v3.4), MPF Memory Portability Format (v3.4), deletion log + tombstones (v3.5), webhook outbox pattern (v3.5), faithful OpenAI compat (v3.5), streaming replication doctrine (v3.5), namespace-uniform tenancy across the whole product surface (v3.5).

**Forward-looking docs reconciled.** `docs/V3_5_CHARTER.md` marked SHIPPED; `docs/V3_6_CHARTER.md` + `docs/V4_PLAN.md` clarified to distinguish planned-vs-shipped. ROADMAP narrative reflects v3.5.x current state instead of "v3.5 in flight."

**Connector + integration docs.** ChatGPT Pro developer-mode doc, connector README, integrations README all updated.

**Test version pins** updated in `tests/test_integration.py` + `tests/test_v3_integration.py`.

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_*namespace_isolation.py --ignore=tests/test_ingest_owner_namespace.py` — **913 passed**, 18 skipped, 0 regressions
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [ ] GitHub `pr-check.yml`

## Squash plan
After merge, the v3.5-dev tip becomes the v3.5.1 tag. Old v3.5.0 tag + GitHub release have been deleted from origin / gitlab / argonas / local — **v3.5.1 is the canonical v3.5 GA**. Public announcement parked until this PR lands.

Authored-By: Codex