### PR TITLE
v4.0 A.6: unified mnemos CLI — closes Phase A

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ EXPOSE 5002
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5002/health').read()" || exit 1
 
-CMD ["python", "-m", "mnemos.api.main"]
+CMD ["mnemos", "serve"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -138,6 +138,7 @@ services:
   mnemos:
     build:
       context: .
+    command: ["mnemos", "serve"]
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
   mnemos:
     build:
       context: .
+    command: ["mnemos", "serve"]
     depends_on:
       postgres:
         condition: service_healthy

--- a/mnemos.service
+++ b/mnemos.service
@@ -14,7 +14,8 @@ Environment="MNEMOS_PORT=5002"
 EnvironmentFile=/opt/mnemos/.env
 # Canonical port is 5002; this overrides [api].port in config.toml if different
 # MNEMOS v3.5 is single-worker by design; do not configure multiple Uvicorn workers.
-ExecStart=/opt/mnemos/venv/bin/python -m mnemos.api.main
+# Keep the venv path explicit so systemd uses the installed console script.
+ExecStart=/opt/mnemos/venv/bin/mnemos serve
 
 # Auto-restart on failure
 Restart=on-failure

--- a/mnemos/cli/main.py
+++ b/mnemos/cli/main.py
@@ -1,8 +1,528 @@
-"""Placeholder CLI entry point for the v4 package layout."""
+"""Unified MNEMOS command line interface."""
+
+import asyncio
+import inspect
+import json
+import os
+import sys
+from contextlib import contextmanager
+from enum import Enum
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+import httpx
+import typer
 
 
-def app() -> None:
-    print("CLI not yet implemented (lands in A.6)")
+def _patch_typer_click_compat() -> None:
+    """Keep Typer 0.9 usable with newer Click releases in older envs."""
+    try:
+        from typer.core import TyperArgument, TyperOption
+
+        if len(inspect.signature(TyperArgument.make_metavar).parameters) == 1:
+
+            def make_metavar(self: Any, ctx: Any = None) -> str:
+                if self.metavar is not None:
+                    return self.metavar
+                var = (self.name or "").upper()
+                if not self.required:
+                    var = f"[{var}]"
+                try:
+                    type_var = self.type.get_metavar(self, ctx)
+                except TypeError:
+                    type_var = self.type.get_metavar(self)
+                if type_var:
+                    var += f":{type_var}"
+                if self.nargs != 1:
+                    var += "..."
+                return var
+
+            TyperArgument.make_metavar = make_metavar
+
+        original_option_init = TyperOption.__init__
+
+        if not getattr(TyperOption.__init__, "_mnemos_click_compat", False):
+
+            def option_init(self: Any, **kwargs: Any) -> None:
+                if kwargs.get("is_flag") is True and kwargs.get("flag_value") is None:
+                    kwargs["type"] = None
+                    kwargs["flag_value"] = True
+                if (
+                    kwargs.get("is_flag") is None
+                    and kwargs.get("flag_value") is None
+                    and not kwargs.get("count", False)
+                ):
+                    kwargs["is_flag"] = False
+                original_option_init(self, **kwargs)
+
+            option_init._mnemos_click_compat = True
+            TyperOption.__init__ = option_init
+
+        if len(inspect.signature(TyperOption.make_metavar).parameters) == 2:
+            original_option_make_metavar = TyperOption.make_metavar
+
+            def option_make_metavar(self: Any, ctx: Any = None) -> str:
+                return original_option_make_metavar(self, ctx)
+
+            TyperOption.make_metavar = option_make_metavar
+    except Exception:
+        return
+
+
+_patch_typer_click_compat()
+
+
+class ExportFormat(str, Enum):
+    mpf = "mpf"
+    jsonl = "jsonl"
+    markdown = "markdown"
+    html = "html"
+    text = "text"
+
+
+class ImportSource(str, Enum):
+    mpf = "mpf"
+    mem0 = "mem0"
+    letta = "letta"
+    graphiti = "graphiti"
+    cognee = "cognee"
+    mempalace = "mempalace"
+    docling = "docling"
+
+
+class ConsultMode(str, Enum):
+    auto = "auto"
+    consensus = "consensus"
+    debate = "debate"
+    single = "single"
+
+
+EXPORT_DISPATCH: dict[str, str] = {
+    "mpf": "mnemos.tools.memory_export",
+    "jsonl": "mnemos.tools.memory_export",
+    "markdown": "mnemos.tools.export_memories_for_docling",
+    "html": "mnemos.tools.export_memories_for_docling",
+    "text": "mnemos.tools.export_memories_for_docling",
+}
+
+IMPORT_DISPATCH: dict[str, str] = {
+    "mpf": "mnemos.tools.memory_import",
+    "docling": "mnemos.tools.docling_import",
+    "mem0": "mnemos.tools.adapters.mem0",
+    "letta": "mnemos.tools.adapters.letta",
+    "graphiti": "mnemos.tools.adapters.graphiti",
+    "cognee": "mnemos.tools.adapters.cognee",
+    "mempalace": "mnemos.tools.adapters.mempalace",
+}
+
+_EXPORT_TOOL_SUBCOMMANDS: dict[ExportFormat, str] = {
+    ExportFormat.mpf: "json",
+    ExportFormat.jsonl: "jsonl",
+    ExportFormat.markdown: "markdown",
+    ExportFormat.html: "html",
+    ExportFormat.text: "text",
+}
+
+app = typer.Typer(help="Unified MNEMOS command line interface.", no_args_is_help=True)
+serve_app = typer.Typer(
+    help="Run MNEMOS API and MCP servers.",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+worker_app = typer.Typer(help="Run MNEMOS background workers.", no_args_is_help=True)
+
+
+@contextmanager
+def _patched_argv(prog: str, argv: Sequence[str]):
+    original = sys.argv[:]
+    sys.argv = [prog, *argv]
+    try:
+        yield
+    finally:
+        sys.argv = original
+
+
+def _main_accepts_argv(main: Callable[..., Any]) -> bool:
+    try:
+        signature = inspect.signature(main)
+    except (TypeError, ValueError):
+        return False
+    return bool(signature.parameters)
+
+
+def _raise_for_int_result(result: Any) -> None:
+    if isinstance(result, int):
+        raise typer.Exit(result)
+
+
+def _run_module_main(module_name: str, argv: Sequence[str] = (), *, prog: Optional[str] = None) -> None:
+    module = import_module(module_name)
+    main = getattr(module, "main")
+
+    if inspect.iscoroutinefunction(main):
+        if argv:
+            raise typer.BadParameter(f"{module_name}.main() does not accept argv")
+        _raise_for_int_result(asyncio.run(main()))
+        return
+
+    if _main_accepts_argv(main):
+        _raise_for_int_result(main(list(argv)))
+        return
+
+    with _patched_argv(prog or module_name, argv):
+        _raise_for_int_result(main())
+
+
+def _run_async_module_main(module_name: str) -> None:
+    module = import_module(module_name)
+    _raise_for_int_result(asyncio.run(module.main()))
+
+
+def _api_env(require_key: bool) -> tuple[str, dict[str, str]]:
+    base = os.getenv("MNEMOS_BASE")
+    api_key = os.getenv("MNEMOS_API_KEY")
+
+    if not base:
+        typer.echo(
+            "ERROR: MNEMOS_BASE is not set. Example: export MNEMOS_BASE=http://localhost:5002",
+            err=True,
+        )
+        raise typer.Exit(2)
+    if require_key and not api_key:
+        typer.echo(
+            "ERROR: MNEMOS_API_KEY is not set. Export a bearer token for this command.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return base.rstrip("/"), headers
+
+
+def _append_env_endpoint(argv: list[str]) -> None:
+    base = os.getenv("MNEMOS_BASE")
+    api_key = os.getenv("MNEMOS_API_KEY")
+    if base:
+        argv.extend(["--endpoint", base])
+    if api_key:
+        argv.extend(["--api-key", api_key])
+
+
+def _has_adapter_target(args: Sequence[str]) -> bool:
+    for arg in args:
+        if arg in {"--out", "--post"} or arg.startswith("--out=") or arg.startswith("--post="):
+            return True
+    return False
+
+
+def _append_adapter_target(argv: list[str], extra_args: Sequence[str]) -> None:
+    if _has_adapter_target(extra_args):
+        return
+    base, headers = _api_env(require_key=True)
+    token = headers["Authorization"].removeprefix("Bearer ")
+    argv.extend(["--post", base, "--api-key", token])
+
+
+def _echo_json_response(response: httpx.Response) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        typer.echo(f"ERROR: HTTP {exc.response.status_code}: {exc.response.text[:500]}", err=True)
+        raise typer.Exit(1) from exc
+
+    try:
+        payload = response.json()
+    except ValueError:
+        typer.echo(response.text)
+        return
+    typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _infer_import_source(source: Path) -> ImportSource:
+    if source.suffix.lower() in {".mpf", ".json", ".jsonl"}:
+        return ImportSource.mpf
+    typer.echo(
+        "ERROR: Could not infer import source. Pass --from mpf, mem0, letta, graphiti, cognee, "
+        "mempalace, or docling.",
+        err=True,
+    )
+    raise typer.Exit(2)
+
+
+def _parse_export_format(format_name: str) -> ExportFormat:
+    try:
+        return ExportFormat(format_name.lower())
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in ExportFormat)
+        typer.echo(f"ERROR: --format must be one of: {valid}", err=True)
+        raise typer.Exit(2) from exc
+
+
+def _parse_import_source(source_name: Optional[str], source: Path) -> ImportSource:
+    if source_name is None:
+        return _infer_import_source(source)
+    try:
+        return ImportSource(source_name.lower())
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in ImportSource)
+        typer.echo(f"ERROR: --from must be one of: {valid}", err=True)
+        raise typer.Exit(2) from exc
+
+
+def _parse_consult_mode(mode: str) -> ConsultMode:
+    try:
+        return ConsultMode(mode.lower())
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in ConsultMode)
+        typer.echo(f"ERROR: --mode must be one of: {valid}", err=True)
+        raise typer.Exit(2) from exc
+
+
+def _adapter_source_args(import_from: ImportSource, source: Path) -> list[str]:
+    source_text = str(source)
+
+    if import_from == ImportSource.mem0:
+        if source_text.startswith(("http://", "https://")):
+            return ["--qdrant-url", source_text]
+        return ["--qdrant-path", source_text]
+
+    if import_from == ImportSource.letta:
+        if source_text.startswith(("http://", "https://")):
+            return ["--mode", "server", "--base", source_text]
+        return ["--mode", "sqlite", "--db", source_text]
+
+    if import_from == ImportSource.graphiti:
+        if source.exists() and source.is_dir():
+            return ["--backend", "kuzu", "--kuzu-db", source_text]
+        return ["--neo4j", source_text]
+
+    if import_from == ImportSource.cognee:
+        return ["--dataset", source_text]
+
+    if import_from == ImportSource.mempalace:
+        return ["--palace", source_text]
+
+    raise typer.BadParameter(f"Unsupported adapter source: {import_from.value}")
+
+
+@serve_app.callback()
+def serve(
+    ctx: typer.Context,
+    host: str = typer.Option("0.0.0.0", "--host", help="API bind address.", is_flag=False),
+    port: int = typer.Option(5002, "--port", help="API listen port.", is_flag=False),
+    workers: int = typer.Option(
+        1,
+        "--workers",
+        is_flag=False,
+        help=(
+            "Uvicorn worker count. Values above 1 are not recommended until "
+            "the Phase C Redis primitives land."
+        ),
+    ),
+) -> None:
+    """Run the MNEMOS FastAPI server."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if workers > 1:
+        typer.echo(
+            "WARNING: workers > 1 is not recommended until v4.0 Phase C lands shared Redis primitives.",
+            err=True,
+        )
+
+    import uvicorn
+
+    uvicorn.run("mnemos.api.main:app", host=host, port=port, workers=workers)
+
+
+@serve_app.command("mcp-stdio")
+def serve_mcp_stdio() -> None:
+    """Run the stdio MCP transport for Claude Code, OpenClaw, and ZeroClaw."""
+    _run_async_module_main("mnemos.mcp.stdio")
+
+
+@serve_app.command("mcp-http")
+def serve_mcp_http(
+    host: str = typer.Option("0.0.0.0", "--host", help="MCP HTTP bind address.", is_flag=False),
+    port: int = typer.Option(5003, "--port", help="MCP HTTP listen port.", is_flag=False),
+) -> None:
+    """Run the HTTP/SSE MCP transport."""
+    _run_module_main(
+        "mnemos.mcp.http",
+        ["--host", host, "--port", str(port)],
+        prog="mnemos serve mcp-http",
+    )
+
+
+@worker_app.command("distillation")
+def worker_distillation() -> None:
+    """Run the compression contest distillation worker."""
+    _run_async_module_main("mnemos.workers.distillation")
+
+
+@app.command()
+def install(
+    agent: bool = typer.Option(False, "--agent", help="LLM-guided installation."),
+    wizard: bool = typer.Option(False, "--wizard", help="Traditional interactive wizard."),
+    unattended: bool = typer.Option(False, "--unattended", help="Non-interactive environment-driven install."),
+    upgrade: bool = typer.Option(False, "--upgrade", help="Re-run migrations only."),
+    check: bool = typer.Option(False, "--check", help="Run environment checks only."),
+) -> None:
+    """Run the MNEMOS install wizard."""
+    selected_modes = sum(bool(value) for value in (agent, wizard, unattended))
+    if selected_modes > 1:
+        typer.echo("ERROR: choose only one of --agent, --wizard, or --unattended.", err=True)
+        raise typer.Exit(2)
+
+    argv: list[str] = []
+    if agent:
+        argv.append("--agent")
+    if wizard:
+        argv.append("--wizard")
+    if unattended:
+        argv.append("--unattended")
+    if upgrade:
+        argv.append("--upgrade")
+    if check:
+        argv.append("--check")
+
+    _run_module_main("mnemos.installer.__main__", argv, prog="mnemos install")
+
+
+@app.command("export")
+def export_memories(
+    format_: str = typer.Option(
+        "mpf",
+        "--format",
+        help="Export format: mpf, jsonl, markdown, html, or text.",
+        is_flag=False,
+    ),
+    out: Path = typer.Option(..., "--out", help="Output file path.", is_flag=False),
+    owner_id: Optional[str] = typer.Option(None, "--owner-id", help="Filter by owner id.", is_flag=False),
+    namespace: Optional[str] = typer.Option(None, "--namespace", help="Filter by namespace.", is_flag=False),
+) -> None:
+    """Export memories through the existing portability tools."""
+    export_format = _parse_export_format(format_)
+    argv = [_EXPORT_TOOL_SUBCOMMANDS[export_format], "--out", str(out)]
+    if owner_id:
+        argv.extend(["--owner-id", owner_id])
+    if namespace:
+        argv.extend(["--namespace", namespace])
+    _append_env_endpoint(argv)
+    _run_module_main("mnemos.tools.memory_export", argv)
+
+
+@app.command("import")
+def import_memories(
+    source: Path = typer.Argument(..., help="Source file, directory, endpoint, or foreign-system locator."),
+    import_from: Optional[str] = typer.Option(None, "--from", help="Source system.", is_flag=False),
+    owner_id: Optional[str] = typer.Option(
+        None,
+        "--owner-id",
+        help="Override imported owner id when supported.",
+        is_flag=False,
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="Override imported namespace when supported.",
+        is_flag=False,
+    ),
+    preserve_owner: bool = typer.Option(False, "--preserve-owner", help="Preserve source MPF ownership metadata."),
+) -> None:
+    """Import memories through the existing portability tools and adapters."""
+    selected_source = _parse_import_source(import_from, source)
+    extra_args: list[str] = []
+
+    if selected_source == ImportSource.mpf:
+        argv = ["json", "--file", str(source)]
+        if source.suffix.lower() == ".jsonl":
+            argv.append("--jsonl")
+        if preserve_owner:
+            argv.append("--preserve-metadata")
+        if owner_id:
+            argv.extend(["--owner-id", owner_id])
+        if namespace:
+            argv.extend(["--namespace", namespace])
+        _append_env_endpoint(argv)
+        argv.extend(extra_args)
+        _run_module_main(IMPORT_DISPATCH[selected_source.value], argv)
+        return
+
+    if selected_source == ImportSource.docling:
+        argv = ["--source" if source.exists() and source.is_dir() else "--file", str(source)]
+        if owner_id:
+            argv.extend(["--owner-id", owner_id])
+        if namespace:
+            argv.extend(["--namespace", namespace])
+        _append_env_endpoint(argv)
+        argv.extend(extra_args)
+        _run_module_main(IMPORT_DISPATCH[selected_source.value], argv)
+        return
+
+    argv = _adapter_source_args(selected_source, source)
+    _append_adapter_target(argv, extra_args)
+    argv.extend(extra_args)
+    _run_module_main(IMPORT_DISPATCH[selected_source.value], argv)
+
+
+@app.command("validate-mpf")
+def validate_mpf(envelope_path: Path = typer.Argument(..., help="MPF envelope path.")) -> None:
+    """Validate an MPF envelope."""
+    _run_module_main("mnemos.tools.mpf_validate", ["--file", str(envelope_path)])
+
+
+@app.command()
+def consult(
+    prompt: str = typer.Argument(..., help="Prompt to send to GRAEAE."),
+    mode: str = typer.Option(
+        "auto",
+        "--mode",
+        help="Consultation mode: auto, consensus, debate, or single.",
+        is_flag=False,
+    ),
+    task_type: Optional[str] = typer.Option(None, "--task-type", help="Task type for routing.", is_flag=False),
+) -> None:
+    """Create a consultation against the configured MNEMOS API."""
+    base, headers = _api_env(require_key=True)
+    consult_mode = _parse_consult_mode(mode)
+    payload: dict[str, Any] = {"prompt": prompt, "mode": consult_mode.value}
+    if task_type:
+        payload["task_type"] = task_type
+
+    try:
+        response = httpx.post(f"{base}/v1/consultations", json=payload, headers=headers, timeout=120)
+    except httpx.RequestError as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    _echo_json_response(response)
+
+
+@app.command()
+def health() -> None:
+    """Check the configured MNEMOS API health endpoint."""
+    base, headers = _api_env(require_key=False)
+    try:
+        response = httpx.get(f"{base}/health", headers=headers, timeout=30)
+    except httpx.RequestError as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    _echo_json_response(response)
+
+
+@app.command()
+def version() -> None:
+    """Print the installed MNEMOS version."""
+    from mnemos._version import __version__
+
+    typer.echo(__version__)
+
+
+app.add_typer(serve_app, name="serve")
+app.add_typer(worker_app, name="worker")
 
 
 if __name__ == "__main__":

--- a/mnemos/tools/docling_import.py
+++ b/mnemos/tools/docling_import.py
@@ -39,6 +39,8 @@ class DoclingImporter:
         overlap: int = 100,
         tags: list = None,
         dry_run: bool = False,
+        owner_id: str = None,
+        namespace: str = None,
     ):
         """
         Args:
