### PR TITLE
v4.0 C.2: drop workers=1 pin — closes Phase C

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,80 @@ test:integration:
     - if: $CI_COMMIT_BRANCH == "master"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
+test:multi-worker:
+  stage: test
+  image: docker:24
+  services:
+    - name: docker:24-dind
+      alias: docker
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+    COMPOSE_PROJECT_NAME: mnemos-mw-$CI_PIPELINE_ID
+    POSTGRES_PASSWORD: mnemos_local
+  before_script: []
+  script:
+    - |
+      cat > docker-compose.multi-worker.ci.yml <<'YAML'
+      services:
+        redis:
+          image: redis:7-alpine
+          healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 2s
+            timeout: 2s
+            retries: 30
+
+        mnemos:
+          command: ["mnemos", "serve", "--host", "0.0.0.0", "--workers", "2"]
+          environment:
+            RATE_LIMIT_STORAGE_URI: redis://redis:6379/1
+            MNEMOS_WORKERS: "2"
+            WEBHOOK_ALLOW_PRIVATE_HOSTS: "true"
+            PG_POOL_MIN: "1"
+            PG_POOL_MAX: "8"
+          depends_on:
+            redis:
+              condition: service_healthy
+
+        smoke:
+          image: curlimages/curl:8.10.1
+          entrypoint: ["/bin/sh", "-lc"]
+          depends_on:
+            mnemos:
+              condition: service_started
+      YAML
+    - docker compose -f docker-compose.yml -f docker-compose.multi-worker.ci.yml up -d --build redis mnemos
+    - |
+      docker compose -f docker-compose.yml -f docker-compose.multi-worker.ci.yml run --rm smoke '
+        set -eu
+        ready=0
+        for _i in $(seq 1 60); do
+          if curl -fsS http://mnemos:5002/health >/tmp/health.json; then
+            ready=1
+            break
+          fi
+          sleep 2
+        done
+        test "$ready" = "1"
+        curl -fsS -X POST http://mnemos:5002/v1/memories \
+          -H "Content-Type: application/json" \
+          -d "{\"content\":\"multi-worker smoke memory\",\"category\":\"ci\"}" \
+          >/tmp/memory.json
+        curl -fsS "http://mnemos:5002/v1/memories?limit=5" >/tmp/memories.json
+        curl -fsS -X POST http://mnemos:5002/v1/webhooks \
+          -H "Content-Type: application/json" \
+          -d "{\"url\":\"http://127.0.0.1:9/webhook\",\"events\":[\"memory.created\"],\"description\":\"multi-worker smoke\"}" \
+          >/tmp/webhook.json
+      '
+    - docker compose -f docker-compose.yml -f docker-compose.multi-worker.ci.yml logs --no-color mnemos
+  after_script:
+    - docker compose -f docker-compose.yml -f docker-compose.multi-worker.ci.yml down -v --remove-orphans || true
+  allow_failure: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH
+
 # ---- build -------------------------------------------------------------
 
 build:docker:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,12 +40,11 @@ The API will be available at `http://$MNEMOS_BIND:$MNEMOS_PORT`
 
 ---
 
-## Single-Worker Runtime
+## Runtime Scaling
 
-MNEMOS v3.5 runs single-worker by design. In-process state (rate limiter,
-dispatch semaphores, recovery worker) is not yet externalized. Horizontal
-scaling is on the v4 roadmap. Operators wanting throughput should scale memory
-size + DB; do not increase workers.
+MNEMOS runs single-worker by default with `RATE_LIMIT_STORAGE_URI=memory://`.
+Horizontal scaling is supported when Redis backs shared rate-limit and
+circuit-breaker state; see `docs/SCALING.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -636,10 +636,9 @@ python api_server.py        # MNEMOS on port 5002
 curl http://localhost:5002/health
 ```
 
