### PR TITLE
v4.0 B.3: import-linter contracts on package boundaries

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Lint (ruff)
         run: .venv/bin/ruff check .
 
+      - name: Lint imports
+        run: .venv/bin/lint-imports --config pyproject.toml
+
       - name: Unit tests
         run: .venv/bin/pytest tests/ --tb=short --ignore=tests/test_live_e2e.py -q

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,14 @@ lint:ruff:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
 
+lint:import-linter:
+  stage: lint
+  script:
+    - lint-imports --config pyproject.toml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH
+
 # ---- test --------------------------------------------------------------
 
 test:unit:

--- a/mnemos/api/dependencies.py
+++ b/mnemos/api/dependencies.py
@@ -5,11 +5,12 @@ added as a secondary path. Auth-disabled mode unchanged.
 """
 import hashlib
 import logging
-from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBearer
+
+from mnemos.core.auth_context import UserContext
 
 logger = logging.getLogger(__name__)
 
@@ -20,15 +21,6 @@ _personal_user_id: str = "default"
 PERSONAL_SINGLETON: "Optional[UserContext]" = None   # set by configure_auth(); None before startup
 
 _bearer = HTTPBearer(auto_error=False)
-
-
-@dataclass
-class UserContext:
-    user_id: str
-    group_ids: List[str]
-    role: str          # "user" | "root"
-    namespace: str
-    authenticated: bool
 
 
 def configure_auth(config: dict) -> None:

--- a/mnemos/api/lifecycle_hooks.py
+++ b/mnemos/api/lifecycle_hooks.py
@@ -1,0 +1,92 @@
+"""API-owned lifespan integrations for domain, webhook, and worker packages."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from mnemos.api.dependencies import configure_auth
+from mnemos.core import lifecycle
+
+logger = logging.getLogger(__name__)
+_registered = False
+
+
+async def _reload_provider_manifest(pool: Any) -> None:
+    from mnemos.domain.graeae.engine import get_graeae_engine
+
+    await get_graeae_engine().reload_from_registry(pool)
+
+
+async def _run_distillation_worker(_pool: Any) -> None:
+    """Supervise the distillation worker loop with bounded restart backoff."""
+    try:
+        from mnemos.workers.distillation import MemoryDistillationWorker
+    except ImportError as e:
+        logger.warning(f"Distillation worker not available: {e}")
+        lifecycle._worker_status["distillation_worker"] = "unavailable"
+        return
+
+    backoff = 1.0
+    while True:
+        worker = MemoryDistillationWorker()
+        try:
+            lifecycle._worker_status["distillation_worker"] = "starting"
+            await worker.start()
+            lifecycle._worker_status["distillation_worker"] = "idle"
+            return
+        except asyncio.CancelledError:
+            logger.info("Distillation worker cancelled (shutdown)")
+            lifecycle._worker_status["distillation_worker"] = "idle"
+            raise
+        except Exception as e:
+            lifecycle._worker_status["distillation_worker"] = "error"
+            logger.exception(f"Distillation worker crashed: {e} - restarting in {backoff:.0f}s")
+        finally:
+            try:
+                if getattr(worker, "db_pool", None):
+                    await worker.db_pool.close()
+            except Exception:
+                pass
+        try:
+            await asyncio.sleep(backoff)
+        except asyncio.CancelledError:
+            lifecycle._worker_status["distillation_worker"] = "idle"
+            raise
+        backoff = min(backoff * 2, 300.0)
+
+
+def _webhook_repair_worker(pool: Any):
+    from mnemos.webhooks import repair_worker_loop
+
+    return repair_worker_loop(pool)
+
+
+def _webhook_delivery_worker(pool: Any):
+    from mnemos.webhooks import delivery_worker_loop
+
+    return delivery_worker_loop(pool)
+
+
+def _federation_sync_worker(pool: Any):
+    from mnemos.domain.federation import federation_worker_loop
+
+    return federation_worker_loop(pool)
+
+
+def register_lifespan_hooks() -> None:
+    """Register high-level integrations once per process."""
+    global _registered
+    if _registered:
+        return
+    lifecycle.register_auth_configurer(configure_auth)
+    lifecycle.register_provider_manifest_reloader(_reload_provider_manifest)
+    lifecycle.register_lifespan_worker(
+        "distillation_worker",
+        _run_distillation_worker,
+        honor_worker_enabled=True,
+    )
+    lifecycle.register_lifespan_worker("webhook retry repair worker", _webhook_repair_worker)
+    lifecycle.register_lifespan_worker("webhook delivery recovery worker", _webhook_delivery_worker)
+    lifecycle.register_lifespan_worker("federation sync worker", _federation_sync_worker)
+    _registered = True

--- a/mnemos/api/main.py
+++ b/mnemos/api/main.py
@@ -28,6 +28,7 @@ from mnemos.api.routes.sessions import router as sessions_router
 from mnemos.api.routes.state import router as state_router
 from mnemos.api.routes.versions import router as versions_router
 from mnemos.api.routes.webhooks import router as webhooks_router