@@ -57,6 +59,8 @@ class DoclingImporter:
         self.overlap = overlap
         self.tags = tags or []
         self.dry_run = dry_run
+        self.owner_id = owner_id
+        self.namespace = namespace
 
     # ------------------------------------------------------------------
     # Public API
@@ -326,6 +330,10 @@ class DoclingImporter:
                 "tags": list(self.tags),
                 "metadata": dict(metadata),
             }
+            if self.owner_id is not None:
+                mem["owner_id"] = self.owner_id
+            if self.namespace is not None:
+                mem["namespace"] = self.namespace
             # Attach source tags automatically
             source = metadata.get("source_file", "")
             if source:
@@ -433,6 +441,10 @@ Examples:
                         help="Recurse into sub-directories (only with --source)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print what would be imported without POSTing")
+    parser.add_argument("--owner-id", default=None,
+                        help="Override owner_id on imported memories when supported")
+    parser.add_argument("--namespace", default=None,
+                        help="Override namespace on imported memories when supported")
     return parser
 
 
@@ -450,6 +462,8 @@ def main(argv=None):
         overlap=args.overlap,
         tags=tags,
         dry_run=args.dry_run,
+        owner_id=args.owner_id,
+        namespace=args.namespace,
     )
 
     if args.file:

--- a/mnemos/tools/memory_export.py
+++ b/mnemos/tools/memory_export.py
@@ -49,6 +49,8 @@ def _fetch_export(
     api_key: Optional[str],
     category: Optional[str],
     limit: int,
+    owner_id: Optional[str] = None,
+    namespace: Optional[str] = None,
     include_sidecars: bool = False,
     include_unattached_kg: bool = False,
 ) -> Dict[str, Any]:
