### PR TITLE
v4.0 D.1: persistence abstraction interface

### DIFF
--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -1,5 +1,6 @@
 """Shared globals, lifespan, and DB/cache helpers for MNEMOS API."""
 import hashlib
+import importlib
 import ipaddress
 import json
 import logging
@@ -11,7 +12,7 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, Protocol
 from urllib.parse import urlparse
 
 import asyncpg
@@ -24,6 +25,11 @@ from mnemos.core.config import PG_CONFIG, get_settings
 from mnemos.core.pool import PoolManager
 
 logger = logging.getLogger(__name__)
+
+
+class PersistenceBackend(Protocol):
+    async def close(self) -> None:
+        ...
 
 # Background task registries — keep finite webhook sends out of the cancel-first
 # worker pool so graceful shutdown can let them finalize their leases.
@@ -192,9 +198,16 @@ _EMBED_TIMEOUT = _PROVIDER_SETTINGS.inference_embed_timeout
 # ── Singleton globals ────────────────────────────────────────────────────────
 _pool: Optional[asyncpg.Pool] = None
 _pool_manager: Optional[PoolManager] = None
+_persistence_backend: PersistenceBackend | None = None
 _cache: Optional[aioredis.Redis] = None
 _redis_client: Optional[aioredis.Redis] = None
 _rls_enabled: bool = False   # set from config at startup; read by handlers
+
+
+def _build_postgres_backend(pool, settings):
+    """Build the current persistence backend without a static core -> db edge."""
+    postgres_module = importlib.import_module("mnemos.persistence.postgres")
+    return postgres_module.PostgresBackend(pool, settings)
 
 
 def _load_config() -> dict:
@@ -300,7 +313,7 @@ async def _log_federation_startup_guidance(pool: asyncpg.Pool) -> None:
 @asynccontextmanager
 async def lifespan(app):
     """FastAPI lifespan: initialize and teardown DB pool, Redis, and workers."""
-    global _pool, _pool_manager, _cache, _redis_client, _rls_enabled, _worker_status
+    global _pool, _pool_manager, _persistence_backend, _cache, _redis_client, _rls_enabled, _worker_status
     logger.info("Starting MNEMOS API Server v3.0.0 (gateway + sessions + DAG + workers)")
 
     config = _load_config()
@@ -318,8 +331,10 @@ async def lifespan(app):
             max_size=PG_CONFIG['pool_max_size'],
         )
         _pool_manager = PoolManager(_pool)
+        _persistence_backend = _build_postgres_backend(_pool, settings)
         app.state.pool = _pool   # auth.py reads this via request.app.state.pool
         app.state.pool_manager = _pool_manager
+        app.state.persistence_backend = _persistence_backend
         logger.info(
             f"asyncpg connection pool initialized "
             f"(min={PG_CONFIG['pool_min_size']}, max={PG_CONFIG['pool_max_size']})"
@@ -455,9 +470,14 @@ async def lifespan(app):
         timeout=_WORKER_SHUTDOWN_CANCEL_SECONDS,
     )
 
-    if _pool:
+    if _persistence_backend is not None:
+        await _persistence_backend.close()
+        logger.info("Persistence backend closed")
+    elif _pool:
         await _pool.close()
         logger.info("DB pool closed")
+    _persistence_backend = None
+    _pool = None
     _pool_manager = None
     if _redis_client:
         await _redis_client.aclose()
@@ -507,6 +527,13 @@ def get_pool_manager() -> PoolManager:
             raise HTTPException(status_code=503, detail="Database pool not available")
         _pool_manager = PoolManager(_pool)
     return _pool_manager
+
+
+def get_persistence_backend() -> PersistenceBackend:
+    """Return the lifecycle-owned persistence backend singleton."""
+    if _persistence_backend is None:
+        raise HTTPException(status_code=503, detail="Persistence backend not available")
+    return _persistence_backend
 
 
 def get_redis_client() -> Optional[aioredis.Redis]:

