### PR TITLE
v4.0 B.1: mnemos/core/pool.py PoolManager — phase 1

### DIFF
--- a/mnemos/api/routes/entities.py
+++ b/mnemos/api/routes/entities.py
@@ -49,7 +49,7 @@ async def create_entity(
         raise HTTPException(status_code=503, detail="Database pool not available")
     try:
         entity_id = str(uuid.uuid4())
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             row = await conn.fetchrow(
                 '''INSERT INTO entities (id, owner_id, namespace, entity_type, name, description, metadata)
                    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
@@ -85,7 +85,7 @@ async def list_entities(
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().acquire() as conn:
             if entity_type and search:
                 rows = await conn.fetch(
                     '''SELECT id::text, entity_type, name, description, metadata, created::text, updated::text
@@ -123,7 +123,7 @@ async def list_entities(
 async def get_entity(entity_id: str, user: UserContext = Depends(get_current_user)):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().acquire() as conn:
         owner, namespace = await assert_owned_context(conn, "entities", entity_id, user)
         row = await conn.fetchrow(
             '''SELECT id::text, entity_type, name, description, metadata,
@@ -153,7 +153,7 @@ async def update_entity(
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             # Re-assert owner + namespace in the UPDATE so concurrent tenancy
             # changes between the probe and write cannot land on the wrong row.
             owner, namespace = await assert_owned_context(conn, "entities", entity_id, user)
@@ -200,7 +200,7 @@ async def link_entities(
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             owner, namespace = await assert_owned_context(conn, "entities", entity_id, user)
             related_owner, related_namespace = await assert_owned_context(conn, "entities", req.related_id, user)
             # Link A->B
@@ -239,7 +239,7 @@ async def delete_entity(entity_id: str, user: UserContext = Depends(get_current_
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             owner, namespace = await assert_owned_context(conn, "entities", entity_id, user)
             # Remove from other entities' arrays (caller's own only; root clears all)
             if is_root(user):
@@ -274,7 +274,7 @@ async def delete_entity(entity_id: str, user: UserContext = Depends(get_current_
 async def get_related_entities(entity_id: str, user: UserContext = Depends(get_current_user)):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().acquire() as conn:
         target_owner, target_ns = await assert_owned_context(conn, "entities", entity_id, user)
         entity = await conn.fetchrow(
             '''SELECT related_entities FROM entities
@@ -286,7 +286,7 @@ async def get_related_entities(entity_id: str, user: UserContext = Depends(get_c
     related_ids = entity['related_entities'] or []
     if not related_ids:
         return {"related": []}
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().acquire() as conn:
         # Only surface related entities visible to the caller (same owner, or root).
         if is_root(user):
             rows = await conn.fetch(

--- a/mnemos/api/routes/health.py
+++ b/mnemos/api/routes/health.py
@@ -20,7 +20,7 @@ async def health_check() -> HealthResponse:
     db_ok = False
     if _lc._pool:
         try:
-            async with _lc._pool.acquire() as conn:
+            async with _lc.get_pool_manager().acquire() as conn:
                 await conn.execute("SELECT 1")
             db_ok = True
         except Exception as e:
@@ -59,7 +59,7 @@ async def get_stats() -> StatsResponse:
         raise HTTPException(status_code=503, detail="Database pool not available")
 
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().acquire() as conn:
             total = await conn.fetchval('SELECT COUNT(*) FROM memories')
             # Federation-aware split: native rows have federation_source
             # NULL; pulled rows carry the peer name there. memories_by_peer

--- a/mnemos/api/routes/journal.py
+++ b/mnemos/api/routes/journal.py
@@ -49,7 +49,7 @@ async def create_journal_entry(
     target_ns = scope_namespace(user, namespace)
     try:
         entry_id = str(uuid.uuid4())
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             if req.date:
                 try:
                     entry_date = date.fromisoformat(req.date)
@@ -93,7 +93,7 @@ async def list_journal_entries(
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().acquire() as conn:
             if date_str:
                 try:
                     parsed_date = date.fromisoformat(date_str)
@@ -145,7 +145,7 @@ async def delete_journal_entry(
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().transactional() as conn:
         result = await conn.execute(
             'DELETE FROM journal WHERE id = $1 AND owner_id = $2 AND namespace = $3',
             entry_id, target_owner, target_ns,

--- a/mnemos/api/routes/kg.py
+++ b/mnemos/api/routes/kg.py
@@ -65,7 +65,7 @@ async def create_triple(req: KGTripleCreate, user: UserContext = Depends(get_cur
         except ValueError:
             raise HTTPException(status_code=422, detail="valid_until must be ISO8601")
 
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().transactional() as conn:
         if req.memory_id:
             # Cross-tenant memory_id references are rejected: a triple's
             # memory_id must point at a memory the caller can see. We
@@ -138,7 +138,7 @@ async def list_triples(
 
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().acquire() as conn:
         rows = await conn.fetch(
             f"SELECT id, subject, predicate, object, subject_type, object_type, valid_from, valid_until, memory_id, confidence, created FROM kg_triples {where} ORDER BY created DESC "
             f"LIMIT ${idx} OFFSET ${idx + 1}",
@@ -157,7 +157,7 @@ async def get_timeline(subject: str, limit: int = Query(100, ge=1, le=1000), use
     """Get all triples for a subject ordered by valid_from (chronological history)."""
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().acquire() as conn:
         if is_root(user):
             rows = await conn.fetch(
                 "SELECT id, subject, predicate, object, subject_type, object_type, valid_from, valid_until, memory_id, confidence, created FROM kg_triples WHERE subject=$1 ORDER BY valid_from ASC LIMIT $2",
@@ -190,7 +190,7 @@ async def update_triple(triple_id: str, req: KGTripleUpdate, user: UserContext =
     if not updates:
         raise HTTPException(status_code=422, detail="No fields to update")
     set_clauses = [f"{col}=${i+2}" for i, col in enumerate(updates.keys())]
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().transactional() as conn:
         row = await conn.fetchrow(
             "SELECT owner_id, namespace FROM kg_triples WHERE id=$1",
             triple_id,
@@ -215,7 +215,7 @@ async def update_triple(triple_id: str, req: KGTripleUpdate, user: UserContext =
 async def delete_triple(triple_id: str, user: UserContext = Depends(get_current_user)):
     if not _lc._pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().transactional() as conn:
         row = await conn.fetchrow(
             "SELECT owner_id, namespace FROM kg_triples WHERE id=$1",
             triple_id,

--- a/mnemos/api/routes/state.py
+++ b/mnemos/api/routes/state.py
@@ -34,7 +34,7 @@ async def list_state_keys(
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().acquire() as conn:
             rows = await conn.fetch(
                 'SELECT key, updated::text, version FROM state '
                 'WHERE owner_id = $1 AND namespace = $2 ORDER BY key',
@@ -58,7 +58,7 @@ async def get_state(
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().acquire() as conn:
             row = await conn.fetchrow(
                 'SELECT key, value, updated::text, version FROM state '
                 'WHERE owner_id = $1 AND namespace = $2 AND key = $3',
@@ -87,7 +87,7 @@ async def set_state(
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
     try:
-        async with _lc._pool.acquire() as conn:
+        async with _lc.get_pool_manager().transactional() as conn:
             row = await conn.fetchrow(
                 '''INSERT INTO state (owner_id, namespace, key, value, updated)
                    VALUES ($1, $2, $3, $4::jsonb, NOW())
@@ -115,7 +115,7 @@ async def delete_state(
         raise HTTPException(status_code=503, detail="Database pool not available")
     target_owner = scope_owner(user, owner_id)
     target_ns = scope_namespace(user, namespace)
-    async with _lc._pool.acquire() as conn:
+    async with _lc.get_pool_manager().transactional() as conn:
         result = await conn.execute(
             'DELETE FROM state WHERE owner_id = $1 AND namespace = $2 AND key = $3',
             target_owner, target_ns, key,

--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from mnemos.core.config import PG_CONFIG
+from mnemos.core.pool import PoolManager
 from mnemos.domain.graeae.engine import get_graeae_engine  # noqa: F401 — re-exported for handlers
 from mnemos.domain.models import MemoryItem
 
@@ -168,6 +169,7 @@ _EMBED_TIMEOUT = float(os.getenv('INFERENCE_EMBED_TIMEOUT', '10'))
 
 # ── Singleton globals ────────────────────────────────────────────────────────
 _pool: Optional[asyncpg.Pool] = None
+_pool_manager: Optional[PoolManager] = None
 _cache: Optional[aioredis.Redis] = None
 _rls_enabled: bool = False   # set from config at startup; read by handlers
 
@@ -321,7 +323,7 @@ async def _run_distillation_worker():
 @asynccontextmanager
 async def lifespan(app):
     """FastAPI lifespan: initialize and teardown DB pool, Redis, and workers."""
-    global _pool, _cache, _rls_enabled, _worker_status
+    global _pool, _pool_manager, _cache, _rls_enabled, _worker_status
     logger.info("Starting MNEMOS API Server v3.0.0 (gateway + sessions + DAG + workers)")
 
     config = _load_config()
@@ -336,7 +338,9 @@ async def lifespan(app):
             min_size=PG_CONFIG['pool_min_size'],
             max_size=PG_CONFIG['pool_max_size'],
         )
+        _pool_manager = PoolManager(_pool)
         app.state.pool = _pool   # auth.py reads this via request.app.state.pool
+        app.state.pool_manager = _pool_manager
         logger.info(
             f"asyncpg connection pool initialized "
             f"(min={PG_CONFIG['pool_min_size']}, max={PG_CONFIG['pool_max_size']})"
@@ -460,6 +464,7 @@ async def lifespan(app):
     if _pool:
         await _pool.close()
         logger.info("DB pool closed")
+    _pool_manager = None
     if _cache:
         await _cache.aclose()
         logger.info("Redis cache closed")
@@ -494,6 +499,16 @@ async def _get_db():
     if not _pool:
         raise HTTPException(status_code=503, detail="Database pool not available")
     return _pool.acquire()
+
+
+def get_pool_manager() -> PoolManager:
+    """Return the lifecycle-owned pool manager singleton."""
+    global _pool_manager
+    if _pool_manager is None or (_pool is not None and _pool_manager.pool is not _pool):
+        if not _pool:
+            raise HTTPException(status_code=503, detail="Database pool not available")
+        _pool_manager = PoolManager(_pool)
+    return _pool_manager
 
 
 _MEMORY_COLS = (

--- a/mnemos/core/pool.py
+++ b/mnemos/core/pool.py
@@ -1,0 +1,156 @@
+"""asyncpg pool wrapper with transaction and retry helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Callable, Optional, TypeVar
+
+import asyncpg
+
+DEFAULT_ACQUIRE_TIMEOUT = float(os.getenv("MNEMOS_POOL_ACQUIRE_TIMEOUT", "10.0"))
+RETRY_DELAY_SECONDS = 0.05
+
+_TRANSIENT_ERRORS = (
+    asyncpg.PostgresConnectionError,
+    asyncpg.InterfaceError,
+    asyncpg.ConnectionDoesNotExistError,
+    ConnectionResetError,
+)
+
+_ISOLATION_LEVELS = {
+    "read_uncommitted": "READ UNCOMMITTED",
+    "read_committed": "READ COMMITTED",
+    "repeatable_read": "REPEATABLE READ",
+    "serializable": "SERIALIZABLE",
+}
+
+T = TypeVar("T")
+
+
+class PoolManager:
+    """Singleton-style wrapper around an asyncpg pool."""
+
+    def __init__(self, pool: asyncpg.Pool):
+        self._pool = pool
+        self._acquire_timeout = DEFAULT_ACQUIRE_TIMEOUT
+
+    @property
+    def pool(self) -> asyncpg.Pool:
+        """Return the wrapped asyncpg pool."""
+        return self._pool
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[asyncpg.Connection]:
+        """Acquire a connection using the default timeout."""
+        try:
+            acquire_ctx = self._pool.acquire(timeout=self._acquire_timeout)
+        except TypeError:
+            # Test fakes often expose a minimal acquire() without asyncpg's
+            # timeout keyword; keep the production path timed while preserving
+            # the asyncpg-shaped connection contract.
+            acquire_ctx = self._pool.acquire()
+
+        async with acquire_ctx as conn:
+            yield conn
+
+    @asynccontextmanager
+    async def transactional(
+        self,
+        *,
+        isolation: str = "read_committed",
+        read_only: bool = False,
+    ) -> AsyncIterator[asyncpg.Connection]:
+        """Acquire a connection and manage BEGIN/COMMIT/ROLLBACK."""
+        begin_sql = _begin_sql(isolation, read_only)
+        async with self.acquire() as conn:
+            await conn.execute(begin_sql)
+            try:
+                yield conn
+            except BaseException:
+                await conn.execute("ROLLBACK")
+                raise
+            else:
+                await conn.execute("COMMIT")
+
+    async def query(self, sql: str, *args: Any, retries: int = 1) -> list[asyncpg.Record]:
+        """Fetch rows with one retry by default for transient connection loss."""
+
+        async def _operation(conn: asyncpg.Connection) -> list[asyncpg.Record]:
+            return await conn.fetch(sql, *args)
+
+        return await self._run_with_retries(_operation, retries=retries)
+
+    async def execute(self, sql: str, *args: Any, retries: int = 1) -> str:
+        """Execute non-fetching SQL with transient-error retry."""
+
+        async def _operation(conn: asyncpg.Connection) -> str:
+            return await conn.execute(sql, *args)
+
+        return await self._run_with_retries(_operation, retries=retries)
+
+    async def fetchrow(
+        self,
+        sql: str,
+        *args: Any,
+        retries: int = 1,
+    ) -> Optional[asyncpg.Record]:
+        """Fetch a single row with transient-error retry."""
+
+        async def _operation(conn: asyncpg.Connection) -> Optional[asyncpg.Record]:
+            return await conn.fetchrow(sql, *args)
+
+        return await self._run_with_retries(_operation, retries=retries)
+
+    async def fetchval(self, sql: str, *args: Any, retries: int = 1) -> Any:
+        """Fetch a single value with transient-error retry."""
+
+        async def _operation(conn: asyncpg.Connection) -> Any:
+            return await conn.fetchval(sql, *args)
+
+        return await self._run_with_retries(_operation, retries=retries)
+
+    async def _run_with_retries(
+        self,
+        operation: Callable[[asyncpg.Connection], Any],
+        *,
+        retries: int,
+    ) -> T:
+        max_retries = max(0, retries)
+        attempt = 0
+        while True:
+            try:
+                async with self.acquire() as conn:
+                    return await operation(conn)
+            except _TRANSIENT_ERRORS:
+                if attempt >= max_retries:
+                    raise
+                attempt += 1
+                await asyncio.sleep(RETRY_DELAY_SECONDS)
+
+
+def _begin_sql(isolation: str, read_only: bool) -> str:
+    normalized = isolation.strip().lower().replace("-", "_").replace(" ", "_")
+    try:
+        isolation_sql = _ISOLATION_LEVELS[normalized]
+    except KeyError as exc:
+        allowed = ", ".join(sorted(_ISOLATION_LEVELS))
+        raise ValueError(f"Unsupported isolation level {isolation!r}; expected one of: {allowed}") from exc
+
+    parts = ["BEGIN"]
+    if normalized != "read_committed":
+        parts.extend(("ISOLATION LEVEL", isolation_sql))
+    if read_only:
+        parts.append("READ ONLY")
+    return " ".join(parts)
+
+
+def get_pool_manager() -> PoolManager:
+    """Return the lifecycle-owned PoolManager singleton."""
+    from mnemos.core import lifecycle
+
+    manager = lifecycle._pool_manager
+    if manager is None:
+        raise RuntimeError("Database pool manager not available")
+    return manager

--- a/tests/test_pool_manager.py
+++ b/tests/test_pool_manager.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections import deque
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from mnemos.core import lifecycle
+from mnemos.core.pool import DEFAULT_ACQUIRE_TIMEOUT, PoolManager, get_pool_manager
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AcquireContext:
+    def __init__(self, conn: "_FakeConnection"):
+        self.conn = conn
+
+    async def __aenter__(self) -> "_FakeConnection":
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn: "_FakeConnection"):
+        self.conn = conn
+        self.acquire_calls: list[dict] = []
+
+    def acquire(self, **kwargs):
+        self.acquire_calls.append(kwargs)
+        return _AcquireContext(self.conn)
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.executes: list[tuple[str, tuple]] = []
+        self.fetch_effects = deque()
+        self.fetchrow_effects = deque()
+        self.fetchval_effects = deque()
+
+    async def execute(self, sql: str, *args):
+        self.executes.append((sql, args))
+        return "EXECUTE OK"
+
+    async def fetch(self, sql: str, *args):
+        effect = self.fetch_effects.popleft() if self.fetch_effects else []
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+    async def fetchrow(self, sql: str, *args):
+        effect = self.fetchrow_effects.popleft() if self.fetchrow_effects else None
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+    async def fetchval(self, sql: str, *args):
+        effect = self.fetchval_effects.popleft() if self.fetchval_effects else None
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+
+async def test_acquire_returns_working_connection():
+    conn = _FakeConnection()
+    conn.fetchval_effects.append(1)
+    pool = _FakePool(conn)
+    manager = PoolManager(pool)
+
+    async with manager.acquire() as acquired:
+        value = await acquired.fetchval("SELECT 1")
+
+    assert acquired is conn
+    assert value == 1
+    assert pool.acquire_calls == [{"timeout": DEFAULT_ACQUIRE_TIMEOUT}]
+
+
+async def test_transactional_commits_on_success():
+    conn = _FakeConnection()
+    manager = PoolManager(_FakePool(conn))
+
+    async with manager.transactional() as tx_conn:
+        await tx_conn.execute("UPDATE example SET ok = true")
+
+    assert [sql for sql, _ in conn.executes] == [
+        "BEGIN",
+        "UPDATE example SET ok = true",
+        "COMMIT",
+    ]
+
+
+async def test_transactional_rolls_back_on_raise():
+    conn = _FakeConnection()
+    manager = PoolManager(_FakePool(conn))
+
+    with pytest.raises(RuntimeError):
+        async with manager.transactional():
+            raise RuntimeError("boom")
+
+    assert [sql for sql, _ in conn.executes] == ["BEGIN", "ROLLBACK"]
+
+
+async def test_transactional_read_only_sets_begin_read_only():
+    conn = _FakeConnection()
+    manager = PoolManager(_FakePool(conn))
+
+    async with manager.transactional(read_only=True):
+        pass
+
+    assert [sql for sql, _ in conn.executes] == ["BEGIN READ ONLY", "COMMIT"]
+
+
+async def test_query_retries_once_on_connection_error_then_succeeds(monkeypatch):
+    conn = _FakeConnection()
+    conn.fetch_effects.extend(
+        [
+            asyncpg.PostgresConnectionError("lost connection"),
+            [{"id": "row-1"}],
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("mnemos.core.pool.asyncio.sleep", sleep)
+    manager = PoolManager(_FakePool(conn))
+
+    rows = await manager.query("SELECT id FROM example")
+
+    assert rows == [{"id": "row-1"}]
+    assert sleep.await_count == 1
+
+
+async def test_query_does_not_retry_on_unique_violation(monkeypatch):
+    conn = _FakeConnection()
+    conn.fetch_effects.append(asyncpg.UniqueViolationError("duplicate"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("mnemos.core.pool.asyncio.sleep", sleep)
+    manager = PoolManager(_FakePool(conn))
+
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await manager.query("SELECT id FROM example")
+
+    assert sleep.await_count == 0
+
+
+async def test_fetchrow_returns_none_on_no_match():
+    conn = _FakeConnection()
+    manager = PoolManager(_FakePool(conn))
+
+    row = await manager.fetchrow("SELECT id FROM example WHERE id=$1", "missing")
+
+    assert row is None
+
+
+async def test_get_pool_manager_returns_lifecycle_singleton(monkeypatch):
+    manager = PoolManager(_FakePool(_FakeConnection()))
+    monkeypatch.setattr(lifecycle, "_pool_manager", manager)
+
+    assert get_pool_manager() is manager


### PR DESCRIPTION
## Summary
First Phase B slice. PoolManager centralizes asyncpg acquisition + transaction context + retry policy + isolation control into one module. Phase 1 conversions cover 5 simpler handlers (state, journal, entities, kg, health) — interface established; remaining handlers convert in a follow-up slice.

### What changed
- `mnemos/core/pool.py` (new, 156 lines) — `PoolManager` class with `acquire`, `transactional`, `query`, `execute`, `fetchrow`, `fetchval`. 1-retry policy on transient asyncpg errors (`PostgresConnectionError`, `InterfaceError`, `ConnectionDoesNotExistError`, `ConnectionResetError`). Module-level singleton via `get_pool_manager()`.
- `mnemos/core/lifecycle.py` — PoolManager instantiated at startup alongside the existing `_pool` global.
- `mnemos/api/routes/{state, journal, entities, kg, health}.py` — converted to use `PoolManager`.
- `tests/test_pool_manager.py` (159 lines, 8 cases).

### Out of scope (deferred)
- `mnemos/api/routes/{memories, webhooks, federation, admin, openai_compat, consultations, dag, portability, oauth, sessions, document_import, ingest, morpheus, narrate}.py` convert in a follow-up.
- `mnemos/webhooks/*` keeps its own conn discipline (state machine).
- `mnemos/db/*_repo.py` repository functions take a conn parameter.

## Test plan
- [x] **951 passed** (was 943, +8), 18 skipped, 0 regressions
- [x] ruff clean

Authored-By: Codex