@@ -67,6 +69,10 @@ def _fetch_export(
     params: Dict[str, str] = {"limit": str(limit)}
     if category:
         params["category"] = category
+    if owner_id:
+        params["owner_id"] = owner_id
+    if namespace:
+        params["namespace"] = namespace
     if include_sidecars:
         params["include_sidecars"] = "true"
         # CLI default matches HTTP default (false). Common CLI
@@ -103,6 +109,8 @@ def _fetch_memories_flat(
     api_key: Optional[str],
     category: Optional[str],
     limit: int,
+    owner_id: Optional[str] = None,
+    namespace: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Flat memory fetch for markdown/html/text paths.
 
@@ -111,7 +119,7 @@ def _fetch_memories_flat(
     export envelope.
     """
     # Prefer /v1/export (keeps all provenance) and flatten records.
-    envelope = _fetch_export(endpoint, api_key, category, limit)
+    envelope = _fetch_export(endpoint, api_key, category, limit, owner_id, namespace)
     flat: List[Dict[str, Any]] = []
     for rec in envelope.get("records") or []:
         if rec.get("kind") != "memory":
@@ -125,6 +133,8 @@ def _fetch_memories_flat(
 def cmd_json(args: argparse.Namespace) -> None:
     envelope = _fetch_export(
         args.endpoint, args.api_key, args.category, args.limit,
+        owner_id=getattr(args, "owner_id", None),
+        namespace=getattr(args, "namespace", None),
         include_sidecars=getattr(args, "include_sidecars", False),
         include_unattached_kg=getattr(args, "include_unattached_kg", False),
     )
@@ -144,6 +154,8 @@ def cmd_json(args: argparse.Namespace) -> None:
 def cmd_jsonl(args: argparse.Namespace) -> None:
     envelope = _fetch_export(
         args.endpoint, args.api_key, args.category, args.limit,
+        owner_id=getattr(args, "owner_id", None),
+        namespace=getattr(args, "namespace", None),
         include_sidecars=getattr(args, "include_sidecars", False),
         include_unattached_kg=getattr(args, "include_unattached_kg", False),
     )
@@ -178,7 +190,9 @@ def cmd_markdown(args: argparse.Namespace) -> None:
         sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
         from mnemos.tools.export_memories_for_docling import export_memories_markdown  # noqa
     memories = _fetch_memories_flat(args.endpoint, args.api_key,
-                                    args.category, args.limit)
+                                    args.category, args.limit,
+                                    getattr(args, "owner_id", None),
+                                    getattr(args, "namespace", None))
     out = Path(args.out)
     export_memories_markdown(memories, out)
     print(f"Wrote {len(memories)} memories as Markdown → {out}")
@@ -191,7 +205,9 @@ def cmd_html(args: argparse.Namespace) -> None:
         sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
         from mnemos.tools.export_memories_for_docling import export_memories_html  # noqa
     memories = _fetch_memories_flat(args.endpoint, args.api_key,
-                                    args.category, args.limit)
+                                    args.category, args.limit,
+                                    getattr(args, "owner_id", None),
+                                    getattr(args, "namespace", None))
     out = Path(args.out)
     export_memories_html(memories, out)
     print(f"Wrote {len(memories)} memories as HTML → {out}")
@@ -204,7 +220,9 @@ def cmd_text(args: argparse.Namespace) -> None:
         sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
         from mnemos.tools.export_memories_for_docling import export_memories_plaintext  # noqa
     memories = _fetch_memories_flat(args.endpoint, args.api_key,
-                                    args.category, args.limit)
+                                    args.category, args.limit,
+                                    getattr(args, "owner_id", None),
+                                    getattr(args, "namespace", None))
     out = Path(args.out)
     export_memories_plaintext(memories, out)
     print(f"Wrote {len(memories)} memories as plain text → {out}")
@@ -235,6 +253,10 @@ def _add_fetch_args(p: argparse.ArgumentParser) -> None:
                    help="Output file path")
     p.add_argument("--category", default=None,
                    help="Filter memories by category (all if omitted)")
+    p.add_argument("--owner-id", default=None,
+                   help="Filter memories by owner_id (all visible owners if omitted)")
+    p.add_argument("--namespace", default=None,
+                   help="Filter memories by namespace (all visible namespaces if omitted)")
     p.add_argument("--limit", type=int, default=10_000,
                    help="Maximum number of memories (default: 10000). "
                         "Matches the server-side _EXPORT_HARD_LIMIT.")

--- a/mnemos/tools/memory_import.py
+++ b/mnemos/tools/memory_import.py
@@ -93,11 +93,15 @@ class BaseImporter:
         category: str = "imported",
         dry_run: bool = False,
         preserve_metadata: bool = False,
+        owner_id: str = None,
+        namespace: str = None,
     ):
         self.endpoint = endpoint.rstrip("/")
         self.api_key = api_key
         self.category = category
         self.dry_run = dry_run
+        self.owner_id = owner_id
+        self.namespace = namespace
         # preserve_metadata routes through /v1/import (MPF envelope)
         # with preserve_owner=true, which requires a root bearer token
         # and keeps id/owner_id/namespace/timestamps verbatim.
@@ -114,6 +118,16 @@ class BaseImporter:
         # server's per-transaction trigger guard (mnemos_charon_trigger_guard
         # migration) cover the whole import in one shot.
         self.source_envelope: Optional[Dict[str, Any]] = None
+
+    def _apply_scope_overrides(self, mem: dict) -> dict:
+        if self.owner_id is None and self.namespace is None:
+            return mem
+        scoped = dict(mem)
+        if self.owner_id is not None:
+            scoped["owner_id"] = self.owner_id
+        if self.namespace is not None:
+            scoped["namespace"] = self.namespace
+        return scoped
 
     def _post(self, memories: list) -> tuple:
         """POST a list of memories to MNEMOS.
@@ -135,13 +149,14 @@ class BaseImporter:
             # which leaves a window where the version-snapshot
             # trigger fires on the records batch before the sidecar
             # trailer arrives — collisions on (memory_id, version_num).
-            if self.source_envelope is not None:
+            if self.source_envelope is not None and self.owner_id is None and self.namespace is None:
                 return self._post_mpf_passthrough(memories)
             return self._post_mpf(memories)
 
         ok = 0
         fail = 0
         for mem in memories:
+            mem = self._apply_scope_overrides(mem)
             if self.dry_run:
                 preview = str(mem.get("content", ""))[:100].replace("\n", " ")
                 cat = mem.get("category", self.category)
@@ -199,8 +214,8 @@ class BaseImporter:
                 "subcategory": mem.get("subcategory"),
                 "created": mem.get("created"),
                 "updated": mem.get("updated"),
-                "owner_id": mem.get("owner_id") or "default",
-                "namespace": mem.get("namespace") or "default",
+                "owner_id": self.owner_id or mem.get("owner_id") or "default",
+                "namespace": self.namespace or mem.get("namespace") or "default",
                 "permission_mode": mem.get("permission_mode"),
                 "quality_rating": mem.get("quality_rating"),
                 "metadata": mem.get("metadata") or {},
@@ -1145,6 +1160,10 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
                         help="Route through /v1/import (MPF envelope, batched) "
                              "keeping id/owner_id/namespace/timestamps verbatim. "
                              "Requires root bearer token.")
+    parser.add_argument("--owner-id", default=None,
+                        help="Override owner_id on imported memories when supported")
+    parser.add_argument("--namespace", default=None,
+                        help="Override namespace on imported memories when supported")
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1230,6 +1249,10 @@ def main(argv=None):
     )
     if hasattr(args, "preserve_metadata"):
         common["preserve_metadata"] = args.preserve_metadata
+    if hasattr(args, "owner_id"):
+        common["owner_id"] = args.owner_id
+    if hasattr(args, "namespace"):
+        common["namespace"] = args.namespace
 
     if args.subcommand == "json":
         importer = JsonImporter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "authlib>=1.3.0",
   "itsdangerous>=2.2.0",
   "prometheus_client>=0.20.0",
+  "typer>=0.9.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ anyio>=4.4.0
 # Utilities
 numpy>=1.26.0
 psutil>=5.9.0
+typer>=0.9.0
 
 # Optional: Intel OpenVINO / phi_server.py (local GPU inference)
 # Install on GPU systems only: pip install mnemos-os[phi]

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from mnemos._version import __version__
+from mnemos.cli import main as cli_main
+
+
+runner = CliRunner()
+
+
+def test_top_level_help_lists_all_subcommands() -> None:
+    result = runner.invoke(cli_main.app, ["--help"])
+
+    assert result.exit_code == 0
+    for command in (
+        "serve",
+        "worker",
+        "install",
+        "export",
+        "import",
+        "validate-mpf",
+        "consult",
+        "health",
+        "version",
+    ):
+        assert command in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["serve", "--help"],
+        ["serve", "mcp-stdio", "--help"],
+        ["serve", "mcp-http", "--help"],
+        ["worker", "--help"],
+        ["worker", "distillation", "--help"],
+        ["install", "--help"],
+        ["export", "--help"],
+        ["import", "--help"],
+        ["validate-mpf", "--help"],
+        ["consult", "--help"],
+        ["health", "--help"],
+        ["version", "--help"],
+    ],
+)
+def test_subcommand_help_works(args: list[str]) -> None:
+    result = runner.invoke(cli_main.app, args)
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+def test_version_prints_package_version() -> None:
+    result = runner.invoke(cli_main.app, ["version"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == __version__
+
+
+def test_dispatch_table_is_complete() -> None:
+    assert cli_main.EXPORT_DISPATCH == {
+        "mpf": "mnemos.tools.memory_export",
+        "jsonl": "mnemos.tools.memory_export",
+        "markdown": "mnemos.tools.export_memories_for_docling",
+        "html": "mnemos.tools.export_memories_for_docling",
+        "text": "mnemos.tools.export_memories_for_docling",
+    }
+    assert cli_main.IMPORT_DISPATCH == {
+        "mpf": "mnemos.tools.memory_import",
+        "docling": "mnemos.tools.docling_import",
+        "mem0": "mnemos.tools.adapters.mem0",
+        "letta": "mnemos.tools.adapters.letta",
+        "graphiti": "mnemos.tools.adapters.graphiti",
+        "cognee": "mnemos.tools.adapters.cognee",
+        "mempalace": "mnemos.tools.adapters.mempalace",
+    }
+
+
+def test_validate_mpf_dispatches_to_validator(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_run_module_main(module: str, argv: list[str], **_kwargs) -> None:
+        calls.append((module, argv))
+
+    monkeypatch.setattr(cli_main, "_run_module_main", fake_run_module_main)
+
+    result = runner.invoke(cli_main.app, ["validate-mpf", "memory.mpf"])
+
+    assert result.exit_code == 0
+    assert calls == [("mnemos.tools.mpf_validate", ["--file", "memory.mpf"])]
+
+
+def test_export_dispatches_to_memory_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_run_module_main(module: str, argv: list[str], **_kwargs) -> None:
+        calls.append((module, argv))
+
+    monkeypatch.delenv("MNEMOS_BASE", raising=False)
+    monkeypatch.delenv("MNEMOS_API_KEY", raising=False)
+    monkeypatch.setattr(cli_main, "_run_module_main", fake_run_module_main)
+
+    result = runner.invoke(
+        cli_main.app,
+        ["export", "--format", "jsonl", "--out", "memories.jsonl", "--owner-id", "alice", "--namespace", "lab"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "mnemos.tools.memory_export",
+            ["jsonl", "--out", "memories.jsonl", "--owner-id", "alice", "--namespace", "lab"],
+        )
+    ]
+
+
+def test_mpf_import_dispatches_to_memory_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_run_module_main(module: str, argv: list[str], **_kwargs) -> None:
+        calls.append((module, argv))
+
+    monkeypatch.delenv("MNEMOS_BASE", raising=False)
+    monkeypatch.delenv("MNEMOS_API_KEY", raising=False)
+    monkeypatch.setattr(cli_main, "_run_module_main", fake_run_module_main)
+
+    result = runner.invoke(
+        cli_main.app,
+        ["import", "memories.json", "--from", "mpf", "--preserve-owner", "--namespace", "lab"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "mnemos.tools.memory_import",
+            ["json", "--file", "memories.json", "--preserve-metadata", "--namespace", "lab"],
+        )
+    ]


### PR DESCRIPTION
## Summary
**Closes Phase A.** Single Typer-based `mnemos` CLI replaces the proliferation of top-level entry points. Each subcommand is a thin dispatcher to existing modules — no functional rewrites.

### CLI surface (9 commands)
```
mnemos serve [api|mcp-stdio|mcp-http]    # FastAPI server / MCP transports
mnemos worker distillation               # background compression contest worker
mnemos install                           # install wizard (mnemos-install console alias preserved)
mnemos export                            # MPF + Docling exports
mnemos import                            # MPF + Docling + foreign-system adapter imports
mnemos validate-mpf                      # MPF envelope validator
mnemos consult                           # /v1/consultations convenience
mnemos health                            # /health probe
mnemos version                           # mnemos.__version__
```

### Entry points updated
- `pyproject.toml` `[project.scripts]`: `mnemos = "mnemos.cli.main:app"` plus `mnemos-install` alias preserved
- `mnemos.service`, `Dockerfile`, `docker-compose.yml`, `docker-compose.staging.yml`: switched to `mnemos serve`

### New tests
`tests/test_cli_surface.py` covers: every subcommand exists, `--help` works, version prints from `_version.py`, dispatch table is complete.

## Test plan
- [x] `.venv-ci/bin/python -m pytest tests/ -q --ignore=tests/test_live_e2e.py --ignore=tests/test_*namespace_isolation.py --ignore=tests/test_ingest_owner_namespace.py` — **943 passed** (was 925, +18 CLI tests), 0 regressions
- [x] `.venv-ci/bin/ruff check . --extend-exclude .venv-ci` — clean
- [x] `python -m mnemos.cli.main --help` lists all subcommands

Authored-By: Codex