-MNEMOS v3.5 runs single-worker by design. In-process state (rate limiter,
-dispatch semaphores, recovery worker) is not yet externalized. Horizontal
-scaling is on the v4 roadmap. Operators wanting throughput should scale memory
-size + DB; do not increase workers.
+MNEMOS runs single-worker by default with `RATE_LIMIT_STORAGE_URI=memory://`.
+Horizontal scaling is supported when Redis backs shared rate-limit and
+circuit-breaker state; see `docs/SCALING.md`.
 
 ---
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,123 @@
+# MNEMOS Scaling
+
+MNEMOS defaults to one Uvicorn worker and `RATE_LIMIT_STORAGE_URI=memory://`.
+That shape remains valid for existing single-host installs and does not require
+Redis.
+
+Multi-worker deployments are supported when shared rate-limit and resilience
+state is backed by Redis. Without Redis, each worker keeps its own in-process
+rate-limit, circuit-breaker, and concurrency state; MNEMOS logs a startup
+warning but does not block boot.
+
+## Single-worker default
+
+Use the default when one API process can handle the workload:
+
+```bash
+MNEMOS_WORKERS=1
+RATE_LIMIT_STORAGE_URI=memory://
+```
+
+This is the migration-safe path for existing v3.5 installs. No Redis service,
+schema change, or config migration is required.
+
+## Multi-worker pattern
+
+For throughput, add Redis and increase workers:
+
+```bash
+RATE_LIMIT_STORAGE_URI=redis://host:6379/1
+MNEMOS_WORKERS=2
+```
+
+Recommended topologies:
+
+- **1 primary writer + N readers**: route ingest, webhook mutation, admin
+  mutation, and background-worker traffic to the primary writer; route read and
+  search traffic across reader pods or instances.
+- **N+1 writers**: allow every API instance to accept writes when the Postgres
+  pool, Redis, webhook lease settings, and downstream provider limits are sized
+  for the aggregate concurrency.
+
+Size database pools from the total process count:
+
+```text
+total_db_connections = replicas * MNEMOS_WORKERS * PG_POOL_MAX
+```
+
+Keep that total under the Postgres or PgBouncer server-side limit with headroom
+for migrations, psql sessions, and maintenance tasks.
+
+## Docker Compose
+
+Use Redis as an additional service, or point `RATE_LIMIT_STORAGE_URI` at an
+external Redis service:
+
+```yaml
+services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  mnemos:
+    environment:
+      RATE_LIMIT_STORAGE_URI: redis://redis:6379/1
+      MNEMOS_WORKERS: "2"
+    depends_on:
+      redis:
+        condition: service_started
+```
+
+The standard compose file can stay single-worker. Apply this as an override
+when testing or operating multi-worker mode.
+
+## Kubernetes
+
+Run Redis as a managed service or a dedicated in-cluster StatefulSet. Configure
+MNEMOS pods with:
+
+```yaml
+env:
+  - name: RATE_LIMIT_STORAGE_URI
+    value: redis://redis:6379/1
+  - name: MNEMOS_WORKERS
+    value: "2"
+```
+
+HorizontalPodAutoscaler guidance:
+
+- Scale on CPU, request latency, and queue depth rather than request count alone.
+- Account for `replicas * MNEMOS_WORKERS * PG_POOL_MAX` before increasing HPA
+  max replicas.
+- Sticky sessions are not required for rate-limit or circuit-breaker correctness
+  because shared state is in Redis.
+- Keep startup probes tolerant of Redis/Postgres cold starts so a scale-out event
+  does not churn pods before dependencies are reachable.
+
+## PgBouncer and asyncpg
+
+Prefer direct Postgres connections or PgBouncer session pooling for MNEMOS API
+pools. PgBouncer transaction mode can conflict with asyncpg assumptions around
+prepared statements and connection-local state unless the asyncpg pool is
+configured for that shape, such as disabling statement caching.
+
+Current operator notes:
+
+- Keep `PG_POOL_MIN` low in multi-worker pods so scale-out does not stampede
+  Postgres with idle connections.
+- Set `PG_POOL_MAX` from aggregate worker count, not per-pod intuition.
+- Test transaction-mode PgBouncer under write load before production. If it is
+  required, add an explicit deployment profile that configures asyncpg for
+  transaction pooling.
+
+## Migration Story
+
+Existing v3.5 single-worker installs continue to work without changing
+anything. `memory://` remains the default fallback.
+
+Operators who want more throughput should:
+
+1. Add Redis.
+2. Set `RATE_LIMIT_STORAGE_URI=redis://host:6379/1`.
+3. Increase `MNEMOS_WORKERS` or pod replicas.
+4. Re-check Postgres pool sizing and downstream provider limits.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -34,9 +34,9 @@ correlation / Prometheus / OpenTelemetry / opt-in structured logs),
 and an OpenAI-compatible gateway that injects compressed memory
 context on the fly.
 
-Apache-2.0. Horizontal scaling of process-local reliability primitives
-remains future work; run one API worker unless the relevant state has
-been externalized.
+Apache-2.0. MNEMOS runs single-worker by default; horizontal scaling is
+supported when Redis backs shared rate-limit and circuit-breaker state.
+See `docs/SCALING.md`.
 
 ## 2. System Scope
 