--- a/mnemos/persistence/__init__.py
+++ b/mnemos/persistence/__init__.py
@@ -1,0 +1,55 @@
+"""Persistence abstraction public API."""
+
+from mnemos.persistence.base import (
+    BranchRepository,
+    CompressionRepository,
+    ConsultationAuditRepository,
+    FederationRepository,
+    KGRepository,
+    MemoryRepository,
+    PersistenceBackend,
+    StateRepository,
+    Transaction,
+    VersionRepository,
+    WebhookRepository,
+)
+from mnemos.persistence.postgres import (
+    PostgresBackend,
+    PostgresBranchRepository,
+    PostgresCompressionRepository,
+    PostgresConsultationAuditRepository,
+    PostgresFederationRepository,
+    PostgresKGRepository,
+    PostgresMemoryRepository,
+    PostgresStateRepository,
+    PostgresTransaction,
+    PostgresVersionRepository,
+    PostgresWebhookRepository,
+)
+from mnemos.persistence.types import ModelRecommendation
+
+__all__ = [
+    "BranchRepository",
+    "CompressionRepository",
+    "ConsultationAuditRepository",
+    "FederationRepository",
+    "KGRepository",
+    "MemoryRepository",
+    "ModelRecommendation",
+    "PersistenceBackend",
+    "PostgresBackend",
+    "PostgresBranchRepository",
+    "PostgresCompressionRepository",
+    "PostgresConsultationAuditRepository",
+    "PostgresFederationRepository",
+    "PostgresKGRepository",
+    "PostgresMemoryRepository",
+    "PostgresStateRepository",
+    "PostgresTransaction",
+    "PostgresVersionRepository",
+    "PostgresWebhookRepository",
+    "StateRepository",
+    "Transaction",
+    "VersionRepository",
+    "WebhookRepository",
+]