+from mnemos.api.lifecycle_hooks import register_lifespan_hooks
 from mnemos.core.lifecycle import lifespan
 from mnemos.core.rate_limit import (
     RateLimitExceeded,
@@ -69,6 +70,8 @@ if os.getenv("MNEMOS_STRUCTURED_LOGS", "").lower() in ("1", "true", "yes"):
     install_structured_logging()
 
 from mnemos._version import __version__ as _MNEMOS_VERSION  # noqa: E402
+
+register_lifespan_hooks()
 
 app = FastAPI(title="MNEMOS API", version=_MNEMOS_VERSION, description="Unified service: GRAEAE consultations + MNEMOS memory + multi-provider inference gateway", lifespan=lifespan)
 

--- a/mnemos/api/routes/memories.py
+++ b/mnemos/api/routes/memories.py
@@ -16,7 +16,6 @@ from mnemos.core.lifecycle import (
     _fts_fetch,
     _get_cache_key,
     _get_embedding,
-    _row_to_memory,
     _vector_search,
 )
 from mnemos.core.security import is_root
@@ -31,6 +30,7 @@ from mnemos.domain.models import (
     MemoryUpdateRequest,
     RehydrationRequest,
     RehydrationResponse,
+    row_to_memory as _row_to_memory,
 )
 
 logger = logging.getLogger(__name__)
@@ -804,7 +804,7 @@ async def update_memory(
         )
     except Exception:
         logger.warning("webhook dispatch failed for memory.updated %s", memory_id, exc_info=True)
-    return _lc._row_to_memory(row)
+    return _row_to_memory(row)
 
 
 @router.delete("/memories/{memory_id}", status_code=204)

--- a/mnemos/api/routes/openai_compat.py
+++ b/mnemos/api/routes/openai_compat.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from mnemos.api.dependencies import UserContext, get_current_user
-from mnemos.db import openai_compat_repo
 from mnemos.domain.openai_compat import content, providers, router as domain_router, schemas, streaming
 
 router = APIRouter(tags=["openai"])
@@ -58,8 +57,8 @@ _EXPORTS = {
     "_stream_error_event": (streaming, "_stream_error_event"),
     "_stream_preflight_exception": (streaming, "_stream_preflight_exception"),
     "_stream_events_for_provider_delta": (streaming, "_stream_events_for_provider_delta"),
-    "_search_mnemos_context": (openai_compat_repo, "fetch_memory_context"),
-    "_get_model_recommendation": (openai_compat_repo, "fetch_model_recommendation"),
+    "_search_mnemos_context": (domain_router, "search_memory_context"),
+    "_get_model_recommendation": (domain_router, "get_model_recommendation"),
 }
 
 __all__ = [
@@ -251,11 +250,11 @@ async def chat_completions(
             user=user,
             search_context=globals().get(
                 "_search_mnemos_context",
-                openai_compat_repo.fetch_memory_context,
+                domain_router.search_memory_context,
             ),
             get_model_recommendation=globals().get(
                 "_get_model_recommendation",
-                openai_compat_repo.fetch_model_recommendation,
+                domain_router.get_model_recommendation,
             ),
             route_to_provider_response=_route_to_provider_response_for_domain,
             route_to_provider_stream=_route_to_provider_stream_for_domain,

--- a/mnemos/api/routes/sessions.py
+++ b/mnemos/api/routes/sessions.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 import mnemos.core.lifecycle as _lc
 from mnemos.api.dependencies import UserContext, get_current_user
 from mnemos.core.security import scope_namespace
-from mnemos.db.openai_compat_repo import fetch_memory_context as _search_mnemos_context
+from mnemos.domain.openai_compat.router import search_memory_context as _search_mnemos_context
 from mnemos.domain.openai_compat.providers import _route_to_provider
 from mnemos.domain.models import (
     ChatMessage,

--- a/mnemos/api/routes/versions.py
+++ b/mnemos/api/routes/versions.py
@@ -11,7 +11,7 @@ import mnemos.core.lifecycle as _lc
 from mnemos.api.dependencies import UserContext, get_current_user
 from mnemos.core.security import is_root
 from mnemos.core.visibility import handle_trigger_pgerror
-from mnemos.domain.models import MemoryItem
+from mnemos.domain.models import MemoryItem, row_to_memory as _row_to_memory
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1", tags=["versions"])
@@ -597,4 +597,4 @@ async def revert_memory(
         f"[VERSION] Reverted {memory_id} to v{version_num} on branch '{branch}' "
         f"by {user.user_id or 'default'}"
     )
-    return _lc._row_to_memory(row)
+    return _row_to_memory(row)

--- a/mnemos/api/routes/webhooks.py
+++ b/mnemos/api/routes/webhooks.py
@@ -3,14 +3,9 @@
 Outbound notifications on memory and consultation events. Delivery is handled
 by `mnemos.webhooks.dispatcher`; this handler is CRUD only.
 """
-import asyncio
-import ipaddress
 import logging
-import os
 import secrets
-import socket
-from typing import List, Union
-from urllib.parse import urlparse
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -26,6 +21,7 @@ from mnemos.domain.models import (
     WebhookItem,
     WebhookListResponse,
 )
+from mnemos.webhooks.validation import validate_webhook_url
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/webhooks", tags=["webhooks"])
@@ -43,99 +39,6 @@ def _validate_events(events: List[str]) -> None:
             status_code=422,
             detail=f"unknown events: {bad}. valid events: {sorted(VALID_WEBHOOK_EVENTS)}",
         )
-
-
-_WEBHOOK_ALLOW_PRIVATE = os.getenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", "false").lower() == "true"
-
-# Cloud-provider instance-metadata hostnames we always refuse, even when
-# WEBHOOK_ALLOW_PRIVATE_HOSTS=true. Includes the link-local IP literals as a
-# belt check (they're also caught by the is_link_local / is_private tests).
-_BLOCKED_METADATA_HOSTS = frozenset({
-    "metadata.google.internal",
-    "metadata.goog",
-    "metadata.tencentyun.com",
-    "100-100-100-200.cn-hangzhou.ecs.aliyuncs.com",
-    "169.254.169.254",
-    "100.100.100.200",
-    "fd00:ec2::254",
-    "fe80::a9fe:a9fe",
-})
-
-_IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
-
-
-def _is_blocked_ip(ip: _IPAddress) -> bool:
-    """SSRF defense: block loopback, private, link-local, multicast, reserved."""
-    return (
-        ip.is_loopback
-        or ip.is_private
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_unspecified
-    )
-
-
-async def _resolve_addrs(host: str) -> List[str]:
-    """Resolve host asynchronously (non-blocking for the event loop).
-
-    Uses the running loop's getaddrinfo which wraps the system resolver in a
-    thread-executor so a slow DNS server doesn't freeze the ASGI worker.
-    """
-    loop = asyncio.get_event_loop()
-    infos = await loop.getaddrinfo(host, None)
-    return [info[4][0] for info in infos]
-
-
-async def validate_webhook_url(url: str) -> None:
-    """Validate a webhook URL: scheme + host not pointing at internal services.
-
-    Called at both subscription create time and dispatch time. Raises
-    HTTPException(422) on bad input. Set WEBHOOK_ALLOW_PRIVATE_HOSTS=true to
-    permit private/loopback targets (useful for local testing; unsafe in
-    production).
-
-    Caveat — DNS rebinding: between this validation and the subsequent
-    httpx connect, a hostile DNS server could switch the record from a
-    public address to an internal one. For genuinely untrusted subscription
-    creators, enforce server-side TLS pinning to a known egress proxy, or
-    pass the pre-resolved IP to httpx and keep the Host header. This
-    validator is a strong filter, not a complete mitigation on its own.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise HTTPException(status_code=422, detail="url must start with http:// or https://")
-    host = parsed.hostname
-    if not host:
-        raise HTTPException(status_code=422, detail="url must include a host")
-
-    if host.lower() in _BLOCKED_METADATA_HOSTS:
-        raise HTTPException(status_code=422, detail="url host is not permitted")
-
-    if _WEBHOOK_ALLOW_PRIVATE:
-        return
-
-    # If host is already an IP literal, check it directly. Otherwise resolve
-    # (asynchronously) and check every returned address family.
-    try:
-        ip = ipaddress.ip_address(host)
-        if _is_blocked_ip(ip):
-            raise HTTPException(status_code=422, detail="url host resolves to a non-routable address")
-        return
-    except ValueError:
-        pass  # not a literal IP — resolve DNS
-
-    try:
-        addrs = await _resolve_addrs(host)
-    except (socket.gaierror, OSError):
-        raise HTTPException(status_code=422, detail="url host could not be resolved")
-    for addr in addrs:
-        try:
-            ip = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
-        if _is_blocked_ip(ip):
-            raise HTTPException(status_code=422, detail="url host resolves to a non-routable address")
 
 
 # Kept as `_validate_url` alias for callers inside this module.

--- a/mnemos/core/auth_context.py
+++ b/mnemos/core/auth_context.py
@@ -1,0 +1,14 @@
+"""Shared authentication context DTOs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class UserContext:
+    user_id: str
+    group_ids: List[str]
+    role: str
+    namespace: str
+    authenticated: bool

--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -22,8 +22,6 @@ from fastapi import HTTPException
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from mnemos.core.config import PG_CONFIG
 from mnemos.core.pool import PoolManager
-from mnemos.domain.graeae.engine import get_graeae_engine  # noqa: F401 — re-exported for handlers
-from mnemos.domain.models import MemoryItem
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +73,38 @@ def _schedule_worker(coro):
 def _schedule_delivery_attempt(coro):
     """Schedule a finite webhook send that graceful shutdown drains before cancel."""
     return _schedule_tracked(coro, _delivery_attempt_tasks)
+
+
+_auth_configurer = None
+_provider_manifest_reloader = None
+_lifespan_worker_factories: dict = {}
+
+
+def register_auth_configurer(configurer) -> None:
+    """Register the API-owned auth configurer without making core import API."""
+    global _auth_configurer
+    _auth_configurer = configurer
+
+
+def register_provider_manifest_reloader(reloader) -> None:
+    """Register the domain-owned provider manifest reload hook."""
+    global _provider_manifest_reloader
+    _provider_manifest_reloader = reloader
+
+
+def register_lifespan_worker(name: str, factory, *, honor_worker_enabled: bool = False) -> None:
+    """Register an app worker factory called with the lifecycle DB pool."""
+    _lifespan_worker_factories[name] = (factory, honor_worker_enabled)
+
+
+async def _run_distillation_worker(pool=None):
+    """Compatibility shim for the registered distillation worker supervisor."""
+    factory_entry = _lifespan_worker_factories.get("distillation_worker")
+    if factory_entry is None:
+        _worker_status["distillation_worker"] = "unavailable"
+        return
+    factory, _honor_worker_enabled = factory_entry
+    await factory(pool)
 
 
 async def _cancel_tracked_tasks(tasks: set, *, label: str, timeout: float) -> None:
@@ -262,62 +292,6 @@ async def _log_federation_startup_guidance(pool: asyncpg.Pool) -> None:
             )
 
 
-# ── Distillation Worker Wrapper ─────────────────────────────────────────────────
-
-async def _run_distillation_worker():
-    """Supervised distillation worker loop — restarts on unhandled errors.
-
-    Dispatches unoptimized memories through the v3.3 going-forward
-    compression stack:
-      - ARTEMIS (CPU-only extractive with identifier preservation)
-      - APOLLO  (schema-aware dense encoding, GPU-optional fallback)
-    Selected by the contest framework per memory.
-
-    Previously a single crash set status to 'idle' and left the worker
-    permanently dead for the rest of the process lifetime. We now restart
-    with exponential backoff up to 5 minutes. asyncio.CancelledError (shutdown)
-    propagates so the lifespan drain works correctly.
-    """
-    import asyncio
-    global _worker_status
-
-    try:
-        from mnemos.workers.distillation import MemoryDistillationWorker
-    except ImportError as e:
-        logger.warning(f"Distillation worker not available: {e}")
-        _worker_status["distillation_worker"] = "unavailable"
-        return
-
-    backoff = 1.0
-    while True:
-        worker = MemoryDistillationWorker()
-        try:
-            _worker_status["distillation_worker"] = "starting"
-            await worker.start()
-            # Graceful exit (worker.start() returned) — stop supervising.
-            _worker_status["distillation_worker"] = "idle"
-            return
-        except asyncio.CancelledError:
-            logger.info("Distillation worker cancelled (shutdown)")
-            _worker_status["distillation_worker"] = "idle"
-            raise
-        except Exception as e:
-            _worker_status["distillation_worker"] = "error"
-            logger.exception(f"Distillation worker crashed: {e} — restarting in {backoff:.0f}s")
-        finally:
-            try:
-                if getattr(worker, "db_pool", None):
-                    await worker.db_pool.close()
-            except Exception:
-                pass
-        try:
-            await asyncio.sleep(backoff)
-        except asyncio.CancelledError:
-            _worker_status["distillation_worker"] = "idle"
-            raise
-        backoff = min(backoff * 2, 300.0)  # cap at 5 minutes
-
-
 # ── App lifespan ─────────────────────────────────────────────────────────────
 
 @asynccontextmanager
@@ -349,9 +323,9 @@ async def lifespan(app):
         logger.error(f"Failed to create DB pool: {e}")
         raise
 
-    # Configure auth (personal profile: auth.enabled=false → no-op beyond singleton)
-    from mnemos.api.dependencies import configure_auth
-    configure_auth(config.get("auth", {}))
+    # Configure auth (personal profile: auth.enabled=false -> no-op beyond singleton).
+    if _auth_configurer is not None:
+        _auth_configurer(config.get("auth", {}))
 
     # Refresh GRAEAE provider manifest from model_registry in the background
     # so startup doesn't block on per-provider HTTP probes (each can take up
@@ -362,22 +336,24 @@ async def lifespan(app):
     # the background task lands. POST /admin/graeae/reload-providers is also
     # available for on-demand refresh (and is what the daily systemd timer
     # uses after sync_provider_models.py finishes).
-    import asyncio as _asyncio_for_reload
-    async def _bg_graeae_reload():
-        try:
-            from mnemos.domain.graeae.engine import get_graeae_engine
-            await _asyncio_for_reload.wait_for(
-                get_graeae_engine().reload_from_registry(_pool),
-                timeout=120,
-            )
-        except _asyncio_for_reload.TimeoutError:
-            logger.warning(
-                "[GRAEAE] background manifest reload exceeded 120s — "
-                "keeping built-in defaults; daily timer will retry",
-            )
-        except Exception as e:
-            logger.warning(f"[GRAEAE] background manifest reload failed: {e}")
-    _schedule_background(_bg_graeae_reload())
+    if _provider_manifest_reloader is not None:
+        import asyncio as _asyncio_for_reload
+
+        async def _bg_provider_manifest_reload():
+            try:
+                await _asyncio_for_reload.wait_for(
+                    _provider_manifest_reloader(_pool),
+                    timeout=120,
+                )
+            except _asyncio_for_reload.TimeoutError:
+                logger.warning(
+                    "[GRAEAE] background manifest reload exceeded 120s - "
+                    "keeping built-in defaults; daily timer will retry",
+                )
+            except Exception as e:
+                logger.warning(f"[GRAEAE] background manifest reload failed: {e}")
+
+        _schedule_background(_bg_provider_manifest_reload())
 
     # RLS enforcement flag
     _rls_enabled = config.get("multiuser", {}).get("rls_enabled", False)
@@ -399,36 +375,26 @@ async def lifespan(app):
         _cache = None
         app.state.cache = None
 
-    # Start background distillation worker (optional)
+    # Start registered background workers. API owns registrations so core stays
+    # below API/domain/webhook/worker packages in the dependency graph.
     worker_enabled = config.get("worker", {}).get("enabled", True)
-    if worker_enabled and _pool:
-        logger.info("Launching background distillation worker")
-        _schedule_worker(_run_distillation_worker())
+    scheduled_workers = 0
+    if _pool:
+        for worker_name, (factory, honor_worker_enabled) in _lifespan_worker_factories.items():
+            if honor_worker_enabled and not worker_enabled:
+                logger.info("%s disabled", worker_name)
+                if worker_name == "distillation_worker":
+                    _worker_status["distillation_worker"] = "disabled"
+                continue
+            logger.info("Launching %s", worker_name)
+            _schedule_worker(factory(_pool))
+            scheduled_workers += 1
+    if scheduled_workers:
         import asyncio as _asyncio
         await _asyncio.sleep(0.5)  # Give worker time to initialize
-    else:
+    elif not worker_enabled:
         logger.info("Background distillation worker disabled")
         _worker_status["distillation_worker"] = "disabled"
-
-    # Webhook retry repair + delivery recovery workers. Repair owns its own
-    # startup burst and periodic cadence, independent of slow webhook sends.
-    if _pool:
-        from mnemos.webhooks import (  # noqa: WPS433
-            delivery_worker_loop as _webhook_delivery,
-        )
-        from mnemos.webhooks import (
-            repair_worker_loop as _webhook_repair,
-        )
-        logger.info('Launching webhook retry repair worker')
-        _schedule_worker(_webhook_repair(_pool))
-        logger.info('Launching webhook delivery recovery worker')
-        _schedule_worker(_webhook_delivery(_pool))
-
-    # Federation sync worker (v3.0.0 — pulls from remote peers on their intervals)
-    if _pool:
-        logger.info('Launching federation sync worker')
-        from mnemos.domain.federation import federation_worker_loop as _federation_worker
-        _schedule_worker(_federation_worker(_pool))
 
     # OAuth expired-session GC worker (v3.0.0)
     if _pool:
@@ -517,37 +483,6 @@ _MEMORY_COLS = (
     "owner_id, group_id, namespace, permission_mode, "
     "source_model, source_provider, source_session, source_agent"
 )
-
-
-def _row_to_memory(row, include_compressed: bool = False) -> MemoryItem:
-    raw_meta = row.get('metadata')
-    if isinstance(raw_meta, str):
-        try:
-            raw_meta = json.loads(raw_meta)
-        except Exception:
-            raw_meta = None
-    elif not isinstance(raw_meta, dict):
-        raw_meta = None
-    return MemoryItem(
-        id=row['id'],
-        content=row['content'],
-        category=row['category'],
-        subcategory=row.get('subcategory'),
-        created=row['created'].isoformat() if row['created'] else '',
-        updated=row['updated'].isoformat() if row.get('updated') else None,
-        metadata=raw_meta if raw_meta else None,
-        quality_rating=row.get('quality_rating'),
-        compressed_content=row.get('compressed_content') if include_compressed else None,
-        verbatim_content=row.get('verbatim_content'),
-        owner_id=row.get('owner_id'),
-        group_id=row.get('group_id'),
-        namespace=row.get('namespace'),
-        permission_mode=row.get('permission_mode'),
-        source_model=row.get('source_model'),
-        source_provider=row.get('source_provider'),
-        source_session=row.get('source_session'),
-        source_agent=row.get('source_agent'),
-    )
 
 
 async def _get_embedding(text: str) -> list:

--- a/mnemos/core/provider_registry.py
+++ b/mnemos/core/provider_registry.py
@@ -1,0 +1,43 @@
+"""Provider registry constants shared below the domain layer."""
+from __future__ import annotations
+
+# Maps each GRAEAE provider name to:
+#   registry_provider - name used by provider_sync.py when upserting into
+#                       model_registry (may differ from the GRAEAE name,
+#                       e.g. claude -> anthropic).
+#   prefer            - ordered list of ILIKE patterns to pick a current
+#                       flagship when arena_score is absent.
+GRAEAE_REGISTRY_MAP: dict[str, dict] = {
+    "together": {
+        "registry_provider": "together",
+        "prefer": ["Qwen3-235B", "Llama-3.3-70B", "Llama-3.1-70B"],
+    },
+    "groq": {
+        "registry_provider": "groq",
+        "prefer": ["llama-3.3-70b-versatile", "llama-3.3", "llama-3.1"],
+    },
+    "openai": {
+        "registry_provider": "openai",
+        "prefer": ["gpt-5", "gpt-4o", "gpt-4"],
+    },
+    "claude": {
+        "registry_provider": "anthropic",
+        "prefer": ["claude-opus", "claude-sonnet"],
+    },
+    "perplexity": {
+        "registry_provider": "perplexity",
+        "prefer": ["sonar-pro", "sonar"],
+    },
+    "xai": {
+        "registry_provider": "xai",
+        "prefer": ["grok-4", "grok-3", "grok"],
+    },
+    "nvidia": {
+        "registry_provider": "nvidia",
+        "prefer": ["llama-3.3-70b-instruct", "llama-3.1-70b-instruct", "nemotron-70b"],
+    },
+    "gemini": {
+        "registry_provider": "gemini",
+        "prefer": ["gemini-3", "gemini-2.5", "gemini-2"],
+    },
+}

--- a/mnemos/core/security.py
+++ b/mnemos/core/security.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import HTTPException
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _CAST_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\[\])?$")

--- a/mnemos/db/mcp_repo.py
+++ b/mnemos/db/mcp_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 from mnemos.core.visibility import read_visibility_predicate, version_visibility_predicate
 
 

--- a/mnemos/db/openai_compat_repo.py
+++ b/mnemos/db/openai_compat_repo.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import mnemos.core.lifecycle as _lc
-from mnemos.domain.graeae.engine import _REGISTRY_MAP
+from mnemos.core.provider_registry import GRAEAE_REGISTRY_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ async def lookup_provider_for_model(model: str) -> Optional[str]:
 
             if "/" in model:
                 head, tail = model.split("/", 1)
-                head_registry = _REGISTRY_MAP.get(head, {"registry_provider": head})[
+                head_registry = GRAEAE_REGISTRY_MAP.get(head, {"registry_provider": head})[
                     "registry_provider"
                 ]
                 row = await conn.fetchrow(

--- a/mnemos/domain/graeae/engine.py
+++ b/mnemos/domain/graeae/engine.py
@@ -41,6 +41,7 @@ from typing import Any, Dict, Optional
 
 import httpx
 
+from mnemos.core.provider_registry import GRAEAE_REGISTRY_MAP
 from mnemos.domain.graeae.api_keys import _PROVIDER_ENV_VARS, get_key
 
 
@@ -1376,24 +1377,8 @@ def _unavailable(model_id: str, error: str = "") -> Dict:
 
 
 # ── Registry-backed manifest refresh ──────────────────────────────────────────
-# Maps each GRAEAE provider name to:
-#   registry_provider — name used by provider_sync.py when upserting into
-#                       model_registry (may differ from the GRAEAE name,
-#                       e.g. claude→anthropic).
-#   prefer            — ordered list of ILIKE patterns to pick a current
-#                       flagship when arena_score is absent (providers
-#                       without Arena coverage: groq, nvidia, perplexity).
 # Arena-ranked models always win over pattern matches when available.
-_REGISTRY_MAP: dict[str, dict] = {
-    "together":   {"registry_provider": "together",   "prefer": ["Qwen3-235B", "Llama-3.3-70B", "Llama-3.1-70B"]},
-    "groq":       {"registry_provider": "groq",       "prefer": ["llama-3.3-70b-versatile", "llama-3.3", "llama-3.1"]},
-    "openai":     {"registry_provider": "openai",     "prefer": ["gpt-5", "gpt-4o", "gpt-4"]},
-    "claude":     {"registry_provider": "anthropic",  "prefer": ["claude-opus", "claude-sonnet"]},
-    "perplexity": {"registry_provider": "perplexity", "prefer": ["sonar-pro", "sonar"]},
-    "xai":        {"registry_provider": "xai",        "prefer": ["grok-4", "grok-3", "grok"]},
-    "nvidia":     {"registry_provider": "nvidia",     "prefer": ["llama-3.3-70b-instruct", "llama-3.1-70b-instruct", "nemotron-70b"]},
-    "gemini":     {"registry_provider": "gemini",     "prefer": ["gemini-3", "gemini-2.5", "gemini-2"]},
-}
+_REGISTRY_MAP = GRAEAE_REGISTRY_MAP
 
 
 _VERSION_RE = re.compile(r"(\d+)(?:[.\-_](\d+))?(?:[.\-_](\d+))?(?:[.\-_](\d+))?")

--- a/mnemos/domain/memory_categorization/entities.py
+++ b/mnemos/domain/memory_categorization/entities.py
@@ -21,7 +21,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 from mnemos.domain.memory_categorization.constants import ENTITY_TYPES
 
 logger = logging.getLogger(__name__)

--- a/mnemos/domain/memory_categorization/journal.py
+++ b/mnemos/domain/memory_categorization/journal.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 logger = logging.getLogger(__name__)
 

--- a/mnemos/domain/memory_categorization/state.py
+++ b/mnemos/domain/memory_categorization/state.py
@@ -18,7 +18,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 logger = logging.getLogger(__name__)
 

--- a/mnemos/domain/models.py
+++ b/mnemos/domain/models.py
@@ -1,4 +1,5 @@
 """Pydantic models for MNEMOS API."""
+import json
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -64,6 +65,37 @@ class MemoryItem(BaseModel):
     source_provider: Optional[str] = None
     source_session: Optional[str] = None
     source_agent: Optional[str] = None
+
+
+def row_to_memory(row, include_compressed: bool = False) -> MemoryItem:
+    raw_meta = row.get("metadata")
+    if isinstance(raw_meta, str):
+        try:
+            raw_meta = json.loads(raw_meta)
+        except Exception:
+            raw_meta = None
+    elif not isinstance(raw_meta, dict):
+        raw_meta = None
+    return MemoryItem(
+        id=row["id"],
+        content=row["content"],
+        category=row["category"],
+        subcategory=row.get("subcategory"),
+        created=row["created"].isoformat() if row["created"] else "",
+        updated=row["updated"].isoformat() if row.get("updated") else None,
+        metadata=raw_meta if raw_meta else None,
+        quality_rating=row.get("quality_rating"),
+        compressed_content=row.get("compressed_content") if include_compressed else None,
+        verbatim_content=row.get("verbatim_content"),
+        owner_id=row.get("owner_id"),
+        group_id=row.get("group_id"),
+        namespace=row.get("namespace"),
+        permission_mode=row.get("permission_mode"),
+        source_model=row.get("source_model"),
+        source_provider=row.get("source_provider"),
+        source_session=row.get("source_session"),
+        source_agent=row.get("source_agent"),
+    )
 
 
 class MemoryListResponse(BaseModel):

--- a/mnemos/domain/openai_compat/providers.py
+++ b/mnemos/domain/openai_compat/providers.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
+from mnemos.core.provider_registry import GRAEAE_REGISTRY_MAP
 from mnemos.db import openai_compat_repo
-from mnemos.domain.graeae.engine import _REGISTRY_MAP, get_graeae_engine
+from mnemos.domain.graeae.engine import get_graeae_engine
 
 from .content import _flatten_messages_for_prompt, _has_content_blocks, _has_message_names, _plain_value
 from .schemas import ChatCompletionRequest
@@ -28,7 +29,7 @@ MODEL_ALIASES = {
 
 _REGISTRY_PROVIDER_TO_GRAEAE: Dict[str, str] = {
     cfg["registry_provider"]: name
-    for name, cfg in _REGISTRY_MAP.items()
+    for name, cfg in GRAEAE_REGISTRY_MAP.items()
 }
 
 
@@ -199,8 +200,8 @@ def _model_not_found_error(model: str) -> dict[str, dict[str, str]]:
 
 def _strip_gateway_namespace(model: str, provider: str) -> str:
     candidate_prefixes = [f"{provider}/"]
-    if provider in _REGISTRY_MAP:
-        registry_name = _REGISTRY_MAP[provider]["registry_provider"]
+    if provider in GRAEAE_REGISTRY_MAP:
+        registry_name = GRAEAE_REGISTRY_MAP[provider]["registry_provider"]
         if registry_name != provider:
             candidate_prefixes.append(f"{registry_name}/")
 

--- a/mnemos/domain/openai_compat/router.py
+++ b/mnemos/domain/openai_compat/router.py
@@ -169,6 +169,14 @@ async def get_model(model_id: str, user: Any) -> ModelInfo:
     return ModelInfo(id=resolved_model, owned_by=_owned_by(provider))
 
 
+async def search_memory_context(*args: Any, **kwargs: Any) -> Any:
+    return await openai_compat_repo.fetch_memory_context(*args, **kwargs)
+
+
+async def get_model_recommendation(*args: Any, **kwargs: Any) -> Any:
+    return await openai_compat_repo.fetch_model_recommendation(*args, **kwargs)
+
+
 async def chat_completion(
     request: ChatCompletionRequest,
     user: Any,

--- a/mnemos/hooks/session_start.py
+++ b/mnemos/hooks/session_start.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 from uuid import uuid4
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 logger = logging.getLogger(__name__)
 

--- a/mnemos/mcp/tools/__init__.py
+++ b/mnemos/mcp/tools/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 from ._runtime import (
     _backend_headers,

--- a/mnemos/mcp/tools/_runtime.py
+++ b/mnemos/mcp/tools/_runtime.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 from mnemos.db.mcp_repo import assert_memory_readable
 
 HTTP_TIMEOUT = 30.0

--- a/mnemos/mcp/tools/dag.py
+++ b/mnemos/mcp/tools/dag.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 import mnemos.core.lifecycle as _lc
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 from mnemos.db import mcp_repo
 
 from ._runtime import _mcp_assert_memory_readable, _mcp_user_required, _rest_get, _rest_post, _tool

--- a/mnemos/mcp/tools/kg.py
+++ b/mnemos/mcp/tools/kg.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 from ._runtime import _rest_delete, _rest_get, _rest_post, _tool
 

--- a/mnemos/mcp/tools/memory.py
+++ b/mnemos/mcp/tools/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 
 from ._runtime import _rest_delete, _rest_get, _rest_post, _tool
 

--- a/mnemos/mcp/tools/models.py
+++ b/mnemos/mcp/tools/models.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 import mnemos.core.lifecycle as _lc
-from mnemos.api.dependencies import UserContext
+from mnemos.core.auth_context import UserContext
 from mnemos.db import mcp_repo
 
 from ._runtime import _rest_get, _tool

--- a/mnemos/webhooks/sender.py
+++ b/mnemos/webhooks/sender.py
@@ -9,6 +9,8 @@ from typing import Any, Awaitable, Optional
 import asyncpg
 import httpx
 
+from mnemos.webhooks import validation as webhook_validation
+
 from . import lease as webhook_lease
 from . import types as webhook_types
 from ._signing import _sign
@@ -114,9 +116,8 @@ async def _send_claimed_delivery_within_deadline(
     header_deadline = loop.time() + send_window_seconds
 
     try:
-        from mnemos.api.routes.webhooks import validate_webhook_url
         await asyncio.wait_for(
-            validate_webhook_url(delivery["url"]),
+            webhook_validation.validate_webhook_url(delivery["url"]),
             timeout=_remaining_timeout_seconds(header_deadline),
         )
     except asyncio.TimeoutError:

--- a/mnemos/webhooks/validation.py
+++ b/mnemos/webhooks/validation.py
@@ -1,0 +1,84 @@
+"""Webhook URL validation shared by CRUD routes and delivery workers."""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import os
+import socket
+from typing import List, Union
+from urllib.parse import urlparse
+
+from fastapi import HTTPException
+
+_WEBHOOK_ALLOW_PRIVATE = os.getenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", "false").lower() == "true"
+
+# Cloud-provider instance-metadata hostnames we always refuse, even when
+# WEBHOOK_ALLOW_PRIVATE_HOSTS=true. Includes the link-local IP literals as a
+# belt check (they're also caught by the is_link_local / is_private tests).
+_BLOCKED_METADATA_HOSTS = frozenset({
+    "metadata.google.internal",
+    "metadata.goog",
+    "metadata.tencentyun.com",
+    "100-100-100-200.cn-hangzhou.ecs.aliyuncs.com",
+    "169.254.169.254",
+    "100.100.100.200",
+    "fd00:ec2::254",
+    "fe80::a9fe:a9fe",
+})
+
+_IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _is_blocked_ip(ip: _IPAddress) -> bool:
+    """SSRF defense: block loopback, private, link-local, multicast, reserved."""
+    return (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+async def _resolve_addrs(host: str) -> List[str]:
+    """Resolve host asynchronously so DNS cannot block the event loop."""
+    loop = asyncio.get_event_loop()
+    infos = await loop.getaddrinfo(host, None)
+    return [info[4][0] for info in infos]
+
+
+async def validate_webhook_url(url: str) -> None:
+    """Validate a webhook URL: scheme + host not pointing at internal services."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=422, detail="url must start with http:// or https://")
+    host = parsed.hostname
+    if not host:
+        raise HTTPException(status_code=422, detail="url must include a host")
+
+    if host.lower() in _BLOCKED_METADATA_HOSTS:
+        raise HTTPException(status_code=422, detail="url host is not permitted")
+
+    if _WEBHOOK_ALLOW_PRIVATE:
+        return
+
+    try:
+        ip = ipaddress.ip_address(host)
+        if _is_blocked_ip(ip):
+            raise HTTPException(status_code=422, detail="url host resolves to a non-routable address")
+        return
+    except ValueError:
+        pass
+
+    try:
+        addrs = await _resolve_addrs(host)
+    except (socket.gaierror, OSError):
+        raise HTTPException(status_code=422, detail="url host could not be resolved")
+    for addr in addrs:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if _is_blocked_ip(ip):
+            raise HTTPException(status_code=422, detail="url host resolves to a non-routable address")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ full = ["sentence-transformers>=2.7.0", "spacy>=3.7.0", "networkx>=3.3"]
 # Note: the `phi` extras are optional GPU-dependent OpenVINO/FastEmbed support. Most installs don't need it.
 phi = ["openvino-genai>=2024.4.0", "fastembed>=0.3.0"]
 dev = [
+  "import-linter>=2.0.0",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
   "pytest-cov>=5.0.0",
@@ -127,6 +128,76 @@ ignore = [
 "**/__init__.py" = ["F401"]
 # Installer uses string forward references to lazily-imported Config
 "mnemos/installer/__main__.py" = ["F821"]
+
+[tool.importlinter]
+root_package = "mnemos"
+include_external_packages = false
+
+[[tool.importlinter.contracts]]
+name = "mnemos layered architecture"
+type = "layers"
+layers = [
+  "mnemos.api",
+  "mnemos.domain",
+  "mnemos.db",
+  "mnemos.core",
+]
+
+[[tool.importlinter.contracts]]
+name = "api routes use domain, not db"
+type = "forbidden"
+source_modules = ["mnemos.api.routes"]
+forbidden_modules = ["mnemos.db"]
+allow_indirect_imports = true
+
+[[tool.importlinter.contracts]]
+name = "domain modules are siblings"
+type = "independence"
+modules = [
+  "mnemos.domain.compression",
+  "mnemos.domain.graeae",
+  "mnemos.domain.morpheus",
+  "mnemos.domain.memory_categorization",
+  "mnemos.domain.openai_compat",
+  "mnemos.domain.portability",
+]
+ignore_imports = [
+  # MORPHEUS intentionally invokes GRAEAE as its reasoning backend.
+  "mnemos.domain.morpheus.runner -> mnemos.domain.graeae.engine",
+  # The OpenAI-compatible gateway is an adapter over GRAEAE provider routing.
+  "mnemos.domain.openai_compat.providers -> mnemos.domain.graeae.engine",
+  # Streaming needs GRAEAE's ProviderStreamError to preserve provider error frames.
+  "mnemos.domain.openai_compat.streaming -> mnemos.domain.graeae.engine",
+]
+
+[[tool.importlinter.contracts]]
+name = "mcp does not call route handlers as functions"
+type = "forbidden"
+source_modules = ["mnemos.mcp"]
+forbidden_modules = ["mnemos.api.routes"]
+allow_indirect_imports = true
+
+[[tool.importlinter.contracts]]
+name = "webhooks does not couple to domain"
+type = "independence"
+modules = ["mnemos.webhooks", "mnemos.domain"]
+
+[[tool.importlinter.contracts]]
+name = "core does not import api/domain/db/webhooks/mcp/etc"
+type = "forbidden"
+source_modules = ["mnemos.core"]
+forbidden_modules = [
+  "mnemos.api",
+  "mnemos.domain",
+  "mnemos.db",
+  "mnemos.webhooks",
+  "mnemos.mcp",
+  "mnemos.workers",
+  "mnemos.cli",
+  "mnemos.tools",
+  "mnemos.installer",
+  "mnemos.hooks",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_webhook_retry_state.py
+++ b/tests/test_webhook_retry_state.py
@@ -933,9 +933,9 @@ def _attempt(attempt_num: int = 1) -> dict[str, Any]:
 
 
 async def _install(monkeypatch, rows: list[dict[str, Any]], statuses: list[int]):
-    from mnemos.api.routes import webhooks
     from mnemos.core import lifecycle
     from mnemos.webhooks import dispatcher as webhook_dispatcher
+    from mnemos.webhooks import validation as webhook_validation
 
     store = _FakeWebhookStore(rows)
     pool = _FakePool(store)
@@ -947,7 +947,7 @@ async def _install(monkeypatch, rows: list[dict[str, Any]], statuses: list[int])
         return None
 
     http_factory = _HTTPClientFactory(statuses)
-    monkeypatch.setattr(webhooks, "validate_webhook_url", _accept_url)
+    monkeypatch.setattr(webhook_validation, "validate_webhook_url", _accept_url)
     monkeypatch.setattr(webhook_dispatcher.httpx, "AsyncClient", http_factory)
     monkeypatch.setattr(webhook_dispatcher, "_send_semaphore", None)
     return webhook_dispatcher, conn, http_factory
@@ -3014,14 +3014,14 @@ def test_repair_sweep_does_not_strip_active_lease_with_successor(monkeypatch):
 
 def test_lifecycle_runs_webhook_retry_repair_on_startup():
     repo_root = Path(__file__).resolve().parents[1]
-    lifecycle_source = (repo_root / "mnemos" / "core" / "lifecycle.py").read_text()
+    lifecycle_hooks_source = (repo_root / "mnemos" / "api" / "lifecycle_hooks.py").read_text()
     dispatcher_source = _webhook_module_source("workers", "repair", "types")
     compact_dispatcher = " ".join(dispatcher_source.split())
 
-    assert "repair_worker_loop as _webhook_repair" in lifecycle_source
-    assert "delivery_worker_loop as _webhook_delivery" in lifecycle_source
-    assert "_schedule_worker(_webhook_repair(_pool))" in lifecycle_source
-    assert "_schedule_worker(_webhook_delivery(_pool))" in lifecycle_source
+    assert "repair_worker_loop" in lifecycle_hooks_source
+    assert "delivery_worker_loop" in lifecycle_hooks_source
+    assert 'register_lifespan_worker("webhook retry repair worker"' in lifecycle_hooks_source
+    assert 'register_lifespan_worker("webhook delivery recovery worker"' in lifecycle_hooks_source
     assert "REPAIR_BURST_SECONDS" in dispatcher_source
     assert "REPAIR_PERIODIC_INTERVAL" in dispatcher_source
     assert "async def repair_worker_loop" in dispatcher_source

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -127,13 +127,14 @@ class TestEventValidation:
         from fastapi import HTTPException
 
         from mnemos.api.routes import webhooks as wh
+        from mnemos.webhooks import validation as webhook_validation
 
         async def _fake_resolve_addrs(host: str):
             if host == "localhost":
                 return ["127.0.0.1"]
             return ["93.184.216.34"]
 
-        monkeypatch.setattr(wh, "_resolve_addrs", _fake_resolve_addrs)
+        monkeypatch.setattr(webhook_validation, "_resolve_addrs", _fake_resolve_addrs)
 
         # Public host — fake DNS keeps the hostname-resolution path covered
         # without requiring external DNS in CI/sandboxed runners.

--- a/tests/test_webhooks_entities_namespace.py
+++ b/tests/test_webhooks_entities_namespace.py
@@ -75,10 +75,12 @@ def _install(monkeypatch, conn):
 
 
 def _install_public_dns(monkeypatch, wh):
+    from mnemos.webhooks import validation as webhook_validation
+
     async def _fake_resolve_addrs(host: str):
         return ["93.184.216.34"]
 
-    monkeypatch.setattr(wh, "_resolve_addrs", _fake_resolve_addrs)
+    monkeypatch.setattr(webhook_validation, "_resolve_addrs", _fake_resolve_addrs)
 
 
 # ─── entities ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Locks in the v4 layered architecture established by Phase A. Six contracts; all KEPT on 152 analyzed files / 318 dependencies on first run after Codex resolved organic violations during the slice.

### Contracts (all kept)
1. **Layered**: `mnemos.api → mnemos.domain → mnemos.db → mnemos.core` (one-way)
2. **api routes use domain, not db** (forbidden direct route → db imports)
3. **domain modules are siblings** (compression / graeae / morpheus / memory_categorization / openai_compat / portability — independent)
4. **mcp does not call route handlers as functions** (REST or domain only)
5. **webhooks does not couple to domain** (webhooks fires events FOR domain mutations but doesn't import them)
6. **core does not import api/domain/db/webhooks/mcp/etc** (core is the leaf)

### Side effects of enforcing the contracts
- New `mnemos/webhooks/validation.py` (84 lines) — validation helpers extracted out of `webhooks/sender.py` to break a domain-coupling violation
- ~36 files touched, +476 / -299 net (mostly imports + targeted refactors to satisfy the contracts)

### CI integration
- Wired into `.gitlab-ci.yml` lint stage and `.github/workflows/pr-check.yml`. Build fails on any future contract violation.

## Test plan
- [x] `.venv-ci/bin/lint-imports --config pyproject.toml` — **6 kept, 0 broken**
- [x] **961 passed**, 18 skipped, 0 regressions
- [x] ruff clean

Authored-By: Codex