@@ -81,9 +81,9 @@ been externalized.
 
 ### 2.2 Explicitly out of scope at v3.5.x
 
-- Horizontal scaling past `workers=1`. GRAEAE reliability primitives
-  (circuit breakers, rate limiters, concurrency guards) are
-  process-local singletons; shared-state refactor remains future work.
+- Published multi-worker throughput guarantees. Redis-backed reliability
+  primitives support multi-worker operation, but measured load-test ceilings
+  remain TODO.
 - Full per-memory deletion-log / GDPR wipe subsystem. v3.5 keeps DELETE
   tombstone snapshots live in the version DAG, but it does not add a separate
   deletion-log table.
@@ -725,13 +725,22 @@ Plus non-`MNEMOS_`-prefixed standards: `GPU_PROVIDER_HOST`,
 - Compression contest throughput depends on APOLLO fallback/judge use;
   ARTEMIS and APOLLO schema matches are CPU-cheap.
 
-### 11.3 Horizontal scaling
+### 11.3 Throughput baseline (Redis multi-worker)
 
-**Currently pinned to `workers=1`.** GRAEAE circuit breakers, rate
-limiters, dispatch semaphores, and recovery workers are in-process state.
-Moving them to shared/external coordination is v4 work.
+Redis-backed multi-worker mode is supported for shared rate-limit and
+circuit-breaker state. Measured multi-worker throughput numbers are not yet
+published.
 