--- a/mnemos/persistence/base.py
+++ b/mnemos/persistence/base.py
@@ -1,0 +1,450 @@
+"""Backend-neutral persistence interfaces for MNEMOS."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from typing import Any, AsyncContextManager, Protocol, runtime_checkable
+
+from mnemos.core.auth_context import UserContext
+from mnemos.persistence.types import Row
+
+
+@runtime_checkable
+class Transaction(Protocol):
+    """Backend-neutral transaction handle.
+
+    Repository methods accept this protocol instead of exposing driver-specific
+    connection objects. Concrete repositories are responsible for translating
+    the handle into their backend's private connection/session type.
+    """
+
+    async def commit(self) -> None:
+        """Commit the transaction."""
+        ...
+
+    async def rollback(self) -> None:
+        """Rollback the transaction."""
+        ...
+
+
+class MemoryRepository(ABC):
+    """Memory row, memory export, and memory DAG read operations."""
+
+    @abstractmethod
+    async def assert_memory_readable(self, tx: Transaction, memory_id: str, user: UserContext) -> None:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_log(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        branch: str,
+        limit: int,
+        user: UserContext,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_diff_commit_pair(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_a: str,
+        commit_b: str,
+        user: UserContext,
+    ) -> tuple[Row | None, Row | None]:
+        ...
+
+    @abstractmethod
+    async def fetch_checkout_commit(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_hash: str,
+        user: UserContext,
+    ) -> Row | None:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_export(
+        self,
+        tx: Transaction,
+        *,
+        effective_owner: str | None,
+        effective_ns: str | None,
+        category: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_referenced_memory_allowlist(
+        self,
+        tx: Transaction,
+        *,
+        referenced_ids: Sequence[str],
+        scope_owner: str | None = None,
+        scope_namespace: str | None = None,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def insert_memory(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        content: str,
+        category: str,
+        subcategory: str | None,
+        metadata_json: str,
+        quality_rating: int,
+        owner_id: str,
+        namespace: str,
+        permission_mode: int,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        created: Any,
+        updated: Any,
+    ) -> str:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_by_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        ...
+
+    @abstractmethod
+    async def set_suppress_version_snapshot(self, tx: Transaction) -> None:
+        ...
+
+    @abstractmethod
+    async def fetch_versioned_memory_ids(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_head_checks(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_context(
+        self,
+        tx: Transaction,
+        query: str,
+        user: Any,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        ...
+
+
+class KGRepository(ABC):
+    """Knowledge graph triple persistence."""
+
+    @abstractmethod
+    async def fetch_kg_triples_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        include_unattached: bool,
+        hard_limit: int,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def insert_kg_triple(
+        self,
+        tx: Transaction,
+        *,
+        triple_id: str,
+        subject: str,
+        predicate: str,
+        obj: str,
+        subject_type: str | None,
+        object_type: str | None,
+        valid_from: Any,
+        valid_until: Any,
+        memory_id: str | None,
+        confidence: float | None,
+        created: Any,
+        owner_id: str,
+        namespace: str | None,
+    ) -> str:
+        ...
+
+    @abstractmethod
+    async def fetch_kg_triple_by_id(self, tx: Transaction, triple_id: str) -> Row | None:
+        ...
+
+
+class VersionRepository(ABC):
+    """Memory version persistence and topology lookups."""
+
+    @abstractmethod
+    async def fetch_memory_versions_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_versions_by_ids(self, tx: Transaction, version_ids: Sequence[str]) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def insert_memory_version(
+        self,
+        tx: Transaction,
+        *,
+        version_id: str,
+        memory_id: str,
+        version_num: int,
+        content: str,
+        category: str | None,
+        subcategory: str | None,
+        metadata_json: str,
+        verbatim_content: str | None,
+        owner_id: str,
+        namespace: str | None,
+        permission_mode: int | None,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        snapshot_at: Any,
+        snapshot_by: str | None,
+        change_type: str | None,
+        commit_hash: str | None,
+        parent_version_id: str | None,
+        branch: str | None,
+        merge_parents: Any,
+    ) -> str:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_version_by_id(self, tx: Transaction, version_id: str) -> Row | None:
+        ...
+
+
+class BranchRepository(ABC):
+    """Memory branch persistence."""
+
+    @abstractmethod
+    async def create_memory_branch(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        name: str,
+        from_commit: str | None,
+        user: UserContext,
+    ) -> dict[str, Any]:
+        ...
+
+    @abstractmethod
+    async def delete_memory_branches_for_memories(self, tx: Transaction, memory_ids: Sequence[str]) -> None:
+        ...
+
+    @abstractmethod
+    async def fetch_memory_branch_heads(
+        self,
+        tx: Transaction,
+        memory_ids: Sequence[str],
+        *,
+        authorized_version_uuids: Sequence[str] | None = None,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def upsert_memory_branch_head(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        branch: str,
+        head_version_id: Any,
+    ) -> None:
+        ...
+
+
+class CompressionRepository(ABC):
+    """Compressed memory variant persistence."""
+
+    @abstractmethod
+    async def fetch_compressed_variants_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def compression_candidate_exists(
+        self,
+        tx: Transaction,
+        *,
+        candidate_id: str,
+        memory_id: str,
+        owner_id: str,
+    ) -> bool:
+        ...
+
+    @abstractmethod
+    async def insert_compressed_variant(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        owner_id: str,
+        winner_candidate_id: str | None,
+        engine_id: str,
+        engine_version: str | None,
+        compressed_content: str | None,
+        compressed_tokens: int | None,
+        compression_ratio: float | None,
+        quality_score: float | None,
+        composite_score: float | None,
+        scoring_profile: str | None,
+        judge_model: str | None,
+        selected_at: Any,
+    ) -> str:
+        ...
+
+    @abstractmethod
+    async def fetch_compressed_variant_by_memory_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        ...
+
+
+class WebhookRepository(ABC):
+    """Webhook persistence surface.
+
+    Webhook SQL has not been extracted into mnemos/db repositories in D.1.
+    """
+
+
+class ConsultationAuditRepository(ABC):
+    """OpenAI-compatible gateway and consultation audit persistence lookups."""
+
+    @abstractmethod
+    async def fetch_recommended_model(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float,
+        quality_floor: float,
+    ) -> tuple[dict[str, Any] | None, list[str]]:
+        ...
+
+    @abstractmethod
+    async def fetch_model_recommendation(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float = 10.0,
+        quality_floor: float = 0.85,
+    ) -> dict[str, Any] | None:
+        ...
+
+    @abstractmethod
+    async def lookup_provider_for_model(self, tx: Transaction, model: str) -> str | None:
+        ...
+
+    @abstractmethod
+    async def fetch_available_models(self, tx: Transaction) -> list[Row]:
+        ...
+
+    @abstractmethod
+    async def fetch_model_provider(self, tx: Transaction, model_id: str) -> str | None:
+        ...
+
+
+class FederationRepository(ABC):
+    """Federation persistence surface.
+
+    Federation SQL has not been extracted into mnemos/db repositories in D.1.
+    """
+
+
+class StateRepository(ABC):
+    """State key-value persistence surface.
+
+    State SQL has not been extracted into mnemos/db repositories in D.1.
+    """
+
+
+class PersistenceBackend(ABC):
+    """Top-level facade exposing backend-specific repository families."""
+
+    @abstractmethod
+    def transactional(self) -> AsyncContextManager[Transaction]:
+        """Open a backend-neutral transaction context."""
+        ...
+
+    @property
+    @abstractmethod
+    def memories(self) -> MemoryRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def kg_triples(self) -> KGRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def memory_versions(self) -> VersionRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def memory_branches(self) -> BranchRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def compression(self) -> CompressionRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def webhooks(self) -> WebhookRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def consultations_audit(self) -> ConsultationAuditRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def federation(self) -> FederationRepository:
+        ...
+
+    @property
+    @abstractmethod
+    def state_kv(self) -> StateRepository:
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        ...
+
+
+@asynccontextmanager
+async def null_transaction(tx: Transaction) -> AsyncIterator[Transaction]:
+    """Yield an existing transaction without managing its lifecycle."""
+    yield tx

--- a/mnemos/persistence/postgres.py
+++ b/mnemos/persistence/postgres.py
@@ -1,0 +1,578 @@
+"""Postgres persistence backend shell.
+
+D.1 keeps the existing mnemos/db repository functions as the implementation
+source of truth. These classes only adapt their asyncpg connection parameters
+to the backend-neutral persistence interfaces.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+
+from mnemos.core.auth_context import UserContext
+from mnemos.db import mcp_repo, openai_compat_repo, portability_repo
+from mnemos.persistence.base import (
+    BranchRepository,
+    CompressionRepository,
+    ConsultationAuditRepository,
+    FederationRepository,
+    KGRepository,
+    MemoryRepository,
+    PersistenceBackend,
+    StateRepository,
+    Transaction,
+    VersionRepository,
+    WebhookRepository,
+)
+from mnemos.persistence.types import Row
+
+
+class PostgresTransaction:
+    """Transaction wrapper that keeps asyncpg private to the Postgres adapter."""
+
+    def __init__(self, conn: asyncpg.Connection, tx: Any):
+        self._conn = conn
+        self._tx = tx
+        self._closed = False
+
+    @property
+    def conn(self) -> asyncpg.Connection:
+        return self._conn
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def commit(self) -> None:
+        if self._closed:
+            return
+        await self._tx.commit()
+        self._closed = True
+
+    async def rollback(self) -> None:
+        if self._closed:
+            return
+        await self._tx.rollback()
+        self._closed = True
+
+
+def _postgres_tx(tx: Transaction) -> PostgresTransaction:
+    if not isinstance(tx, PostgresTransaction):
+        raise TypeError("Postgres repositories require a PostgresTransaction")
+    return tx
+
+
+class PostgresMemoryRepository(MemoryRepository):
+    async def assert_memory_readable(self, tx: Transaction, memory_id: str, user: UserContext) -> None:
+        await mcp_repo.assert_memory_readable(_postgres_tx(tx).conn, memory_id, user)
+
+    async def fetch_memory_log(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        branch: str,
+        limit: int,
+        user: UserContext,
+    ) -> list[Row]:
+        return await mcp_repo.fetch_memory_log(_postgres_tx(tx).conn, memory_id, branch, limit, user)
+
+    async def fetch_diff_commit_pair(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_a: str,
+        commit_b: str,
+        user: UserContext,
+    ) -> tuple[Row | None, Row | None]:
+        return await mcp_repo.fetch_diff_commit_pair(_postgres_tx(tx).conn, memory_id, commit_a, commit_b, user)
+
+    async def fetch_checkout_commit(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_hash: str,
+        user: UserContext,
+    ) -> Row | None:
+        return await mcp_repo.fetch_checkout_commit(_postgres_tx(tx).conn, memory_id, commit_hash, user)
+
+    async def fetch_memory_export(
+        self,
+        tx: Transaction,
+        *,
+        effective_owner: str | None,
+        effective_ns: str | None,
+        category: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[Row]:
+        return await portability_repo.fetch_memory_export(
+            _postgres_tx(tx).conn,
+            effective_owner=effective_owner,
+            effective_ns=effective_ns,
+            category=category,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def fetch_referenced_memory_allowlist(
+        self,
+        tx: Transaction,
+        *,
+        referenced_ids: Sequence[str],
+        scope_owner: str | None = None,
+        scope_namespace: str | None = None,
+    ) -> list[Row]:
+        return await portability_repo.fetch_referenced_memory_allowlist(
+            _postgres_tx(tx).conn,
+            referenced_ids=referenced_ids,
+            scope_owner=scope_owner,
+            scope_namespace=scope_namespace,
+        )
+
+    async def insert_memory(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        content: str,
+        category: str,
+        subcategory: str | None,
+        metadata_json: str,
+        quality_rating: int,
+        owner_id: str,
+        namespace: str,
+        permission_mode: int,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        created: Any,
+        updated: Any,
+    ) -> str:
+        return await portability_repo.insert_memory(
+            _postgres_tx(tx).conn,
+            memory_id=memory_id,
+            content=content,
+            category=category,
+            subcategory=subcategory,
+            metadata_json=metadata_json,
+            quality_rating=quality_rating,
+            owner_id=owner_id,
+            namespace=namespace,
+            permission_mode=permission_mode,
+            source_model=source_model,
+            source_provider=source_provider,
+            source_session=source_session,
+            source_agent=source_agent,
+            created=created,
+            updated=updated,
+        )
+
+    async def fetch_memory_by_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        return await portability_repo.fetch_memory_by_id(_postgres_tx(tx).conn, memory_id)
+
+    async def set_suppress_version_snapshot(self, tx: Transaction) -> None:
+        await portability_repo.set_suppress_version_snapshot(_postgres_tx(tx).conn)
+
+    async def fetch_versioned_memory_ids(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        return await portability_repo.fetch_versioned_memory_ids(_postgres_tx(tx).conn, memory_ids)
+
+    async def fetch_memory_head_checks(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        return await portability_repo.fetch_memory_head_checks(_postgres_tx(tx).conn, memory_ids)
+
+    async def fetch_memory_context(
+        self,
+        tx: Transaction,
+        query: str,
+        user: Any,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        _postgres_tx(tx)
+        return await openai_compat_repo.fetch_memory_context(query, user, limit=limit)
+
+
+class PostgresKGRepository(KGRepository):
+    async def fetch_kg_triples_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        include_unattached: bool,
+        hard_limit: int,
+    ) -> list[Row]:
+        return await portability_repo.fetch_kg_triples_for_export(
+            _postgres_tx(tx).conn,
+            memory_ids=memory_ids,
+            effective_owner=effective_owner,
+            effective_ns=effective_ns,
+            include_unattached=include_unattached,
+            hard_limit=hard_limit,
+        )
+
+    async def insert_kg_triple(
+        self,
+        tx: Transaction,
+        *,
+        triple_id: str,
+        subject: str,
+        predicate: str,
+        obj: str,
+        subject_type: str | None,
+        object_type: str | None,
+        valid_from: Any,
+        valid_until: Any,
+        memory_id: str | None,
+        confidence: float | None,
+        created: Any,
+        owner_id: str,
+        namespace: str | None,
+    ) -> str:
+        return await portability_repo.insert_kg_triple(
+            _postgres_tx(tx).conn,
+            triple_id=triple_id,
+            subject=subject,
+            predicate=predicate,
+            obj=obj,
+            subject_type=subject_type,
+            object_type=object_type,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            memory_id=memory_id,
+            confidence=confidence,
+            created=created,
+            owner_id=owner_id,
+            namespace=namespace,
+        )
+
+    async def fetch_kg_triple_by_id(self, tx: Transaction, triple_id: str) -> Row | None:
+        return await portability_repo.fetch_kg_triple_by_id(_postgres_tx(tx).conn, triple_id)
+
+
+class PostgresVersionRepository(VersionRepository):
+    async def fetch_memory_versions_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        return await portability_repo.fetch_memory_versions_for_export(
+            _postgres_tx(tx).conn,
+            memory_ids=memory_ids,
+            effective_owner=effective_owner,
+            effective_ns=effective_ns,
+            hard_limit=hard_limit,
+        )
+
+    async def fetch_memory_versions_by_ids(self, tx: Transaction, version_ids: Sequence[str]) -> list[Row]:
+        return await portability_repo.fetch_memory_versions_by_ids(_postgres_tx(tx).conn, version_ids)
+
+    async def insert_memory_version(
+        self,
+        tx: Transaction,
+        *,
+        version_id: str,
+        memory_id: str,
+        version_num: int,
+        content: str,
+        category: str | None,
+        subcategory: str | None,
+        metadata_json: str,
+        verbatim_content: str | None,
+        owner_id: str,
+        namespace: str | None,
+        permission_mode: int | None,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        snapshot_at: Any,
+        snapshot_by: str | None,
+        change_type: str | None,
+        commit_hash: str | None,
+        parent_version_id: str | None,
+        branch: str | None,
+        merge_parents: Any,
+    ) -> str:
+        return await portability_repo.insert_memory_version(
+            _postgres_tx(tx).conn,
+            version_id=version_id,
+            memory_id=memory_id,
+            version_num=version_num,
+            content=content,
+            category=category,
+            subcategory=subcategory,
+            metadata_json=metadata_json,
+            verbatim_content=verbatim_content,
+            owner_id=owner_id,
+            namespace=namespace,
+            permission_mode=permission_mode,
+            source_model=source_model,
+            source_provider=source_provider,
+            source_session=source_session,
+            source_agent=source_agent,
+            snapshot_at=snapshot_at,
+            snapshot_by=snapshot_by,
+            change_type=change_type,
+            commit_hash=commit_hash,
+            parent_version_id=parent_version_id,
+            branch=branch,
+            merge_parents=merge_parents,
+        )
+
+    async def fetch_memory_version_by_id(self, tx: Transaction, version_id: str) -> Row | None:
+        return await portability_repo.fetch_memory_version_by_id(_postgres_tx(tx).conn, version_id)
+
+
+class PostgresBranchRepository(BranchRepository):
+    async def create_memory_branch(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        name: str,
+        from_commit: str | None,
+        user: UserContext,
+    ) -> dict[str, Any]:
+        return await mcp_repo.create_memory_branch(_postgres_tx(tx).conn, memory_id, name, from_commit, user)
+
+    async def delete_memory_branches_for_memories(self, tx: Transaction, memory_ids: Sequence[str]) -> None:
+        await portability_repo.delete_memory_branches_for_memories(_postgres_tx(tx).conn, memory_ids)
+
+    async def fetch_memory_branch_heads(
+        self,
+        tx: Transaction,
+        memory_ids: Sequence[str],
+        *,
+        authorized_version_uuids: Sequence[str] | None = None,
+    ) -> list[Row]:
+        return await portability_repo.fetch_memory_branch_heads(
+            _postgres_tx(tx).conn,
+            memory_ids,
+            authorized_version_uuids=authorized_version_uuids,
+        )
+
+    async def upsert_memory_branch_head(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        branch: str,
+        head_version_id: Any,
+    ) -> None:
+        await portability_repo.upsert_memory_branch_head(
+            _postgres_tx(tx).conn,
+            memory_id=memory_id,
+            branch=branch,
+            head_version_id=head_version_id,
+        )
+
+
+class PostgresCompressionRepository(CompressionRepository):
+    async def fetch_compressed_variants_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        return await portability_repo.fetch_compressed_variants_for_export(
+            _postgres_tx(tx).conn,
+            memory_ids=memory_ids,
+            effective_owner=effective_owner,
+            hard_limit=hard_limit,
+        )
+
+    async def compression_candidate_exists(
+        self,
+        tx: Transaction,
+        *,
+        candidate_id: str,
+        memory_id: str,
+        owner_id: str,
+    ) -> bool:
+        return await portability_repo.compression_candidate_exists(
+            _postgres_tx(tx).conn,
+            candidate_id=candidate_id,
+            memory_id=memory_id,
+            owner_id=owner_id,
+        )
+
+    async def insert_compressed_variant(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        owner_id: str,
+        winner_candidate_id: str | None,
+        engine_id: str,
+        engine_version: str | None,
+        compressed_content: str | None,
+        compressed_tokens: int | None,
+        compression_ratio: float | None,
+        quality_score: float | None,
+        composite_score: float | None,
+        scoring_profile: str | None,
+        judge_model: str | None,
+        selected_at: Any,
+    ) -> str:
+        return await portability_repo.insert_compressed_variant(
+            _postgres_tx(tx).conn,
+            memory_id=memory_id,
+            owner_id=owner_id,
+            winner_candidate_id=winner_candidate_id,
+            engine_id=engine_id,
+            engine_version=engine_version,
+            compressed_content=compressed_content,
+            compressed_tokens=compressed_tokens,
+            compression_ratio=compression_ratio,
+            quality_score=quality_score,
+            composite_score=composite_score,
+            scoring_profile=scoring_profile,
+            judge_model=judge_model,
+            selected_at=selected_at,
+        )
+
+    async def fetch_compressed_variant_by_memory_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        return await portability_repo.fetch_compressed_variant_by_memory_id(_postgres_tx(tx).conn, memory_id)
+
+
+class PostgresWebhookRepository(WebhookRepository):
+    pass
+
+
+class PostgresConsultationAuditRepository(ConsultationAuditRepository):
+    async def fetch_recommended_model(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float,
+        quality_floor: float,
+    ) -> tuple[dict[str, Any] | None, list[str]]:
+        return await mcp_repo.fetch_recommended_model(_postgres_tx(tx).conn, task_type, cost_budget, quality_floor)
+
+    async def fetch_model_recommendation(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float = 10.0,
+        quality_floor: float = 0.85,
+    ) -> dict[str, Any] | None:
+        _postgres_tx(tx)
+        return await openai_compat_repo.fetch_model_recommendation(task_type, cost_budget, quality_floor)
+
+    async def lookup_provider_for_model(self, tx: Transaction, model: str) -> str | None:
+        _postgres_tx(tx)
+        return await openai_compat_repo.lookup_provider_for_model(model)
+
+    async def fetch_available_models(self, tx: Transaction) -> list[Row]:
+        _postgres_tx(tx)
+        return await openai_compat_repo.fetch_available_models()
+
+    async def fetch_model_provider(self, tx: Transaction, model_id: str) -> str | None:
+        _postgres_tx(tx)
+        return await openai_compat_repo.fetch_model_provider(model_id)
+
+
+class PostgresFederationRepository(FederationRepository):
+    pass
+
+
+class PostgresStateRepository(StateRepository):
+    pass
+
+
+class PostgresBackend(PersistenceBackend):
+    """Postgres persistence facade backed by an asyncpg pool."""
+
+    def __init__(self, pool: asyncpg.Pool, settings: Any):
+        self._pool = pool
+        self._settings = settings
+        self._memories = PostgresMemoryRepository()
+        self._kg_triples = PostgresKGRepository()
+        self._memory_versions = PostgresVersionRepository()
+        self._memory_branches = PostgresBranchRepository()
+        self._compression = PostgresCompressionRepository()
+        self._webhooks = PostgresWebhookRepository()
+        self._consultations_audit = PostgresConsultationAuditRepository()
+        self._federation = PostgresFederationRepository()
+        self._state_kv = PostgresStateRepository()
+        self._closed = False
+
+    @property
+    def settings(self) -> Any:
+        return self._settings
+
+    @asynccontextmanager
+    async def transactional(self) -> AsyncIterator[Transaction]:
+        acquire_ctx = self._pool.acquire()
+        if inspect.isawaitable(acquire_ctx):
+            acquire_ctx = await acquire_ctx
+        async with acquire_ctx as conn:
+            raw_tx = conn.transaction()
+            await raw_tx.start()
+            tx = PostgresTransaction(conn, raw_tx)
+            try:
+                yield tx
+            except BaseException:
+                if not tx.closed:
+                    await tx.rollback()
+                raise
+            else:
+                if not tx.closed:
+                    await tx.commit()
+
+    @property
+    def memories(self) -> MemoryRepository:
+        return self._memories
+
+    @property
+    def kg_triples(self) -> KGRepository:
+        return self._kg_triples
+
+    @property
+    def memory_versions(self) -> VersionRepository:
+        return self._memory_versions
+
+    @property
+    def memory_branches(self) -> BranchRepository:
+        return self._memory_branches
+
+    @property
+    def compression(self) -> CompressionRepository:
+        return self._compression
+
+    @property
+    def webhooks(self) -> WebhookRepository:
+        return self._webhooks
+
+    @property
+    def consultations_audit(self) -> ConsultationAuditRepository:
+        return self._consultations_audit
+
+    @property
+    def federation(self) -> FederationRepository:
+        return self._federation
+
+    @property
+    def state_kv(self) -> StateRepository:
+        return self._state_kv
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        close = getattr(self._pool, "close", None)
+        if close is not None:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        self._closed = True

--- a/mnemos/persistence/types.py
+++ b/mnemos/persistence/types.py
@@ -1,0 +1,23 @@
+"""Shared persistence typing primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+JSONObject: TypeAlias = dict[str, JSONValue]
+Row: TypeAlias = Any
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRecommendation:
+    """Backend-neutral shape for model routing recommendations."""
+
+    provider: str
+    model_id: str
+    display_name: str | None
+    cost_per_mtok: float
+    quality_score: float
+    context_window: int | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ type = "layers"
 layers = [
   "mnemos.api",
   "mnemos.domain",
+  "mnemos.persistence",
   "mnemos.db",
   "mnemos.core",
 ]
@@ -182,6 +183,18 @@ allow_indirect_imports = true
 name = "webhooks does not couple to domain"
 type = "independence"
 modules = ["mnemos.webhooks", "mnemos.domain"]
+
+[[tool.importlinter.contracts]]
+name = "persistence has no upward deps"
+type = "forbidden"
+source_modules = ["mnemos.persistence"]
+forbidden_modules = [
+  "mnemos.api",
+  "mnemos.domain",
+  "mnemos.mcp",
+  "mnemos.webhooks",
+  "mnemos.workers",
+]
 
 [[tool.importlinter.contracts]]
 name = "core does not import api/domain/db/webhooks/mcp/etc"

--- a/tests/test_persistence_interface.py
+++ b/tests/test_persistence_interface.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import mnemos.core.lifecycle as lifecycle
+from mnemos.persistence import (
+    BranchRepository,
+    CompressionRepository,
+    ConsultationAuditRepository,
+    FederationRepository,
+    KGRepository,
+    MemoryRepository,
+    PersistenceBackend,
+    PostgresBackend,
+    PostgresBranchRepository,
+    PostgresCompressionRepository,
+    PostgresConsultationAuditRepository,
+    PostgresFederationRepository,
+    PostgresKGRepository,
+    PostgresMemoryRepository,
+    PostgresStateRepository,
+    PostgresTransaction,
+    PostgresVersionRepository,
+    PostgresWebhookRepository,
+    StateRepository,
+    Transaction,
+    VersionRepository,
+    WebhookRepository,
+)
+
+
+class FakeAsyncpgTransaction:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    async def start(self) -> None:
+        self.calls.append("start")
+
+    async def commit(self) -> None:
+        self.calls.append("commit")
+
+    async def rollback(self) -> None:
+        self.calls.append("rollback")
+
+
+class FakeConnection:
+    def __init__(self, raw_tx: FakeAsyncpgTransaction):
+        self.raw_tx = raw_tx
+
+    def transaction(self) -> FakeAsyncpgTransaction:
+        return self.raw_tx
+
+
+class FakeAcquire:
+    def __init__(self, conn: FakeConnection):
+        self.conn = conn
+
+    async def __aenter__(self) -> FakeConnection:
+        return self.conn
+
+    async def __aexit__(self, *_exc_info) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection):
+        self.conn = conn
+        self.close_calls = 0
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self.conn)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+def _backend_with_raw_tx(raw_tx: FakeAsyncpgTransaction) -> PostgresBackend:
+    return PostgresBackend(FakePool(FakeConnection(raw_tx)), SimpleNamespace())
+
+
+def test_persistence_backend_abc_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        PersistenceBackend()
+
+
+def test_postgres_backend_exposes_all_repository_properties():
+    backend = _backend_with_raw_tx(FakeAsyncpgTransaction())
+
+    assert isinstance(backend.memories, MemoryRepository)
+    assert isinstance(backend.kg_triples, KGRepository)
+    assert isinstance(backend.memory_versions, VersionRepository)
+    assert isinstance(backend.memory_branches, BranchRepository)
+    assert isinstance(backend.compression, CompressionRepository)
+    assert isinstance(backend.webhooks, WebhookRepository)
+    assert isinstance(backend.consultations_audit, ConsultationAuditRepository)
+    assert isinstance(backend.federation, FederationRepository)
+    assert isinstance(backend.state_kv, StateRepository)
+
+
+def test_postgres_backend_repositories_are_postgres_adapters():
+    backend = _backend_with_raw_tx(FakeAsyncpgTransaction())
+
+    assert isinstance(backend.memories, PostgresMemoryRepository)
+    assert isinstance(backend.kg_triples, PostgresKGRepository)
+    assert isinstance(backend.memory_versions, PostgresVersionRepository)
+    assert isinstance(backend.memory_branches, PostgresBranchRepository)
+    assert isinstance(backend.compression, PostgresCompressionRepository)
+    assert isinstance(backend.webhooks, PostgresWebhookRepository)
+    assert isinstance(backend.consultations_audit, PostgresConsultationAuditRepository)
+    assert isinstance(backend.federation, PostgresFederationRepository)
+    assert isinstance(backend.state_kv, PostgresStateRepository)
+
+
+@pytest.mark.asyncio
+async def test_postgres_transaction_auto_commit_uses_asyncpg_transaction():
+    raw_tx = FakeAsyncpgTransaction()
+    backend = _backend_with_raw_tx(raw_tx)
+
+    async with backend.transactional() as tx:
+        assert isinstance(tx, Transaction)
+        assert isinstance(tx, PostgresTransaction)
+
+    assert raw_tx.calls == ["start", "commit"]
+
+
+@pytest.mark.asyncio
+async def test_postgres_transaction_explicit_rollback_skips_auto_commit():
+    raw_tx = FakeAsyncpgTransaction()
+    backend = _backend_with_raw_tx(raw_tx)
+
+    async with backend.transactional() as tx:
+        await tx.rollback()
+
+    assert raw_tx.calls == ["start", "rollback"]
+
+
+@pytest.mark.asyncio
+async def test_postgres_transaction_exception_rolls_back():
+    raw_tx = FakeAsyncpgTransaction()
+    backend = _backend_with_raw_tx(raw_tx)
+
+    with pytest.raises(RuntimeError):
+        async with backend.transactional():
+            raise RuntimeError("boom")
+
+    assert raw_tx.calls == ["start", "rollback"]
+
+
+def test_get_persistence_backend_returns_lifecycle_singleton(monkeypatch):
+    backend = _backend_with_raw_tx(FakeAsyncpgTransaction())
+    monkeypatch.setattr(lifecycle, "_persistence_backend", backend)
+
+    assert lifecycle.get_persistence_backend() is backend
+
+
+def test_get_persistence_backend_raises_when_unavailable(monkeypatch):
+    monkeypatch.setattr(lifecycle, "_persistence_backend", None)
+
+    with pytest.raises(HTTPException) as exc:
+        lifecycle.get_persistence_backend()
+
+    assert exc.value.status_code == 503


### PR DESCRIPTION
PersistenceBackend ABC + 9 per-domain repository sub-interfaces (memory / kg / version / branch / compression / webhook / consultation_audit / federation / state). Postgres adapter ships as thin wrapper around mnemos/db/*_repo.py — no behavior change. Foundation for D.2 SQLite. Added 7th import-linter contract: persistence has no upward deps. 993 passed (+8), ruff clean. Per docs/V4_PLAN.md Track 5b §3.3. Authored-By: Codex