-### 11.4 Backup / restore
+TODO: add load-test results for 2-worker and 3-worker deployments with Redis.
+
+### 11.4 Horizontal scaling
+
+Single-worker remains the default. Multi-worker is supported with Redis via
+`RATE_LIMIT_STORAGE_URI=redis://host:6379/1`; in-process `memory://` fallback
+logs a startup warning when `MNEMOS_WORKERS > 1` because rate-limit and
+circuit-breaker state can drift between processes.
+
+### 11.5 Backup / restore
 
 - `pg_dump` + rolling storage (see `tools/backup/`).
 - MPF v0.1 `/v1/export` endpoint for portable snapshots (not a

--- a/docs/SYSTEM_REQUIREMENTS.md
+++ b/docs/SYSTEM_REQUIREMENTS.md
@@ -54,9 +54,9 @@ for production ingest.
   - **Sufficient**: any CUDA-capable GPU with enough VRAM to load
     the chosen embedding/LLM model. The default models (see
     `CLAUDE.md` at the repo root) fit on 8 GB.
-* **Ancillary**: Redis/memcached NOT required — the contest
-  path is single-worker per the DEPLOYMENT scaling note. Multi-worker
-  coordination is v3.2.
+* **Ancillary**: Redis is not required for the default single-worker
+  deployment. Redis is required for multi-worker shared rate-limit and
+  circuit-breaker state; see `docs/SCALING.md`.
 
 ## Workstation tier — full feature set, CPU-only acceptable
 

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -582,30 +582,35 @@ pyinstaller --onefile mnemos-cli.spec
 
 ---
 
-## 8. Horizontal scaling
+## 8. Horizontal scaling - shipped (v4.0 C.1 + C.2)
 
 ### 8.1 GRAEAE breaker + rate-limit state → Redis
 
-**Current state:** GRAEAE's circuit breaker + in-process semaphores are singletons (only work with `workers=1` in `api_server.py`).
+**Shipped state:** GRAEAE's circuit breaker, rate limiter, and concurrency guard
+have Redis-backed implementations with in-process fallback. The `workers=1`
+operational pin has been removed; multi-worker startup warns when Redis is not
+configured.
 
 **What ships:**
-- `api/resilience.py:RedisCircuitBreaker` — circuit breaker backed by Redis.
-- `api/resilience.py:RedisRateLimiter` — token bucket backed by Redis.
-- MNEMOS startup checks: if Redis available, use it; else fall back to in-process (with warning).
+- `mnemos/core/resilience.py:RedisCircuitBreaker` - circuit breaker backed by Redis.
+- `mnemos/core/resilience.py:RedisRateLimiter` - token bucket backed by Redis.
+- `mnemos/core/resilience.py:RedisConcurrencyLimiter` - Redis slot leases for shared concurrency limits.
+- MNEMOS startup checks: if Redis available, use it; else fall back to in-process and warn when workers > 1.
 
 **Benefit:** Deploy multiple MNEMOS API workers; they coordinate breaker + rate-limit state via Redis.
 
 **Affected files:**
-- New: `api/resilience.py` (Redis-backed primitives).
-- Modified: `api/rate_limit.py` (use RedisRateLimiter), `api/models.py` (use RedisCircuitBreaker for GRAEAE calls).
-- Modified: `api_server.py` — remove `workers=1` constraint; document Redis requirement for horizontal scaling.
+- Modified: `mnemos/core/resilience.py` (Redis-backed primitives).
+- Modified: `mnemos/core/lifecycle.py` (Redis client ownership + multi-worker warning).
+- Modified: `mnemos/cli/main.py`, `mnemos/api/main.py` - remove `workers=1` pin.
+- New: `docs/SCALING.md` - Redis-backed multi-worker deployment doctrine.
 
-**Effort:** 3 days (Redis integration, testing on multi-worker setup).
+**Effort:** shipped across v4.0 C.1 + C.2.
 
 ### 8.2 Documented scaling playbooks
 
 **Deliverables:**
-- `docs/SCALING.md` — how to run MNEMOS on Kubernetes / docker-compose at scale.
+- `docs/SCALING.md` - how to run MNEMOS on Kubernetes / docker-compose at scale.
 - Example: 3x API workers + 1x distillation worker + 1x morpheus worker + Postgres + Redis on k8s.
 - Helm values file: `deploy/mnemos-k8s/values.yaml`.
 

--- a/mnemos/api/main.py
+++ b/mnemos/api/main.py
@@ -254,10 +254,11 @@ if _document_import_available:
 
 if __name__ == "__main__":
     import uvicorn
-    # workers=1 is required: GRAEAE circuit breakers, rate limiters, and semaphores
-    # are in-process state. Multiple workers each get their own copy and will not
-    # share limits. Use MNEMOS_PORT env var to override (default: 5002).
+
+    # Multi-worker is supported when Redis backs the shared resilience
+    # primitives. In-process fallback remains available and logs a startup
+    # warning when MNEMOS_WORKERS > 1 with RATE_LIMIT_STORAGE_URI=memory://.
     settings = get_settings().server
     port = settings.port
     host = settings.bind
-    uvicorn.run(app, host=host, port=port, workers=1)
+    uvicorn.run("mnemos.api.main:app", host=host, port=port, workers=settings.workers)

--- a/mnemos/cli/main.py
+++ b/mnemos/cli/main.py
@@ -328,29 +328,21 @@ def serve(
     ctx: typer.Context,
     host: str = typer.Option("0.0.0.0", "--host", help="API bind address.", is_flag=False),
     port: int = typer.Option(5002, "--port", help="API listen port.", is_flag=False),
-    workers: int = typer.Option(
-        1,
+    workers: Optional[int] = typer.Option(
+        None,
         "--workers",
         is_flag=False,
-        help=(
-            "Uvicorn worker count. Values above 1 are not recommended until "
-            "the Phase C Redis primitives land."
-        ),
+        help="Uvicorn worker count. Defaults to MNEMOS_WORKERS (1).",
     ),
 ) -> None:
     """Run the MNEMOS FastAPI server."""
     if ctx.invoked_subcommand is not None:
         return
 
-    if workers > 1:
-        typer.echo(
-            "WARNING: workers > 1 is not recommended until v4.0 Phase C lands shared Redis primitives.",
-            err=True,
-        )
-
     import uvicorn
 
-    uvicorn.run("mnemos.api.main:app", host=host, port=port, workers=workers)
+    worker_count = workers if workers is not None else get_settings().server.workers
+    uvicorn.run("mnemos.api.main:app", host=host, port=port, workers=worker_count)
 
 
 @serve_app.command("mcp-stdio")

--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -259,6 +259,20 @@ def _peer_url_looks_same_lan(url: str) -> bool:
     return peer_ip.is_private or peer_ip.is_loopback or peer_ip.is_link_local
 
 
+def _warn_if_multi_worker_without_redis(settings) -> None:
+    """Warn when multi-worker mode is using per-process resilience state."""
+    workers = getattr(settings.server, "workers", 1)
+    storage_uri = settings.rate_limit.storage_uri.strip().lower()
+    if workers > 1 and storage_uri == "memory://":
+        logger.warning(
+            "MNEMOS is starting with workers=%d and RATE_LIMIT_STORAGE_URI=memory://; "
+            "multi-worker without Redis will produce drift in rate limit and "
+            "circuit breaker state. Set RATE_LIMIT_STORAGE_URI=redis://host:6379/1 "
+            "for shared state.",
+            workers,
+        )
+
+
 async def _log_federation_startup_guidance(pool: asyncpg.Pool) -> None:
     configured_peer_urls = _configured_federation_peer_urls()
     db_peer_urls: list[str] = []
@@ -291,6 +305,7 @@ async def lifespan(app):
 
     config = _load_config()
     settings = get_settings()
+    _warn_if_multi_worker_without_redis(settings)
 
     try:
         _pool = await asyncpg.create_pool(

--- a/mnemos/domain/compression/gpu_guard.py
+++ b/mnemos/domain/compression/gpu_guard.py
@@ -62,9 +62,9 @@ registry. Multiple GPU-consuming paths sharing the same
 (and any other GPU-consuming path) that the endpoint is unresponsive
 without each having to time out independently.
 
-For v3.2 horizontal-scaling work, the registry becomes a Redis-backed
-shared-state singleton. v3.1 is single-worker per the DEPLOYMENT.md
-scaling note; process-local state is correct for the constraint.
+The deployment is single-process by default; multi-worker is safe with
+Redis-backed shared state since v4.0. Process-local fallback remains
+available for the default single-worker shape.
 """
 
 from __future__ import annotations
@@ -89,7 +89,7 @@ class CircuitState(str, Enum):
 class GuardConfig:
     """Tunables for a GPUGuard.
 
-    Defaults are conservative for the single-worker v3.1 deployment:
+    Defaults are conservative for the single-process default deployment:
     three consecutive failures open the circuit for 30 seconds. Operators
     who run against flaky remote endpoints can relax these; operators
     who want stricter failure isolation can tighten them.

--- a/tests/test_multi_worker_settings.py
+++ b/tests/test_multi_worker_settings.py
@@ -1,0 +1,83 @@
+"""Multi-worker settings and startup warning coverage."""
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+
+from mnemos.core import config
+from mnemos.core import lifecycle
+
+
+_ENV_KEYS = (
+    "MNEMOS_CONFIG_PATH",
+    "MNEMOS_WORKERS",
+    "RATE_LIMIT_STORAGE_URI",
+    "RATE_LIMIT_STORAGE",
+)
+
+
+@contextmanager
+def _isolated_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    config_path: str,
+    env: dict[str, str] | None = None,
+) -> Iterator[None]:
+    with monkeypatch.context() as scoped:
+        for key in _ENV_KEYS:
+            scoped.delenv(key, raising=False)
+        scoped.setenv("MNEMOS_CONFIG_PATH", config_path)
+        for key, value in (env or {}).items():
+            scoped.setenv(key, value)
+        config._reset_settings_for_tests()
+        yield
+    config._reset_settings_for_tests()
+
+
+def test_workers_default_to_one(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, str(tmp_path / "missing.toml")):
+        assert config.get_settings().server.workers == 1
+
+
+def test_workers_override_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, str(tmp_path / "missing.toml"), {"MNEMOS_WORKERS": "4"}):
+        assert config.get_settings().server.workers == 4
+
+
+def test_multi_worker_memory_storage_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    env = {
+        "MNEMOS_WORKERS": "2",
+        "RATE_LIMIT_STORAGE_URI": "memory://",
+    }
+    with _isolated_settings(monkeypatch, str(tmp_path / "missing.toml"), env):
+        settings = config.get_settings()
+        caplog.set_level(logging.WARNING, logger="mnemos.core.lifecycle")
+
+        lifecycle._warn_if_multi_worker_without_redis(settings)
+
+    assert "multi-worker without Redis will produce drift" in caplog.text
+    assert "rate limit and circuit breaker state" in caplog.text
+
+
+def test_multi_worker_redis_storage_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    env = {
+        "MNEMOS_WORKERS": "2",
+        "RATE_LIMIT_STORAGE_URI": "redis://redis:6379/1",
+    }
+    with _isolated_settings(monkeypatch, str(tmp_path / "missing.toml"), env):
+        settings = config.get_settings()
+        caplog.set_level(logging.WARNING, logger="mnemos.core.lifecycle")
+
+        lifecycle._warn_if_multi_worker_without_redis(settings)
+
+    assert "multi-worker without Redis will produce drift" not in caplog.text


### PR DESCRIPTION
Drops the workers=1 hard pin now that C.1 shipped Redis-backed primitives. CLI and api/main.py honor Settings.server.workers; honest startup warning when workers>1 + memory:// rate-limit storage. docs/SCALING.md ships the K8s/Redis playbook. Doctrine updated across DEPLOYMENT/README/SPECIFICATION/SYSTEM_REQUIREMENTS/V4_PLAN. multi-worker integration smoke job in GitLab CI (allow_failure initially). 985 passed (+4 multi-worker tests), ruff clean, 6 import-linter contracts kept. GPT independent audit #1 concern fully resolved. Authored-By: Codex