### PR TITLE
v4.0 D.2: SQLite implementation of persistence interface

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,65 @@ test:integration:
     - if: $CI_COMMIT_BRANCH == "master"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
+test:persistence-parity:
+  stage: test
+  services:
+    - name: pgvector/pgvector:pg17
+      alias: postgres
+      variables:
+        POSTGRES_PASSWORD: test
+        POSTGRES_DB: mnemos_test
+        POSTGRES_USER: postgres
+  variables:
+    PGHOST: postgres
+    PGUSER: postgres
+    PGPASSWORD: test
+    PGDATABASE: mnemos_test
+    DATABASE_URL: "postgresql://postgres:test@postgres:5432/mnemos_test"
+    MNEMOS_TEST_DB: "postgresql://postgres:test@postgres:5432/mnemos_test"
+  before_script:
+    - apt-get update -qq && apt-get install -qq -y postgresql-client
+    - pip install --cache-dir=.cache/pip -e ".[dev,sqlite]"
+    - |
+      for i in $(seq 1 30); do
+        if pg_isready -h postgres -U postgres -t 1 >/dev/null 2>&1; then
+          echo "postgres ready"; break
+        fi
+        sleep 1
+      done
+    - |
+      psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 <<'SQL'
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'mnemos_user') THEN
+          CREATE ROLE mnemos_user LOGIN PASSWORD 'test';
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'mnemos') THEN
+          CREATE ROLE mnemos LOGIN PASSWORD 'test';
+        END IF;
+      END $$;
+      SQL
+    - |
+      for f in $(python - <<'PY'
+      from tests.test_migration_lists_sync import EXPECTED_MIGRATIONS
+      print(" ".join(f"db/{name}" for name in EXPECTED_MIGRATIONS))
+      PY
+      ); do
+        echo "applying $f"
+        psql -h postgres -U postgres -d mnemos_test -v ON_ERROR_STOP=1 -f "$f"
+      done
+  script:
+    - pytest tests/test_persistence_parity.py --tb=short -q --junitxml=junit-persistence-parity.xml
+  artifacts:
+    when: always
+    reports:
+      junit: junit-persistence-parity.xml
+    expire_in: 1 week
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
 test:multi-worker:
   stage: test
   image: docker:24

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -48,6 +48,19 @@ circuit-breaker state; see `docs/SCALING.md`.
 
 ---
 
+## SQLite Profile
+
+The SQLite profile is available for local development, laptops, and edge
+single-user deployments. Set `MNEMOS_PERSISTENCE_BACKEND=sqlite` with
+`MNEMOS_SQLITE_PATH=/path/to/mnemos.sqlite3`, or set
+`MNEMOS_PERSISTENCE_BACKEND=auto` with a `sqlite:///...` `MNEMOS_DATABASE_URL`.
+
+See `docs/SQLITE_PROFILE.md` for the constraints: no RLS, no LISTEN/NOTIFY, no
+advisory locks, FTS5 instead of PostgreSQL tsvector, and sqlite-vec instead of
+pgvector.
+
+---
+
 ## MCP HTTP/SSE Auth
 
 The stdio MCP server and HTTP/SSE MCP server expose the same canonical tool

--- a/db/migrations_sqlite/migrations.sql
+++ b/db/migrations_sqlite/migrations.sql
@@ -1,0 +1,599 @@
+-- SQLite profile schema mirror for db/migrations.sql through v3.5.
+--
+-- SQLite stores UUID, JSONB, TIMESTAMPTZ, arrays, and vector columns as TEXT.
+-- JSON values are plain JSON text consumed through JSON1-aware application SQL.
+-- FTS uses FTS5. Vector search uses sqlite-vec when the vec0 extension is
+-- available and falls back to the memory_embeddings JSON table otherwise.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS memories (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'general',
+  task_type TEXT,
+  context TEXT,
+  importance INTEGER DEFAULT 5,
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  access_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed TEXT,
+  embedding TEXT,
+  is_compressed INTEGER NOT NULL DEFAULT 0,
+  original_reference TEXT,
+  compression_ratio REAL,
+  quality_rating INTEGER NOT NULL DEFAULT 0,
+  subcategory TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  verbatim_content TEXT,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  group_id TEXT,
+  namespace TEXT NOT NULL DEFAULT 'default',
+  permission_mode INTEGER NOT NULL DEFAULT 600,
+  source_model TEXT,
+  source_provider TEXT,
+  source_session TEXT,
+  source_agent TEXT,
+  llm_optimized INTEGER NOT NULL DEFAULT 0,
+  optimized_at TEXT,
+  federation_source TEXT,
+  federation_synced_at TEXT,
+  morpheus_run_id TEXT,
+  morpheus_cluster_id TEXT,
+  source_memory_ids TEXT NOT NULL DEFAULT '[]',
+  provenance TEXT NOT NULL DEFAULT '{}',
+  last_recalled_at TEXT,
+  recall_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+CREATE INDEX IF NOT EXISTS idx_memories_task_type ON memories(task_type);
+CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created DESC);
+CREATE INDEX IF NOT EXISTS idx_memories_updated_id ON memories(updated ASC, id ASC);
+CREATE INDEX IF NOT EXISTS idx_memories_is_compressed ON memories(is_compressed);
+CREATE INDEX IF NOT EXISTS idx_memories_original_reference ON memories(original_reference);
+CREATE INDEX IF NOT EXISTS idx_memories_owner_id ON memories(owner_id);
+CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);
+CREATE INDEX IF NOT EXISTS idx_memories_group_id ON memories(group_id) WHERE group_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_memories_owner_cat ON memories(owner_id, category);
+CREATE INDEX IF NOT EXISTS idx_memories_federation ON memories(federation_source) WHERE federation_source IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_memories_morpheus_run ON memories(morpheus_run_id);
+CREATE INDEX IF NOT EXISTS idx_memories_provenance ON memories(source_provider, source_model, source_agent);
+CREATE INDEX IF NOT EXISTS idx_memories_last_recalled_at ON memories(last_recalled_at DESC);
+CREATE INDEX IF NOT EXISTS idx_memories_recall_count ON memories(recall_count DESC);
+
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+  memory_id TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+  embedding TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+  id UNINDEXED,
+  content,
+  category,
+  tokenize = 'porter'
+);
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_ai
+AFTER INSERT ON memories
+BEGIN
+  INSERT INTO memories_fts(id, content, category)
+  VALUES (new.id, new.content, new.category);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_ad
+AFTER DELETE ON memories
+BEGIN
+  DELETE FROM memories_fts WHERE id = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_au
+AFTER UPDATE OF content, category ON memories
+BEGIN
+  DELETE FROM memories_fts WHERE id = old.id;
+  INSERT INTO memories_fts(id, content, category)
+  VALUES (new.id, new.content, new.category);
+END;
+
+CREATE TABLE IF NOT EXISTS compression_quality_log (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  memory_id TEXT,
+  original_content TEXT,
+  compressed_content TEXT,
+  original_tokens INTEGER,
+  compressed_tokens INTEGER,
+  compression_ratio REAL,
+  quality_rating INTEGER,
+  llm_feedback TEXT,
+  reviewed INTEGER NOT NULL DEFAULT 0,
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  owner_id TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE INDEX IF NOT EXISTS idx_compression_log_memory_id ON compression_quality_log(memory_id);
+CREATE INDEX IF NOT EXISTS idx_compression_log_created ON compression_quality_log(created DESC);
+CREATE INDEX IF NOT EXISTS idx_compression_log_reviewed ON compression_quality_log(reviewed);
+CREATE INDEX IF NOT EXISTS idx_compression_log_quality_rating ON compression_quality_log(quality_rating);
+
+CREATE TABLE IF NOT EXISTS graeae_consultations (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  prompt TEXT NOT NULL,
+  task_type TEXT NOT NULL,
+  consensus_response TEXT,
+  consensus_score REAL,
+  winning_muse TEXT,
+  cost REAL DEFAULT 0,
+  latency_ms INTEGER DEFAULT 0,
+  mode TEXT DEFAULT 'single',
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_graeae_consult_task_type ON graeae_consultations(task_type);
+CREATE INDEX IF NOT EXISTS idx_graeae_consult_created ON graeae_consultations(created DESC);
+CREATE INDEX IF NOT EXISTS idx_graeae_consult_mode ON graeae_consultations(mode);
+CREATE INDEX IF NOT EXISTS idx_graeae_consult_winning_muse ON graeae_consultations(winning_muse);
+CREATE INDEX IF NOT EXISTS idx_graeae_consultations_owner ON graeae_consultations(owner_id);
+CREATE INDEX IF NOT EXISTS idx_graeae_consultations_owner_namespace
+  ON graeae_consultations(owner_id, namespace);
+
+CREATE TABLE IF NOT EXISTS state (
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  key TEXT NOT NULL,
+  value TEXT,
+  updated TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (owner_id, namespace, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_state_owner ON state(owner_id);
+CREATE INDEX IF NOT EXISTS idx_state_owner_namespace ON state(owner_id, namespace);
+
+CREATE TABLE IF NOT EXISTS journal (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  entry_date TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  topic TEXT,
+  content TEXT NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_journal_entry_date ON journal(entry_date DESC);
+CREATE INDEX IF NOT EXISTS idx_journal_topic ON journal(topic);
+CREATE INDEX IF NOT EXISTS idx_journal_created ON journal(created DESC);
+CREATE INDEX IF NOT EXISTS idx_journal_owner ON journal(owner_id);
+CREATE INDEX IF NOT EXISTS idx_journal_owner_date ON journal(owner_id, entry_date DESC);
+CREATE INDEX IF NOT EXISTS idx_journal_owner_namespace ON journal(owner_id, namespace);
+
+CREATE TABLE IF NOT EXISTS entities (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  entity_type TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(owner_id, namespace, entity_type, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(entity_type);
+CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(name);
+CREATE INDEX IF NOT EXISTS idx_entities_owner ON entities(owner_id);
+CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace);
+CREATE INDEX IF NOT EXISTS idx_entities_owner_namespace ON entities(owner_id, namespace);
+
+CREATE TABLE IF NOT EXISTS kg_triples (
+  id TEXT PRIMARY KEY,
+  subject TEXT NOT NULL,
+  predicate TEXT NOT NULL,
+  object TEXT NOT NULL,
+  subject_type TEXT,
+  object_type TEXT,
+  valid_from TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  valid_until TEXT,
+  memory_id TEXT REFERENCES memories(id) ON DELETE SET NULL,
+  confidence REAL NOT NULL DEFAULT 1.0,
+  created TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_subject ON kg_triples(subject);
+CREATE INDEX IF NOT EXISTS idx_kg_predicate ON kg_triples(predicate);
+CREATE INDEX IF NOT EXISTS idx_kg_memory_id ON kg_triples(memory_id);
+CREATE INDEX IF NOT EXISTS idx_kg_owner_id ON kg_triples(owner_id);
+CREATE INDEX IF NOT EXISTS idx_kg_namespace ON kg_triples(namespace);
+CREATE INDEX IF NOT EXISTS idx_kg_owner_subject ON kg_triples(owner_id, subject);
+CREATE INDEX IF NOT EXISTS idx_kg_owner_predicate ON kg_triples(owner_id, predicate);
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_namespace ON users(namespace);
+
+CREATE TABLE IF NOT EXISTS groups (
+  id TEXT PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS user_groups (
+  user_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  PRIMARY KEY (user_id, group_id)
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  user_id TEXT NOT NULL,
+  key_hash TEXT NOT NULL,
+  label TEXT,
+  revoked INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(key_hash) WHERE revoked = 0;
+
+CREATE TABLE IF NOT EXISTS memory_versions (
+  id TEXT PRIMARY KEY,
+  memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  version_num INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  category TEXT,
+  subcategory TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  verbatim_content TEXT,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  permission_mode INTEGER NOT NULL DEFAULT 600,
+  source_model TEXT,
+  source_provider TEXT,
+  source_session TEXT,
+  source_agent TEXT,
+  snapshot_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  snapshot_by TEXT,
+  change_type TEXT NOT NULL DEFAULT 'create',
+  commit_hash TEXT,
+  parent_version_id TEXT REFERENCES memory_versions(id) ON DELETE SET NULL,
+  branch TEXT NOT NULL DEFAULT 'main',
+  merge_parents TEXT NOT NULL DEFAULT '[]',
+  UNIQUE(memory_id, branch, version_num)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mv_memory_id ON memory_versions(memory_id);
+CREATE INDEX IF NOT EXISTS idx_mv_memory_id_vnum ON memory_versions(memory_id, version_num DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_snapshot_at ON memory_versions(snapshot_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_commit_hash ON memory_versions(commit_hash)
+  WHERE commit_hash IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_main_linear ON memory_versions(memory_id, version_num)
+  WHERE branch = 'main';
+
+CREATE TABLE IF NOT EXISTS memory_branches (
+  memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  head_version_id TEXT REFERENCES memory_versions(id) ON DELETE SET NULL,
+  created_by TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (memory_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_branches_memory ON memory_branches(memory_id);
+
+CREATE TABLE IF NOT EXISTS graeae_audit_log (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  sequence_num INTEGER,
+  consultation_id TEXT,
+  prompt TEXT,
+  prompt_hash TEXT,
+  provider TEXT,
+  model TEXT,
+  response_text TEXT,
+  response_hash TEXT,
+  chain_hash TEXT,
+  prev_id TEXT,
+  prev_chain_hash TEXT,
+  task_type TEXT,
+  quality_score REAL,
+  latency_ms INTEGER,
+  cost_usd REAL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_sequence ON graeae_audit_log(sequence_num);
+CREATE INDEX IF NOT EXISTS idx_audit_created ON graeae_audit_log(created_at);
+CREATE INDEX IF NOT EXISTS idx_graeae_audit_log_consultation ON graeae_audit_log(consultation_id);
+CREATE INDEX IF NOT EXISTS idx_graeae_audit_log_created_at ON graeae_audit_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_graeae_audit_log_chain_hash ON graeae_audit_log(chain_hash);
+
+CREATE TABLE IF NOT EXISTS consultation_memory_refs (
+  consultation_id TEXT NOT NULL,
+  memory_id TEXT NOT NULL,
+  relevance_score REAL,
+  injected_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (consultation_id, memory_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consultation_memory_refs_consultation
+  ON consultation_memory_refs(consultation_id);
+CREATE INDEX IF NOT EXISTS idx_consultation_memory_refs_memory
+  ON consultation_memory_refs(memory_id);
+CREATE INDEX IF NOT EXISTS idx_consultation_memory_refs_injected_at
+  ON consultation_memory_refs(injected_at DESC);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  namespace TEXT NOT NULL DEFAULT 'default',
+  title TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_created ON sessions(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_owner_namespace ON sessions(user_id, namespace);
+
+CREATE TABLE IF NOT EXISTS session_messages (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_messages_session_ts
+  ON session_messages(session_id, timestamp ASC);
+CREATE INDEX IF NOT EXISTS idx_session_messages_role ON session_messages(session_id, role);
+
+CREATE TABLE IF NOT EXISTS session_memory_injections (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  relevance_score REAL,
+  injected_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_memory_injections_session
+  ON session_memory_injections(session_id);
+
+CREATE TABLE IF NOT EXISTS model_registry (
+  provider TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  display_name TEXT,
+  family TEXT,
+  capabilities TEXT NOT NULL DEFAULT '[]',
+  input_cost_per_mtok REAL NOT NULL DEFAULT 0,
+  output_cost_per_mtok REAL NOT NULL DEFAULT 0,
+  context_window INTEGER,
+  arena_score REAL,
+  graeae_weight REAL NOT NULL DEFAULT 0,
+  available INTEGER NOT NULL DEFAULT 1,
+  deprecated INTEGER NOT NULL DEFAULT 0,
+  last_synced TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  PRIMARY KEY (provider, model_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_registry_provider ON model_registry(provider);
+CREATE INDEX IF NOT EXISTS idx_model_registry_available ON model_registry(available) WHERE available = 1;
+CREATE INDEX IF NOT EXISTS idx_model_registry_arena_score ON model_registry(arena_score DESC);
+CREATE INDEX IF NOT EXISTS idx_model_registry_graeae_weight ON model_registry(graeae_weight DESC);
+CREATE INDEX IF NOT EXISTS idx_model_registry_family ON model_registry(family);
+CREATE INDEX IF NOT EXISTS idx_model_registry_last_synced ON model_registry(last_synced DESC);
+
+CREATE TABLE IF NOT EXISTS model_registry_sync_log (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  provider TEXT NOT NULL,
+  models_seen INTEGER NOT NULL DEFAULT 0,
+  models_upserted INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'ok',
+  error TEXT,
+  synced_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_registry_sync_log_provider
+  ON model_registry_sync_log(provider);
+CREATE INDEX IF NOT EXISTS idx_model_registry_sync_log_synced_at
+  ON model_registry_sync_log(synced_at DESC);
+
+CREATE TABLE IF NOT EXISTS memory_compression_queue (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  scheduled_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcq_ready ON memory_compression_queue(status, scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_mcq_memory ON memory_compression_queue(memory_id);
+CREATE INDEX IF NOT EXISTS idx_mcq_owner ON memory_compression_queue(owner_id);
+
+CREATE TABLE IF NOT EXISTS memory_compression_candidates (
+  id TEXT PRIMARY KEY,
+  memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  contest_id TEXT,
+  engine_id TEXT NOT NULL,
+  engine_version TEXT,
+  candidate_content TEXT,
+  candidate_tokens INTEGER,
+  compression_ratio REAL,
+  quality_score REAL,
+  composite_score REAL,
+  is_winner INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcc_memory ON memory_compression_candidates(memory_id);
+CREATE INDEX IF NOT EXISTS idx_mcc_contest ON memory_compression_candidates(contest_id);
+CREATE INDEX IF NOT EXISTS idx_mcc_memory_winner ON memory_compression_candidates(memory_id, is_winner);
+CREATE INDEX IF NOT EXISTS idx_mcc_owner ON memory_compression_candidates(owner_id);
+CREATE INDEX IF NOT EXISTS idx_mcc_engine ON memory_compression_candidates(engine_id);
+
+CREATE TABLE IF NOT EXISTS memory_compressed_variants (
+  memory_id TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  winner_candidate_id TEXT REFERENCES memory_compression_candidates(id) ON DELETE SET NULL,
+  engine_id TEXT NOT NULL,
+  engine_version TEXT,
+  compressed_content TEXT,
+  compressed_tokens INTEGER,
+  compression_ratio REAL,
+  quality_score REAL,
+  composite_score REAL,
+  scoring_profile TEXT NOT NULL DEFAULT 'balanced',
+  judge_model TEXT,
+  selected_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcv_owner ON memory_compressed_variants(owner_id);
+CREATE INDEX IF NOT EXISTS idx_mcv_engine ON memory_compressed_variants(engine_id);
+
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  url TEXT NOT NULL,
+  events TEXT NOT NULL DEFAULT '[]',
+  secret TEXT,
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  revoked INTEGER NOT NULL DEFAULT 0,
+  revoked_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subscriptions_owner
+  ON webhook_subscriptions(owner_id, namespace);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  subscription_id TEXT NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  attempt_num INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'pending',
+  response_status INTEGER,
+  response_body TEXT,
+  error TEXT,
+  scheduled_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  delivered_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  lease_token TEXT,
+  lease_expires_at TEXT,
+  writer_revision INTEGER NOT NULL DEFAULT 1,
+  status_updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  superseded INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_subscription
+  ON webhook_deliveries(subscription_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_pending
+  ON webhook_deliveries(scheduled_at)
+  WHERE status IN ('pending', 'retrying') AND superseded = 0;
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_lease_expires_at
+  ON webhook_deliveries(lease_expires_at);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_webhook_deliveries_live_chain_attempt
+  ON webhook_deliveries(subscription_id, event_type, payload_hash, attempt_num)
+  WHERE status IN ('pending', 'retrying') AND superseded = 0;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_webhook_deliveries_succeeded_chain
+  ON webhook_deliveries(subscription_id, event_type, payload_hash)
+  WHERE status = 'succeeded';
+
+CREATE TABLE IF NOT EXISTS oauth_providers (
+  id TEXT PRIMARY KEY,
+  issuer TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  client_secret TEXT,
+  scopes TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS oauth_identities (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  provider_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  email TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_identities_user ON oauth_identities(user_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_identities_email ON oauth_identities(email) WHERE email IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS oauth_sessions (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  user_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  access_token TEXT,
+  refresh_token TEXT,
+  expires_at TEXT,
+  revoked INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_sessions_user ON oauth_sessions(user_id) WHERE revoked = 0;
+CREATE INDEX IF NOT EXISTS idx_oauth_sessions_expires ON oauth_sessions(expires_at) WHERE revoked = 0;
+
+CREATE TABLE IF NOT EXISTS federation_peers (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  base_url TEXT NOT NULL UNIQUE,
+  api_key TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  last_sync_at TEXT,
+  cursor_updated TEXT,
+  cursor_id TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_federation_peers_enabled
+  ON federation_peers(enabled) WHERE enabled = 1;
+
+CREATE TABLE IF NOT EXISTS federation_sync_log (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  peer_id TEXT NOT NULL REFERENCES federation_peers(id) ON DELETE CASCADE,
+  direction TEXT NOT NULL,
+  status TEXT NOT NULL,
+  records_seen INTEGER NOT NULL DEFAULT 0,
+  records_written INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  synced_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_federation_sync_log_peer
+  ON federation_sync_log(peer_id, synced_at DESC);
+
+CREATE TABLE IF NOT EXISTS morpheus_runs (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  owner_id TEXT NOT NULL DEFAULT 'default',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  status TEXT NOT NULL DEFAULT 'pending',
+  config TEXT NOT NULL DEFAULT '{}',
+  started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  finished_at TEXT,
+  error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_morpheus_runs_status ON morpheus_runs(status);
+CREATE INDEX IF NOT EXISTS idx_morpheus_runs_started ON morpheus_runs(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_morpheus_runs_namespace ON morpheus_runs(namespace);

--- a/db/migrations_sqlite/migrations_charon_trigger_guard.sql
+++ b/db/migrations_sqlite/migrations_charon_trigger_guard.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_charon_trigger_guard.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_model_registry.sql
+++ b/db/migrations_sqlite/migrations_model_registry.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_model_registry.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v1_multiuser.sql
+++ b/db/migrations_sqlite/migrations_v1_multiuser.sql
@@ -1,0 +1,4 @@
+-- SQLite mirror for v1 multi-user columns, indexes, and visibility semantics.
+-- RLS policies are not available in SQLite; the application visibility
+-- predicate in mnemos.core.visibility is the enforcement boundary.
+CREATE INDEX IF NOT EXISTS idx_memories_owner_namespace ON memories(owner_id, namespace);

--- a/db/migrations_sqlite/migrations_v2_sessions.sql
+++ b/db/migrations_sqlite/migrations_v2_sessions.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v2_sessions.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v2_versioning.sql
+++ b/db/migrations_sqlite/migrations_v2_versioning.sql
@@ -1,0 +1,4 @@
+-- SQLite mirror for v2 memory_versions and audit tables.
+-- The consolidated schema creates these tables up front to keep SQLite startup
+-- idempotent on fresh single-file databases.
+CREATE INDEX IF NOT EXISTS idx_mv_branch_head ON memory_versions(memory_id, branch, version_num DESC);

--- a/db/migrations_sqlite/migrations_v3_1_2_audit_log_columns.sql
+++ b/db/migrations_sqlite/migrations_v3_1_2_audit_log_columns.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_1_2_audit_log_columns.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_1_2_kg_tenancy.sql
+++ b/db/migrations_sqlite/migrations_v3_1_2_kg_tenancy.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_1_2_kg_tenancy.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_1_compression.sql
+++ b/db/migrations_sqlite/migrations_v3_1_compression.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_1_compression.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_1_versioning_fix.sql
+++ b/db/migrations_sqlite/migrations_v3_1_versioning_fix.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_1_versioning_fix.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_2_2_version_snapshot_new_values.sql
+++ b/db/migrations_sqlite/migrations_v3_2_2_version_snapshot_new_values.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_2_2_version_snapshot_new_values.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_2_entities_namespace.sql
+++ b/db/migrations_sqlite/migrations_v3_2_entities_namespace.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_2_entities_namespace.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_2_user_namespace.sql
+++ b/db/migrations_sqlite/migrations_v3_2_user_namespace.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_2_user_namespace.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_3_morpheus.sql
+++ b/db/migrations_sqlite/migrations_v3_3_morpheus.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_3_morpheus.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_3_morpheus_namespace.sql
+++ b/db/migrations_sqlite/migrations_v3_3_morpheus_namespace.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_3_morpheus_namespace.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_3_recall_tracking.sql
+++ b/db/migrations_sqlite/migrations_v3_3_recall_tracking.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_3_recall_tracking.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_4_federation_compat.sql
+++ b/db/migrations_sqlite/migrations_v3_4_federation_compat.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_4_federation_compat.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_entities_namespace_unique.sql
+++ b/db/migrations_sqlite/migrations_v3_5_entities_namespace_unique.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_entities_namespace_unique.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_rls_group_select_unix_bits.sql
+++ b/db/migrations_sqlite/migrations_v3_5_rls_group_select_unix_bits.sql
@@ -1,0 +1,3 @@
+-- SQLite mirror for group read visibility bit semantics.
+-- SQLite has no RLS. The application predicate extracts Unix-style group bits
+-- with ((permission_mode / 10) % 10) exactly like the PostgreSQL policy.

--- a/db/migrations_sqlite/migrations_v3_5_session_compression_legacy_drop.sql
+++ b/db/migrations_sqlite/migrations_v3_5_session_compression_legacy_drop.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_session_compression_legacy_drop.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_session_compression_ratio_drop.sql
+++ b/db/migrations_sqlite/migrations_v3_5_session_compression_ratio_drop.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_session_compression_ratio_drop.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_sessions_consultations_namespace.sql
+++ b/db/migrations_sqlite/migrations_v3_5_sessions_consultations_namespace.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_sessions_consultations_namespace.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_state_journal_namespace.sql
+++ b/db/migrations_sqlite/migrations_v3_5_state_journal_namespace.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_state_journal_namespace.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_trigger_same_memory_parent.sql
+++ b/db/migrations_sqlite/migrations_v3_5_trigger_same_memory_parent.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_trigger_same_memory_parent.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_attempt_lease.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_attempt_lease.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_attempt_lease.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_attempt_unique.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_attempt_unique.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_attempt_unique.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_retry_terminal_state.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_retry_terminal_state.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_retry_terminal_state.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_status_updated_at.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_status_updated_at.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_status_updated_at.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_succeeded_terminal_trigger.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_succeeded_terminal_trigger.sql
@@ -1,0 +1,4 @@
+-- SQLite mirror for v3.5 succeeded-terminal webhook guard.
+-- PostgreSQL uses a trigger. The SQLite profile enforces this in
+-- mnemos.webhooks.finalize because SQLite deployments are single-process or
+-- use serialized writes through the backend mutex.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_succeeded_unique.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_succeeded_unique.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_succeeded_unique.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_superseded_marker.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_superseded_marker.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_superseded_marker.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_5_webhook_writer_revision.sql
+++ b/db/migrations_sqlite/migrations_v3_5_webhook_writer_revision.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_5_webhook_writer_revision.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_dag.sql
+++ b/db/migrations_sqlite/migrations_v3_dag.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_dag.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_federation.sql
+++ b/db/migrations_sqlite/migrations_v3_federation.sql
@@ -1,0 +1,4 @@
+-- SQLite mirror for v3 federation tables.
+-- There is no LISTEN/NOTIFY; federation pullers poll using compound cursors.
+CREATE INDEX IF NOT EXISTS idx_federation_peers_cursor
+  ON federation_peers(cursor_updated, cursor_id);

--- a/db/migrations_sqlite/migrations_v3_graeae_unified.sql
+++ b/db/migrations_sqlite/migrations_v3_graeae_unified.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_graeae_unified.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_oauth.sql
+++ b/db/migrations_sqlite/migrations_v3_oauth.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_oauth.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_ownership.sql
+++ b/db/migrations_sqlite/migrations_v3_ownership.sql
@@ -1,0 +1,5 @@
+-- SQLite mirror for migrations_v3_ownership.
+-- The logical schema change from the PostgreSQL migration is represented
+-- in migrations.sql with SQLite-compatible TEXT/INTEGER/JSON storage and
+-- idempotent indexes. PostgreSQL-only GRANT, COMMENT, RLS, advisory-lock,
+-- and trigger-function statements are intentionally omitted.

--- a/db/migrations_sqlite/migrations_v3_webhooks.sql
+++ b/db/migrations_sqlite/migrations_v3_webhooks.sql
@@ -1,0 +1,4 @@
+-- SQLite mirror for v3 webhook subscriptions and deliveries.
+-- LISTEN/NOTIFY is unavailable; workers poll webhook_deliveries.
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status_attempt
+  ON webhook_deliveries(status, attempt_num, scheduled_at);

--- a/docs/SQLITE_PROFILE.md
+++ b/docs/SQLITE_PROFILE.md
@@ -1,0 +1,82 @@
+# SQLite Profile
+
+The SQLite persistence backend is the MNEMOS lite profile for laptops, edge
+devices, single-user development, and small offline deployments. It implements
+the same persistence interface as `PostgresBackend`, but uses SQLite storage,
+FTS5, JSON1-compatible JSON text, and `sqlite-vec` when the extension is
+available.
+
+## When To Use It
+
+Use SQLite when you want a local MNEMOS node with minimal operational surface:
+
+- Developer laptop or CI smoke tests.
+- Single-user personal memory store.
+- Edge profile targets such as Pi-class systems or phone-adjacent sync tools.
+- Offline-first testing before promoting data to a Postgres deployment.
+
+Use Postgres when you need multi-user hard isolation, concurrent writers across
+processes, LISTEN/NOTIFY, advisory locks, pgvector indexing, streaming
+replication, or production HA.
+
+## Storage Mapping
+
+The SQLite migration chain lives in `db/migrations_sqlite/` and mirrors the
+canonical Postgres migration list.
+
+- `UUID` -> `TEXT`
+- `JSONB` -> JSON text, queried through SQLite JSON1 where needed
+- `TIMESTAMPTZ` -> ISO-8601 `TEXT`
+- `TEXT[]` / `UUID[]` -> JSON text arrays
+- `pgvector vector(768)` -> `sqlite-vec` `vec0` when available, plus a JSON
+  fallback table for portable tests
+- PostgreSQL full-text search -> SQLite FTS5
+- Partial unique indexes -> SQLite partial unique indexes
+
+## Deliberate Differences
+
+SQLite has no row-level security. The profile is single-user or
+single-namespace by deployment convention; tenancy is enforced at the
+application layer through the same visibility predicate used by non-RLS reads.
+
+SQLite has no LISTEN/NOTIFY. Federation and webhook workers use polling.
+
+SQLite has no advisory locks. The backend serializes transactions through one
+connection mutex, matching SQLite's serialized-write model.
+
+Postgres enforces webhook `status='succeeded'` as terminal through a trigger.
+The SQLite profile enforces that path in `mnemos.webhooks.finalize` because the
+profile does not rely on trigger functions for retry-chain safety.
+
+## Configuration
+
+Install the optional dependencies:
+
+```bash
+pip install "mnemos-os[sqlite]"
+```
+
+Select SQLite explicitly:
+
+```bash
+MNEMOS_PERSISTENCE_BACKEND=sqlite
+MNEMOS_SQLITE_PATH=/var/lib/mnemos/mnemos.sqlite3
+```
+
+Or use URI auto-detection:
+
+```bash
+MNEMOS_PERSISTENCE_BACKEND=auto
+MNEMOS_DATABASE_URL=sqlite:////var/lib/mnemos/mnemos.sqlite3
+```
+
+Postgres remains the default backend.
+
+## Operational Notes
+
+Keep one MNEMOS process writing to the SQLite database. WAL mode is enabled on
+open, and foreign keys are enabled for every connection.
+
+Back up the `.sqlite3` file and its WAL/shm companions together, or checkpoint
+before copying. For large multi-user deployments, migrate to Postgres instead
+of stretching SQLite beyond its intended profile.

--- a/mnemos/core/config.py
+++ b/mnemos/core/config.py
@@ -30,6 +30,18 @@ def _config_model_config(*, env_prefix: str = "", extra: str = "ignore") -> Sett
 class _DatabaseSettings(BaseSettings):
     model_config = _config_model_config(env_prefix="PG_")
 
+    backend: str = Field(
+        "auto",
+        validation_alias=AliasChoices("MNEMOS_PERSISTENCE_BACKEND", "PERSISTENCE_BACKEND", "PG_BACKEND"),
+    )
+    url: str = Field(
+        "",
+        validation_alias=AliasChoices("MNEMOS_DATABASE_URL", "DATABASE_URL", "PG_URL"),
+    )
+    sqlite_path: Path = Field(
+        Path("mnemos.sqlite3"),
+        validation_alias=AliasChoices("MNEMOS_SQLITE_PATH", "SQLITE_DB_PATH", "PG_SQLITE_PATH"),
+    )
     host: str = "localhost"
     port: int = 5432
     database: str = "mnemos"

--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -210,6 +210,47 @@ def _build_postgres_backend(pool, settings):
     return postgres_module.PostgresBackend(pool, settings)
 
 
+async def _build_sqlite_backend(db_path, settings):
+    """Build and open the SQLite persistence backend."""
+    sqlite_module = importlib.import_module("mnemos.persistence.sqlite")
+    backend = sqlite_module.SqliteBackend(db_path, settings)
+    await backend.open()
+    return backend
+
+
+def _select_persistence_backend(settings) -> str:
+    database_settings = getattr(settings, "database", None)
+    if database_settings is None:
+        return "postgres"
+    configured = getattr(database_settings, "backend", "auto").strip().lower()
+    database_url = getattr(database_settings, "url", "").strip().lower()
+    if configured in {"postgres", "postgresql", "pg"}:
+        return "postgres"
+    if configured in {"sqlite", "sqlite3"}:
+        return "sqlite"
+    if configured == "auto":
+        if database_url.startswith("sqlite:"):
+            return "sqlite"
+        if database_url.startswith(("postgres:", "postgresql:")):
+            return "postgres"
+        return "postgres"
+    raise ValueError(
+        "Unsupported persistence backend "
+        f"{settings.database.backend!r}; expected postgres, sqlite, or auto"
+    )
+
+
+def _sqlite_path_from_settings(settings):
+    database_settings = getattr(settings, "database", None)
+    database_url = getattr(database_settings, "url", "").strip() if database_settings is not None else ""
+    if database_url.startswith("sqlite:"):
+        parsed = urlparse(database_url)
+        if parsed.path in {"", "/:memory:"}:
+            return parsed.netloc or ":memory:"
+        return parsed.path
+    return getattr(database_settings, "sqlite_path", "mnemos.sqlite3")
+
+
 def _load_config() -> dict:
     """Load config.toml from standard locations. Returns empty dict if not found."""
     candidates = [
@@ -286,15 +327,16 @@ def _warn_if_multi_worker_without_redis(settings) -> None:
         )
 
 
-async def _log_federation_startup_guidance(pool: asyncpg.Pool) -> None:
+async def _log_federation_startup_guidance(pool: asyncpg.Pool | None) -> None:
     configured_peer_urls = _configured_federation_peer_urls()
     db_peer_urls: list[str] = []
-    try:
-        async with pool.acquire() as conn:
-            rows = await conn.fetch("SELECT base_url FROM federation_peers WHERE enabled")
-        db_peer_urls = [row["base_url"] for row in rows if row["base_url"]]
-    except Exception as exc:
-        logger.debug("federation startup guidance skipped DB peer scan: %s", exc)
+    if pool is not None:
+        try:
+            async with pool.acquire() as conn:
+                rows = await conn.fetch("SELECT base_url FROM federation_peers WHERE enabled")
+            db_peer_urls = [row["base_url"] for row in rows if row["base_url"]]
+        except Exception as exc:
+            logger.debug("federation startup guidance skipped DB peer scan: %s", exc)
 
     if get_settings().federation.enabled and not configured_peer_urls and not db_peer_urls:
         logger.info("federation enabled but no peers configured — federation pulls and exports are inactive.")
@@ -320,27 +362,38 @@ async def lifespan(app):
     settings = get_settings()
     _warn_if_multi_worker_without_redis(settings)
 
+    backend_type = _select_persistence_backend(settings)
     try:
-        _pool = await asyncpg.create_pool(
-            user=PG_CONFIG['user'],
-            password=PG_CONFIG['password'],
-            database=PG_CONFIG['database'],
-            host=PG_CONFIG['host'],
-            port=PG_CONFIG['port'],
-            min_size=PG_CONFIG['pool_min_size'],
-            max_size=PG_CONFIG['pool_max_size'],
-        )
-        _pool_manager = PoolManager(_pool)
-        _persistence_backend = _build_postgres_backend(_pool, settings)
-        app.state.pool = _pool   # auth.py reads this via request.app.state.pool
-        app.state.pool_manager = _pool_manager
-        app.state.persistence_backend = _persistence_backend
-        logger.info(
-            f"asyncpg connection pool initialized "
-            f"(min={PG_CONFIG['pool_min_size']}, max={PG_CONFIG['pool_max_size']})"
-        )
+        if backend_type == "sqlite":
+            _pool = None
+            _pool_manager = None
+            sqlite_path = _sqlite_path_from_settings(settings)
+            _persistence_backend = await _build_sqlite_backend(sqlite_path, settings)
+            app.state.pool = None
+            app.state.pool_manager = None
+            app.state.persistence_backend = _persistence_backend
+            logger.info("SQLite persistence backend initialized (%s)", sqlite_path)
+        else:
+            _pool = await asyncpg.create_pool(
+                user=PG_CONFIG['user'],
+                password=PG_CONFIG['password'],
+                database=PG_CONFIG['database'],
+                host=PG_CONFIG['host'],
+                port=PG_CONFIG['port'],
+                min_size=PG_CONFIG['pool_min_size'],
+                max_size=PG_CONFIG['pool_max_size'],
+            )
+            _pool_manager = PoolManager(_pool)
+            _persistence_backend = _build_postgres_backend(_pool, settings)
+            app.state.pool = _pool   # auth.py reads this via request.app.state.pool
+            app.state.pool_manager = _pool_manager
+            app.state.persistence_backend = _persistence_backend
+            logger.info(
+                f"asyncpg connection pool initialized "
+                f"(min={PG_CONFIG['pool_min_size']}, max={PG_CONFIG['pool_max_size']})"
+            )
     except Exception as e:
-        logger.error(f"Failed to create DB pool: {e}")
+        logger.error(f"Failed to initialize {backend_type} persistence backend: {e}")
         raise
 
     # Configure auth (personal profile: auth.enabled=false -> no-op beyond singleton).
@@ -379,7 +432,7 @@ async def lifespan(app):
     # the background task lands. POST /admin/graeae/reload-providers is also
     # available for on-demand refresh (and is what the daily systemd timer
     # uses after sync_provider_models.py finishes).
-    if _provider_manifest_reloader is not None:
+    if _provider_manifest_reloader is not None and _pool is not None:
         import asyncio as _asyncio_for_reload
 
         async def _bg_provider_manifest_reload():

--- a/mnemos/persistence/__init__.py
+++ b/mnemos/persistence/__init__.py
@@ -26,6 +26,20 @@ from mnemos.persistence.postgres import (
     PostgresVersionRepository,
     PostgresWebhookRepository,
 )
+from mnemos.persistence.sqlite import (
+    SQLITE_MIGRATION_FILES,
+    SqliteBackend,
+    SqliteBranchRepository,
+    SqliteCompressionRepository,
+    SqliteConsultationAuditRepository,
+    SqliteFederationRepository,
+    SqliteKGRepository,
+    SqliteMemoryRepository,
+    SqliteStateRepository,
+    SqliteTransaction,
+    SqliteVersionRepository,
+    SqliteWebhookRepository,
+)
 from mnemos.persistence.types import ModelRecommendation
 
 __all__ = [
@@ -48,6 +62,18 @@ __all__ = [
     "PostgresTransaction",
     "PostgresVersionRepository",
     "PostgresWebhookRepository",
+    "SQLITE_MIGRATION_FILES",
+    "SqliteBackend",
+    "SqliteBranchRepository",
+    "SqliteCompressionRepository",
+    "SqliteConsultationAuditRepository",
+    "SqliteFederationRepository",
+    "SqliteKGRepository",
+    "SqliteMemoryRepository",
+    "SqliteStateRepository",
+    "SqliteTransaction",
+    "SqliteVersionRepository",
+    "SqliteWebhookRepository",
     "StateRepository",
     "Transaction",
     "VersionRepository",

--- a/mnemos/persistence/postgres.py
+++ b/mnemos/persistence/postgres.py
@@ -8,8 +8,12 @@ to the backend-neutral persistence interfaces.
 from __future__ import annotations
 
 import inspect
+import hashlib
+import json
+import uuid
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Any
 
 import asyncpg
@@ -447,7 +451,87 @@ class PostgresCompressionRepository(CompressionRepository):
 
 
 class PostgresWebhookRepository(WebhookRepository):
-    pass
+    async def insert_subscription(
+        self,
+        tx: Transaction,
+        *,
+        subscription_id: str | None = None,
+        url: str,
+        events: Sequence[str],
+        secret: str | None = None,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> str:
+        subscription_id = subscription_id or str(uuid.uuid4())
+        await _postgres_tx(tx).conn.execute(
+            """
+            INSERT INTO webhook_subscriptions (id, url, events, secret, owner_id, namespace)
+            VALUES ($1::uuid, $2, $3::text[], $4, $5, $6)
+            """,
+            subscription_id,
+            url,
+            list(events),
+            secret or "",
+            owner_id,
+            namespace,
+        )
+        return subscription_id
+
+    async def dispatch_event(
+        self,
+        tx: Transaction,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        owner_id: str | None = None,
+        namespace: str | None = None,
+    ) -> list[str]:
+        conn = _postgres_tx(tx).conn
+        query = """
+            SELECT id
+            FROM webhook_subscriptions
+            WHERE NOT revoked AND $1 = ANY(events)
+        """
+        args: list[Any] = [event_type]
+        if owner_id is not None:
+            query += " AND owner_id = $2"
+            args.append(owner_id)
+            if namespace is not None:
+                query += " AND namespace = $3"
+                args.append(namespace)
+        subscriptions = await conn.fetch(query, *args)
+        body = json.dumps(
+            {"event": event_type, "timestamp": datetime.now(timezone.utc).isoformat(), "data": payload},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        delivery_ids: list[str] = []
+        for sub in subscriptions:
+            delivery_id = str(uuid.uuid4())
+            await conn.execute(
+                """
+                INSERT INTO webhook_deliveries
+                  (id, subscription_id, event_type, payload, payload_hash, status, writer_revision)
+                VALUES ($1::uuid, $2, $3, $4, $5, 'pending', $6)
+                """,
+                delivery_id,
+                sub["id"],
+                event_type,
+                body,
+                body_hash,
+                2,
+            )
+            delivery_ids.append(delivery_id)
+        return delivery_ids
+
+    async def fetch_deliveries(self, tx: Transaction, subscription_id: str | None = None) -> list[Row]:
+        if subscription_id is None:
+            return await _postgres_tx(tx).conn.fetch("SELECT * FROM webhook_deliveries ORDER BY created ASC")
+        return await _postgres_tx(tx).conn.fetch(
+            "SELECT * FROM webhook_deliveries WHERE subscription_id = $1::uuid ORDER BY created ASC",
+            subscription_id,
+        )
 
 
 class PostgresConsultationAuditRepository(ConsultationAuditRepository):
@@ -484,15 +568,125 @@ class PostgresConsultationAuditRepository(ConsultationAuditRepository):
 
 
 class PostgresFederationRepository(FederationRepository):
-    pass
+    async def fetch_memory_page(
+        self,
+        tx: Transaction,
+        *,
+        updated_after: Any | None = None,
+        id_after: str | None = None,
+        limit: int = 100,
+    ) -> list[Row]:
+        conn = _postgres_tx(tx).conn
+        if updated_after is not None and id_after is not None:
+            return await conn.fetch(
+                """
+                SELECT id, content, category, subcategory, metadata, owner_id, namespace, updated
+                FROM memories
+                WHERE updated > $1 OR (updated = $1 AND id > $2)
+                ORDER BY updated ASC, id ASC
+                LIMIT $3
+                """,
+                updated_after,
+                id_after,
+                limit,
+            )
+        return await conn.fetch(
+            """
+            SELECT id, content, category, subcategory, metadata, owner_id, namespace, updated
+            FROM memories
+            ORDER BY updated ASC, id ASC
+            LIMIT $1
+            """,
+            limit,
+        )
+
+    async def upsert_peer(
+        self,
+        tx: Transaction,
+        *,
+        peer_id: str,
+        base_url: str,
+        name: str | None = None,
+        enabled: bool = True,
+    ) -> None:
+        await _postgres_tx(tx).conn.execute(
+            """
+            INSERT INTO federation_peers (id, base_url, name, auth_token, enabled)
+            VALUES ($1::uuid, $2, $3, '', $4)
+            ON CONFLICT (id) DO UPDATE
+            SET base_url = EXCLUDED.base_url,
+                name = EXCLUDED.name,
+                enabled = EXCLUDED.enabled
+            """,
+            peer_id,
+            base_url,
+            name,
+            enabled,
+        )
 
 
 class PostgresStateRepository(StateRepository):
-    pass
+    async def get(
+        self,
+        tx: Transaction,
+        key: str,
+        *,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> Row | None:
+        return await _postgres_tx(tx).conn.fetchrow(
+            "SELECT key, value, owner_id, namespace FROM state "
+            "WHERE owner_id = $1 AND namespace = $2 AND key = $3",
+            owner_id,
+            namespace,
+            key,
+        )
+
+    async def set(
+        self,
+        tx: Transaction,
+        key: str,
+        value: str,
+        *,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> None:
+        await _postgres_tx(tx).conn.execute(
+            """
+            INSERT INTO state (owner_id, namespace, key, value)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (owner_id, namespace, key) DO UPDATE
+            SET value = EXCLUDED.value
+            """,
+            owner_id,
+            namespace,
+            key,
+            value,
+        )
+
+    async def delete(
+        self,
+        tx: Transaction,
+        key: str,
+        *,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> None:
+        await _postgres_tx(tx).conn.execute(
+            "DELETE FROM state WHERE owner_id = $1 AND namespace = $2 AND key = $3",
+            owner_id,
+            namespace,
+            key,
+        )
 
 
 class PostgresBackend(PersistenceBackend):
     """Postgres persistence facade backed by an asyncpg pool."""
+
+    supports_listen_notify = True
+    supports_advisory_locks = True
+    supports_row_level_security = True
+    supports_pgvector = True
 
     def __init__(self, pool: asyncpg.Pool, settings: Any):
         self._pool = pool

--- a/mnemos/persistence/sqlite.py
+++ b/mnemos/persistence/sqlite.py
@@ -1,0 +1,1682 @@
+"""SQLite persistence backend for the MNEMOS persistence interface."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import logging
+import math
+import sqlite3
+import uuid
+from collections.abc import AsyncIterator, Iterable, Sequence
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - exercised when the sqlite extra is installed.
+    import aiosqlite
+except ImportError:  # pragma: no cover - local CI can run without optional extra.
+    aiosqlite = None
+
+from mnemos.core.auth_context import UserContext
+from mnemos.persistence.base import (
+    BranchRepository,
+    CompressionRepository,
+    ConsultationAuditRepository,
+    FederationRepository,
+    KGRepository,
+    MemoryRepository,
+    PersistenceBackend,
+    StateRepository,
+    Transaction,
+    VersionRepository,
+    WebhookRepository,
+)
+from mnemos.persistence.types import Row
+
+logger = logging.getLogger(__name__)
+
+
+SQLITE_MIGRATION_FILES = [
+    "migrations.sql",
+    "migrations_v1_multiuser.sql",
+    "migrations_v2_versioning.sql",
+    "migrations_v2_sessions.sql",
+    "migrations_model_registry.sql",
+    "migrations_v3_dag.sql",
+    "migrations_v3_graeae_unified.sql",
+    "migrations_v3_webhooks.sql",
+    "migrations_v3_oauth.sql",
+    "migrations_v3_federation.sql",
+    "migrations_v3_ownership.sql",
+    "migrations_v3_1_compression.sql",
+    "migrations_v3_1_versioning_fix.sql",
+    "migrations_v3_1_2_kg_tenancy.sql",
+    "migrations_v3_1_2_audit_log_columns.sql",
+    "migrations_v3_2_user_namespace.sql",
+    "migrations_v3_2_entities_namespace.sql",
+    "migrations_v3_2_2_version_snapshot_new_values.sql",
+    "migrations_v3_3_morpheus.sql",
+    "migrations_v3_3_morpheus_namespace.sql",
+    "migrations_v3_3_recall_tracking.sql",
+    "migrations_charon_trigger_guard.sql",
+    "migrations_v3_4_federation_compat.sql",
+    "migrations_v3_5_trigger_same_memory_parent.sql",
+    "migrations_v3_5_rls_group_select_unix_bits.sql",
+    "migrations_v3_5_webhook_retry_terminal_state.sql",
+    "migrations_v3_5_webhook_attempt_lease.sql",
+    "migrations_v3_5_webhook_writer_revision.sql",
+    "migrations_v3_5_webhook_status_updated_at.sql",
+    "migrations_v3_5_webhook_superseded_marker.sql",
+    "migrations_v3_5_webhook_attempt_unique.sql",
+    "migrations_v3_5_webhook_succeeded_unique.sql",
+    "migrations_v3_5_webhook_succeeded_terminal_trigger.sql",
+    "migrations_v3_5_entities_namespace_unique.sql",
+    "migrations_v3_5_state_journal_namespace.sql",
+    "migrations_v3_5_session_compression_ratio_drop.sql",
+    "migrations_v3_5_session_compression_legacy_drop.sql",
+    "migrations_v3_5_sessions_consultations_namespace.sql",
+]
+
+
+def _dict_factory(cursor: sqlite3.Cursor, row: tuple[Any, ...]) -> dict[str, Any]:
+    return {column[0]: row[index] for index, column in enumerate(cursor.description)}
+
+
+def _is_root(user: UserContext) -> bool:
+    return user.role == "root"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sqlite_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _json_text(value: Any, *, default: Any = None) -> str:
+    if value is None:
+        value = default
+    if isinstance(value, str):
+        return value
+    return json.dumps(value if value is not None else default)
+
+
+def _json_list(value: Any) -> list[Any]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        return decoded if isinstance(decoded, list) else []
+    return []
+
+
+def _placeholders(values: Sequence[Any]) -> str:
+    return ", ".join("?" for _ in values)
+
+
+def _in_clause(column: str, values: Sequence[Any], params: list[Any]) -> str:
+    if not values:
+        return "0"
+    params.extend(values)
+    return f"{column} IN ({_placeholders(values)})"
+
+
+def _read_visibility_clause(
+    user: UserContext,
+    params: list[Any],
+    *,
+    table_alias: str = "",
+) -> str:
+    p = f"{table_alias}." if table_alias else ""
+    params.append(user.user_id)
+    group_ids = list(user.group_ids)
+    if group_ids:
+        group_clause = f"{p}group_id IN ({_placeholders(group_ids)})"
+        params.extend(group_ids)
+    else:
+        group_clause = "0"
+    return (
+        "("
+        f"{p}owner_id = ?"
+        f" OR {p}federation_source IS NOT NULL"
+        f" OR ({p}permission_mode % 10) >= 4"
+        f" OR ((({p}permission_mode / 10) % 10) >= 4 "
+        f"AND {p}group_id IS NOT NULL AND {group_clause})"
+        ")"
+    )
+
+
+def _version_visibility_clause(
+    user: UserContext,
+    params: list[Any],
+    *,
+    table_alias: str = "",
+) -> str:
+    p = f"{table_alias}." if table_alias else ""
+    params.append(user.user_id)
+    return f"({p}owner_id = ? OR ({p}permission_mode % 10) >= 4)"
+
+
+def _parse_embedding(raw: Any) -> list[float]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            raw = [part for part in raw.strip("[]").split(",") if part]
+    if isinstance(raw, Iterable):
+        out: list[float] = []
+        for item in raw:
+            try:
+                out.append(float(item))
+            except (TypeError, ValueError):
+                return []
+        return out
+    return []
+
+
+def _cosine_similarity(left: Any, right: Any) -> float:
+    a = _parse_embedding(left)
+    b = _parse_embedding(right)
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _call(method: Any, *args: Any) -> Any:
+    return await _maybe_await(method(*args))
+
+
+async def _execute(conn: Any, sql: str, params: Sequence[Any] = ()) -> Any:
+    normalized = tuple(_sqlite_value(value) for value in params)
+    return await _maybe_await(conn.execute(sql, normalized))
+
+
+async def _executemany(conn: Any, sql: str, rows: Sequence[Sequence[Any]]) -> Any:
+    normalized = [tuple(_sqlite_value(value) for value in row) for row in rows]
+    return await _maybe_await(conn.executemany(sql, normalized))
+
+
+async def _executescript(conn: Any, sql: str) -> Any:
+    return await _maybe_await(conn.executescript(sql))
+
+
+async def _fetch_all(conn: Any, sql: str, params: Sequence[Any] = ()) -> list[Row]:
+    cursor = await _execute(conn, sql, params)
+    try:
+        rows = await _maybe_await(cursor.fetchall())
+    finally:
+        close = getattr(cursor, "close", None)
+        if close is not None:
+            await _maybe_await(close())
+    return list(rows)
+
+
+async def _fetch_one(conn: Any, sql: str, params: Sequence[Any] = ()) -> Row | None:
+    cursor = await _execute(conn, sql, params)
+    try:
+        row = await _maybe_await(cursor.fetchone())
+    finally:
+        close = getattr(cursor, "close", None)
+        if close is not None:
+            await _maybe_await(close())
+    return row
+
+
+async def _fetch_val(conn: Any, sql: str, params: Sequence[Any] = ()) -> Any:
+    row = await _fetch_one(conn, sql, params)
+    if row is None:
+        return None
+    if isinstance(row, dict):
+        return next(iter(row.values()))
+    return row[0]
+
+
+async def _commit(conn: Any) -> None:
+    await _maybe_await(conn.commit())
+
+
+async def _rollback(conn: Any) -> None:
+    await _maybe_await(conn.rollback())
+
+
+class SqliteTransaction:
+    """Transaction wrapper that keeps SQLite connection details private."""
+
+    def __init__(self, conn: Any):
+        self._conn = conn
+        self._closed = False
+
+    @property
+    def conn(self) -> Any:
+        return self._conn
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def commit(self) -> None:
+        if self._closed:
+            return
+        await _commit(self._conn)
+        self._closed = True
+
+    async def rollback(self) -> None:
+        if self._closed:
+            return
+        await _rollback(self._conn)
+        self._closed = True
+
+
+def _sqlite_tx(tx: Transaction) -> SqliteTransaction:
+    if not isinstance(tx, SqliteTransaction):
+        raise TypeError("SQLite repositories require a SqliteTransaction")
+    return tx
+
+
+class _SqliteRepository:
+    @staticmethod
+    def _conn(tx: Transaction) -> Any:
+        return _sqlite_tx(tx).conn
+
+
+class SqliteMemoryRepository(_SqliteRepository, MemoryRepository):
+    async def assert_memory_readable(self, tx: Transaction, memory_id: str, user: UserContext) -> None:
+        conn = self._conn(tx)
+        if _is_root(user):
+            row = await _fetch_one(conn, "SELECT 1 FROM memory_versions WHERE memory_id = ? LIMIT 1", (memory_id,))
+        else:
+            params: list[Any] = [memory_id]
+            vis_clause = _read_visibility_clause(user, params)
+            params.append(user.namespace)
+            row = await _fetch_one(
+                conn,
+                f"SELECT 1 FROM memories WHERE id = ? AND {vis_clause} AND namespace = ? LIMIT 1",
+                params,
+            )
+        if not row:
+            raise PermissionError(f"Memory {memory_id} not found")
+
+    async def fetch_memory_log(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        branch: str,
+        limit: int,
+        user: UserContext,
+    ) -> list[Row]:
+        rows = await _fetch_all(
+            self._conn(tx),
+            """
+            WITH RECURSIVE commit_walk AS (
+                SELECT
+                    mv.id, mv.memory_id, mv.commit_hash, mv.parent_version_id,
+                    mv.version_num, mv.branch, mv.content, mv.category,
+                    mv.change_type, mv.snapshot_at, mv.snapshot_by,
+                    mv.owner_id, mv.namespace, mv.permission_mode,
+                    1 AS depth
+                FROM memory_versions mv
+                INNER JOIN memory_branches mb ON (
+                    mb.memory_id = mv.memory_id AND
+                    mb.name = ? AND
+                    mb.head_version_id = mv.id
+                )
+                WHERE mv.memory_id = ?
+                UNION ALL
+                SELECT
+                    mv.id, mv.memory_id, mv.commit_hash, mv.parent_version_id,
+                    mv.version_num, mv.branch, mv.content, mv.category,
+                    mv.change_type, mv.snapshot_at, mv.snapshot_by,
+                    mv.owner_id, mv.namespace, mv.permission_mode,
+                    cw.depth + 1
+                FROM memory_versions mv
+                INNER JOIN commit_walk cw
+                    ON mv.id = cw.parent_version_id
+                   AND mv.memory_id = cw.memory_id
+                WHERE cw.depth < ?
+            )
+            SELECT
+                commit_hash, version_num, branch, category, change_type,
+                snapshot_at, snapshot_by, owner_id, namespace, permission_mode
+            FROM commit_walk
+            ORDER BY depth ASC
+            LIMIT ?
+            """,
+            (branch, memory_id, limit, limit),
+        )
+        if _is_root(user):
+            return rows
+        return [
+            row for row in rows
+            if row["namespace"] == user.namespace
+            and (row["owner_id"] == user.user_id or (row["permission_mode"] % 10) >= 4)
+        ]
+
+    async def fetch_diff_commit_pair(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_a: str,
+        commit_b: str,
+        user: UserContext,
+    ) -> tuple[Row | None, Row | None]:
+        conn = self._conn(tx)
+        if _is_root(user):
+            sql = "SELECT content, version_num FROM memory_versions WHERE memory_id = ? AND commit_hash = ?"
+            return (
+                await _fetch_one(conn, sql, (memory_id, commit_a)),
+                await _fetch_one(conn, sql, (memory_id, commit_b)),
+            )
+        params_a: list[Any] = [memory_id, commit_a]
+        vis_clause = _version_visibility_clause(user, params_a)
+        params_a.append(user.namespace)
+        sql = (
+            "SELECT content, version_num FROM memory_versions "
+            f"WHERE memory_id = ? AND commit_hash = ? AND {vis_clause} AND namespace = ?"
+        )
+        params_b: list[Any] = [memory_id, commit_b]
+        vis_clause_b = _version_visibility_clause(user, params_b)
+        params_b.append(user.namespace)
+        sql_b = (
+            "SELECT content, version_num FROM memory_versions "
+            f"WHERE memory_id = ? AND commit_hash = ? AND {vis_clause_b} AND namespace = ?"
+        )
+        return (await _fetch_one(conn, sql, params_a), await _fetch_one(conn, sql_b, params_b))
+
+    async def fetch_checkout_commit(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        commit_hash: str,
+        user: UserContext,
+    ) -> Row | None:
+        conn = self._conn(tx)
+        select = (
+            "SELECT commit_hash, version_num, branch, category, subcategory, "
+            "content, change_type, snapshot_at, snapshot_by "
+            "FROM memory_versions "
+        )
+        if _is_root(user):
+            return await _fetch_one(conn, select + "WHERE memory_id = ? AND commit_hash = ?", (memory_id, commit_hash))
+        params: list[Any] = [memory_id, commit_hash]
+        vis_clause = _version_visibility_clause(user, params)
+        params.append(user.namespace)
+        return await _fetch_one(
+            conn,
+            select + f"WHERE memory_id = ? AND commit_hash = ? AND {vis_clause} AND namespace = ?",
+            params,
+        )
+
+    async def fetch_memory_export(
+        self,
+        tx: Transaction,
+        *,
+        effective_owner: str | None,
+        effective_ns: str | None,
+        category: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[Row]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if effective_owner:
+            conditions.append("owner_id = ?")
+            params.append(effective_owner)
+        if effective_ns:
+            conditions.append("namespace = ?")
+            params.append(effective_ns)
+        if category:
+            conditions.append("category = ?")
+            params.append(category)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.extend([limit, offset])
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT id, content, category, subcategory, created, updated, "
+            "owner_id, namespace, permission_mode, quality_rating, "
+            "source_model, source_provider, source_session, source_agent, "
+            f"metadata FROM memories {where} ORDER BY created ASC LIMIT ? OFFSET ?",
+            params,
+        )
+
+    async def fetch_referenced_memory_allowlist(
+        self,
+        tx: Transaction,
+        *,
+        referenced_ids: Sequence[str],
+        scope_owner: str | None = None,
+        scope_namespace: str | None = None,
+    ) -> list[Row]:
+        if not referenced_ids:
+            return []
+        params: list[Any] = []
+        conditions = [_in_clause("id", list(referenced_ids), params)]
+        if scope_owner is not None:
+            conditions.append("owner_id = ?")
+            params.append(scope_owner)
+        if scope_namespace is not None:
+            conditions.append("namespace = ?")
+            params.append(scope_namespace)
+        return await _fetch_all(
+            self._conn(tx),
+            f"SELECT id, owner_id, namespace FROM memories WHERE {' AND '.join(conditions)}",
+            params,
+        )
+
+    async def insert_memory(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        content: str,
+        category: str,
+        subcategory: str | None,
+        metadata_json: str,
+        quality_rating: int,
+        owner_id: str,
+        namespace: str,
+        permission_mode: int,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        created: Any,
+        updated: Any,
+    ) -> str:
+        await _execute(
+            self._conn(tx),
+            """
+            INSERT OR IGNORE INTO memories (
+                id, content, category, subcategory, metadata,
+                quality_rating, owner_id, namespace, permission_mode,
+                source_model, source_provider, source_session, source_agent,
+                created, updated
+            )
+            VALUES (
+                ?, ?, ?, ?, ?,
+                ?, ?, ?, ?,
+                ?, ?, ?, ?,
+                COALESCE(?, CURRENT_TIMESTAMP), COALESCE(?, CURRENT_TIMESTAMP)
+            )
+            """,
+            (
+                memory_id,
+                content,
+                category,
+                subcategory,
+                metadata_json,
+                quality_rating,
+                owner_id,
+                namespace,
+                permission_mode,
+                source_model,
+                source_provider,
+                source_session,
+                source_agent,
+                created,
+                updated,
+            ),
+        )
+        return "INSERT 0 1"
+
+    async def fetch_memory_by_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        return await _fetch_one(
+            self._conn(tx),
+            "SELECT content, category, subcategory, metadata, quality_rating, owner_id, "
+            "namespace, permission_mode, source_model, source_provider, source_session, "
+            "source_agent, created, updated FROM memories WHERE id = ?",
+            (memory_id,),
+        )
+
+    async def set_suppress_version_snapshot(self, tx: Transaction) -> None:
+        await _execute(self._conn(tx), "CREATE TEMP TABLE IF NOT EXISTS mnemos_tx_flags (key TEXT PRIMARY KEY)")
+        await _execute(self._conn(tx), "INSERT OR IGNORE INTO mnemos_tx_flags(key) VALUES ('suppress_version_snapshot')")
+
+    async def fetch_versioned_memory_ids(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        if not memory_ids:
+            return []
+        params: list[Any] = []
+        condition = _in_clause("memory_id", list(memory_ids), params)
+        return await _fetch_all(
+            self._conn(tx),
+            f"SELECT DISTINCT memory_id FROM memory_versions WHERE {condition}",
+            params,
+        )
+
+    async def fetch_memory_head_checks(self, tx: Transaction, memory_ids: Sequence[str]) -> list[Row]:
+        if not memory_ids:
+            return []
+        params: list[Any] = []
+        condition = _in_clause("m.id", list(memory_ids), params)
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT m.id, m.content AS memory_content, mv.content AS head_content "
+            "FROM memories m "
+            "LEFT JOIN memory_branches b ON b.memory_id = m.id AND b.name = 'main' "
+            "LEFT JOIN memory_versions mv ON mv.id = b.head_version_id "
+            f"WHERE {condition}",
+            params,
+        )
+
+    async def fetch_memory_context(
+        self,
+        tx: Transaction,
+        query: str,
+        user: Any,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        conn = self._conn(tx)
+        categories = ("solutions", "patterns", "decisions", "infrastructure")
+        category_placeholders = _placeholders(categories)
+        like_q = f"%{query}%"
+        params: list[Any] = []
+        if getattr(user, "role", None) == "root":
+            params.extend([like_q, *categories, limit])
+            rows = await _fetch_all(
+                conn,
+                "SELECT m.id, COALESCE(v.compressed_content, m.content) AS content "
+                "FROM memories m "
+                "LEFT JOIN memory_compressed_variants v ON v.memory_id = m.id "
+                f"WHERE lower(m.content) LIKE lower(?) OR m.category IN ({category_placeholders}) "
+                "ORDER BY m.updated DESC LIMIT ?",
+                params,
+            )
+        else:
+            vis_clause = _read_visibility_clause(user, params, table_alias="m")
+            params.extend([user.namespace, like_q, *categories, limit])
+            rows = await _fetch_all(
+                conn,
+                "SELECT m.id, COALESCE(v.compressed_content, m.content) AS content "
+                "FROM memories m "
+                "LEFT JOIN memory_compressed_variants v ON v.memory_id = m.id "
+                f"WHERE {vis_clause} AND m.namespace = ? "
+                f"AND (lower(m.content) LIKE lower(?) OR m.category IN ({category_placeholders})) "
+                "ORDER BY m.updated DESC LIMIT ?",
+                params,
+            )
+        return [{"id": row["id"], "content": row["content"]} for row in rows]
+
+    async def upsert_memory_embedding(self, tx: Transaction, memory_id: str, embedding: Sequence[float]) -> None:
+        embedding_json = json.dumps([float(value) for value in embedding])
+        conn = self._conn(tx)
+        await _execute(conn, "UPDATE memories SET embedding = ? WHERE id = ?", (embedding_json, memory_id))
+        await _execute(
+            conn,
+            "INSERT INTO memory_embeddings(memory_id, embedding) VALUES (?, ?) "
+            "ON CONFLICT(memory_id) DO UPDATE SET embedding = excluded.embedding",
+            (memory_id, embedding_json),
+        )
+
+    async def semantic_search(
+        self,
+        tx: Transaction,
+        embedding: Sequence[float],
+        *,
+        limit: int = 5,
+        owner_id: str | None = None,
+        namespace: str | None = None,
+    ) -> list[Row]:
+        embedding_json = json.dumps([float(value) for value in embedding])
+        conditions = ["me.embedding IS NOT NULL"]
+        params: list[Any] = [embedding_json]
+        if owner_id is not None:
+            conditions.append("m.owner_id = ?")
+            params.append(owner_id)
+        if namespace is not None:
+            conditions.append("m.namespace = ?")
+            params.append(namespace)
+        params.append(limit)
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT m.id, m.content, m.category, "
+            "mnemos_cosine_similarity(me.embedding, ?) AS similarity "
+            "FROM memory_embeddings me "
+            "JOIN memories m ON m.id = me.memory_id "
+            f"WHERE {' AND '.join(conditions)} "
+            "ORDER BY similarity DESC, m.updated DESC LIMIT ?",
+            params,
+        )
+
+    async def fts_search(
+        self,
+        tx: Transaction,
+        query: str,
+        *,
+        limit: int = 5,
+        owner_id: str | None = None,
+        namespace: str | None = None,
+    ) -> list[Row]:
+        conn = self._conn(tx)
+        conditions: list[str] = []
+        params: list[Any] = [query]
+        if owner_id is not None:
+            conditions.append("m.owner_id = ?")
+            params.append(owner_id)
+        if namespace is not None:
+            conditions.append("m.namespace = ?")
+            params.append(namespace)
+        where_extra = f" AND {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+        try:
+            return await _fetch_all(
+                conn,
+                "SELECT m.id, m.content, m.category, bm25(memories_fts) AS rank "
+                "FROM memories_fts "
+                "JOIN memories m ON m.id = memories_fts.id "
+                f"WHERE memories_fts MATCH ?{where_extra} "
+                "ORDER BY rank ASC, m.updated DESC LIMIT ?",
+                params,
+            )
+        except sqlite3.Error:
+            like_params: list[Any] = [f"%{query}%"]
+            like_conditions = ["lower(m.content) LIKE lower(?)"]
+            if owner_id is not None:
+                like_conditions.append("m.owner_id = ?")
+                like_params.append(owner_id)
+            if namespace is not None:
+                like_conditions.append("m.namespace = ?")
+                like_params.append(namespace)
+            like_params.append(limit)
+            return await _fetch_all(
+                conn,
+                "SELECT m.id, m.content, m.category FROM memories m "
+                f"WHERE {' AND '.join(like_conditions)} ORDER BY m.updated DESC LIMIT ?",
+                like_params,
+            )
+
+
+class SqliteKGRepository(_SqliteRepository, KGRepository):
+    async def fetch_kg_triples_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        include_unattached: bool,
+        hard_limit: int,
+    ) -> list[Row]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if memory_ids:
+            memory_condition = _in_clause("memory_id", list(memory_ids), params)
+            if include_unattached:
+                conditions.append(f"(memory_id IS NULL OR {memory_condition})")
+            else:
+                conditions.append(memory_condition)
+        elif include_unattached:
+            conditions.append("memory_id IS NULL")
+        else:
+            return []
+        if effective_owner:
+            conditions.append("owner_id = ?")
+            params.append(effective_owner)
+        if effective_ns:
+            conditions.append("namespace = ?")
+            params.append(effective_ns)
+        params.append(hard_limit + 1)
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT id, subject, predicate, object, subject_type, object_type, "
+            "valid_from, valid_until, memory_id, confidence, created, owner_id, namespace "
+            f"FROM kg_triples WHERE {' AND '.join(conditions)} LIMIT ?",
+            params,
+        )
+
+    async def insert_kg_triple(
+        self,
+        tx: Transaction,
+        *,
+        triple_id: str,
+        subject: str,
+        predicate: str,
+        obj: str,
+        subject_type: str | None,
+        object_type: str | None,
+        valid_from: Any,
+        valid_until: Any,
+        memory_id: str | None,
+        confidence: float | None,
+        created: Any,
+        owner_id: str,
+        namespace: str | None,
+    ) -> str:
+        await _execute(
+            self._conn(tx),
+            """
+            INSERT OR IGNORE INTO kg_triples (
+                id, subject, predicate, object,
+                subject_type, object_type,
+                valid_from, valid_until,
+                memory_id, confidence, created,
+                owner_id, namespace
+            )
+            VALUES (
+                ?, ?, ?, ?,
+                ?, ?,
+                COALESCE(?, CURRENT_TIMESTAMP), ?,
+                ?, COALESCE(?, 1.0),
+                COALESCE(?, CURRENT_TIMESTAMP),
+                ?, COALESCE(?, 'default')
+            )
+            """,
+            (
+                triple_id,
+                subject,
+                predicate,
+                obj,
+                subject_type,
+                object_type,
+                valid_from,
+                valid_until,
+                memory_id,
+                confidence,
+                created,
+                owner_id,
+                namespace,
+            ),
+        )
+        return "INSERT 0 1"
+
+    async def fetch_kg_triple_by_id(self, tx: Transaction, triple_id: str) -> Row | None:
+        return await _fetch_one(
+            self._conn(tx),
+            "SELECT subject, predicate, object, subject_type, object_type, memory_id, "
+            "confidence, owner_id, namespace, valid_from, valid_until, created "
+            "FROM kg_triples WHERE id = ?",
+            (triple_id,),
+        )
+
+    async def search_triples(
+        self,
+        tx: Transaction,
+        query: str,
+        *,
+        owner_id: str | None = None,
+        namespace: str | None = None,
+        limit: int = 20,
+    ) -> list[Row]:
+        params: list[Any] = [f"%{query}%", f"%{query}%", f"%{query}%"]
+        conditions = [
+            "(lower(subject) LIKE lower(?) OR lower(predicate) LIKE lower(?) OR lower(object) LIKE lower(?))"
+        ]
+        if owner_id is not None:
+            conditions.append("owner_id = ?")
+            params.append(owner_id)
+        if namespace is not None:
+            conditions.append("namespace = ?")
+            params.append(namespace)
+        params.append(limit)
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT * FROM kg_triples "
+            f"WHERE {' AND '.join(conditions)} ORDER BY valid_from ASC, created ASC LIMIT ?",
+            params,
+        )
+
+
+async def _fetch_sidecar(
+    conn: Any,
+    *,
+    table: str,
+    columns: str,
+    memory_id_column: str,
+    memory_ids: Sequence[str],
+    effective_owner: str | None,
+    effective_ns: str | None,
+    bound_to_memories: bool,
+    hard_limit: int,
+    order_by: str | None = None,
+) -> list[Row]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    if bound_to_memories:
+        if not memory_ids:
+            return []
+        conditions.append(_in_clause(memory_id_column, list(memory_ids), params))
+    if effective_owner:
+        conditions.append("owner_id = ?")
+        params.append(effective_owner)
+    if effective_ns:
+        conditions.append("namespace = ?")
+        params.append(effective_ns)
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    order = f"ORDER BY {order_by}" if order_by else ""
+    params.append(hard_limit + 1)
+    return await _fetch_all(conn, f"SELECT {columns} FROM {table} {where} {order} LIMIT ?", params)
+
+
+class SqliteVersionRepository(_SqliteRepository, VersionRepository):
+    async def fetch_memory_versions_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        effective_ns: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        return await _fetch_sidecar(
+            self._conn(tx),
+            table="memory_versions",
+            columns=(
+                "id, memory_id, version_num, content, category, "
+                "subcategory, metadata, verbatim_content, owner_id, "
+                "namespace, permission_mode, source_model, source_provider, "
+                "source_session, source_agent, snapshot_at, snapshot_by, "
+                "change_type, commit_hash, parent_version_id, branch, merge_parents"
+            ),
+            memory_id_column="memory_id",
+            memory_ids=memory_ids,
+            effective_owner=effective_owner,
+            effective_ns=effective_ns,
+            bound_to_memories=True,
+            hard_limit=hard_limit,
+            order_by="memory_id ASC, branch ASC, version_num ASC",
+        )
+
+    async def fetch_memory_versions_by_ids(self, tx: Transaction, version_ids: Sequence[str]) -> list[Row]:
+        if not version_ids:
+            return []
+        params: list[Any] = []
+        condition = _in_clause("id", list(version_ids), params)
+        return await _fetch_all(
+            self._conn(tx),
+            f"SELECT id, memory_id, owner_id, namespace FROM memory_versions WHERE {condition}",
+            params,
+        )
+
+    async def insert_memory_version(
+        self,
+        tx: Transaction,
+        *,
+        version_id: str,
+        memory_id: str,
+        version_num: int,
+        content: str,
+        category: str | None,
+        subcategory: str | None,
+        metadata_json: str,
+        verbatim_content: str | None,
+        owner_id: str,
+        namespace: str | None,
+        permission_mode: int | None,
+        source_model: str | None,
+        source_provider: str | None,
+        source_session: str | None,
+        source_agent: str | None,
+        snapshot_at: Any,
+        snapshot_by: str | None,
+        change_type: str | None,
+        commit_hash: str | None,
+        parent_version_id: str | None,
+        branch: str | None,
+        merge_parents: Any,
+    ) -> str:
+        await _execute(
+            self._conn(tx),
+            """
+            INSERT OR IGNORE INTO memory_versions (
+                id, memory_id, version_num, content,
+                category, subcategory, metadata, verbatim_content,
+                owner_id, namespace, permission_mode,
+                source_model, source_provider, source_session, source_agent,
+                snapshot_at, snapshot_by, change_type,
+                commit_hash, parent_version_id, branch, merge_parents
+            )
+            VALUES (
+                ?, ?, ?, ?,
+                ?, ?, ?, ?,
+                ?, ?, COALESCE(?, 600),
+                ?, ?, ?, ?,
+                COALESCE(?, CURRENT_TIMESTAMP), ?, COALESCE(?, 'create'),
+                ?, ?, COALESCE(?, 'main'), ?
+            )
+            """,
+            (
+                version_id,
+                memory_id,
+                version_num,
+                content,
+                category,
+                subcategory,
+                metadata_json,
+                verbatim_content,
+                owner_id,
+                namespace,
+                permission_mode,
+                source_model,
+                source_provider,
+                source_session,
+                source_agent,
+                snapshot_at,
+                snapshot_by,
+                change_type,
+                commit_hash,
+                parent_version_id,
+                branch,
+                _json_text(merge_parents, default=[]),
+            ),
+        )
+        return "INSERT 0 1"
+
+    async def fetch_memory_version_by_id(self, tx: Transaction, version_id: str) -> Row | None:
+        return await _fetch_one(
+            self._conn(tx),
+            "SELECT memory_id, owner_id, namespace, version_num, content, commit_hash, "
+            "parent_version_id, branch, merge_parents, category, subcategory, metadata, "
+            "verbatim_content, permission_mode, source_model, source_provider, source_session, "
+            "source_agent, snapshot_at, snapshot_by, change_type "
+            "FROM memory_versions WHERE id = ?",
+            (version_id,),
+        )
+
+
+class SqliteBranchRepository(_SqliteRepository, BranchRepository):
+    async def create_memory_branch(
+        self,
+        tx: Transaction,
+        memory_id: str,
+        name: str,
+        from_commit: str | None,
+        user: UserContext,
+    ) -> dict[str, Any]:
+        conn = self._conn(tx)
+        if _is_root(user):
+            live = await _fetch_one(conn, "SELECT 1 FROM memories WHERE id = ?", (memory_id,))
+        else:
+            live = await _fetch_one(
+                conn,
+                "SELECT 1 FROM memories WHERE id = ? AND owner_id = ? AND namespace = ?",
+                (memory_id, user.user_id, user.namespace),
+            )
+        if not live:
+            return {"success": False, "error": f"Memory {memory_id} not found"}
+
+        if from_commit:
+            start = await self._fetch_branch_start_by_commit(conn, memory_id, from_commit, user)
+            if not start:
+                return {"success": False, "error": "Commit not found"}
+        else:
+            start = await self._fetch_main_branch_start(conn, memory_id, user)
+            if not start:
+                return {"success": False, "error": "main branch not found"}
+
+        await _execute(
+            conn,
+            "INSERT OR IGNORE INTO memory_branches (memory_id, name, head_version_id, created_by) "
+            "VALUES (?, ?, ?, ?)",
+            (memory_id, name, start["id"], user.user_id),
+        )
+        existing = await self._fetch_existing_branch(conn, memory_id, name, user)
+        if existing is None:
+            return {
+                "success": False,
+                "error": (
+                    "branch exists but its head is not visible or points at a foreign memory version; "
+                    "reconciliation required"
+                ),
+            }
+        if existing["head_version_id"] == start["id"]:
+            return {
+                "success": True,
+                "memory_id": memory_id,
+                "branch": name,
+                "commit_hash": existing["commit_hash"],
+                "created_by": user.user_id,
+                "idempotent": existing["head_version_id"] != start["id"],
+            }
+        return {
+            "success": False,
+            "error": f"branch '{name}' already exists at a different head; refusing to silently move it",
+        }
+
+    async def _fetch_branch_start_by_commit(
+        self,
+        conn: Any,
+        memory_id: str,
+        from_commit: str,
+        user: UserContext,
+    ) -> Row | None:
+        if _is_root(user):
+            return await _fetch_one(
+                conn,
+                "SELECT id, commit_hash FROM memory_versions WHERE memory_id = ? AND commit_hash = ?",
+                (memory_id, from_commit),
+            )
+        params: list[Any] = [memory_id, from_commit]
+        vis_clause = _version_visibility_clause(user, params)
+        params.append(user.namespace)
+        return await _fetch_one(
+            conn,
+            "SELECT id, commit_hash FROM memory_versions "
+            f"WHERE memory_id = ? AND commit_hash = ? AND {vis_clause} AND namespace = ?",
+            params,
+        )
+
+    async def _fetch_main_branch_start(self, conn: Any, memory_id: str, user: UserContext) -> Row | None:
+        if _is_root(user):
+            return await _fetch_one(
+                conn,
+                "SELECT mv.id, mv.commit_hash FROM memory_versions mv "
+                "INNER JOIN memory_branches mb ON mb.memory_id = mv.memory_id AND mb.head_version_id = mv.id "
+                "WHERE mv.memory_id = ? AND mb.name = 'main'",
+                (memory_id,),
+            )
+        params: list[Any] = [memory_id]
+        vis_clause = _version_visibility_clause(user, params, table_alias="mv")
+        params.append(user.namespace)
+        return await _fetch_one(
+            conn,
+            "SELECT mv.id, mv.commit_hash FROM memory_versions mv "
+            "INNER JOIN memory_branches mb ON mb.memory_id = mv.memory_id AND mb.head_version_id = mv.id "
+            f"WHERE mv.memory_id = ? AND mb.name = 'main' AND {vis_clause} AND mv.namespace = ?",
+            params,
+        )
+
+    async def _fetch_existing_branch(
+        self,
+        conn: Any,
+        memory_id: str,
+        name: str,
+        user: UserContext,
+    ) -> Row | None:
+        if _is_root(user):
+            return await _fetch_one(
+                conn,
+                "SELECT mb.head_version_id, mv.commit_hash FROM memory_branches mb "
+                "INNER JOIN memory_versions mv ON mv.id = mb.head_version_id AND mv.memory_id = mb.memory_id "
+                "WHERE mb.memory_id = ? AND mb.name = ?",
+                (memory_id, name),
+            )
+        params: list[Any] = [memory_id, name]
+        vis_clause = _version_visibility_clause(user, params, table_alias="mv")
+        params.append(user.namespace)
+        return await _fetch_one(
+            conn,
+            "SELECT mb.head_version_id, mv.commit_hash FROM memory_branches mb "
+            "INNER JOIN memory_versions mv ON mv.id = mb.head_version_id AND mv.memory_id = mb.memory_id "
+            f"AND {vis_clause} AND mv.namespace = ? "
+            "WHERE mb.memory_id = ? AND mb.name = ?",
+            params[2:] + params[:2],
+        )
+
+    async def delete_memory_branches_for_memories(self, tx: Transaction, memory_ids: Sequence[str]) -> None:
+        if not memory_ids:
+            return
+        params: list[Any] = []
+        condition = _in_clause("memory_id", list(memory_ids), params)
+        await _execute(self._conn(tx), f"DELETE FROM memory_branches WHERE {condition}", params)
+
+    async def fetch_memory_branch_heads(
+        self,
+        tx: Transaction,
+        memory_ids: Sequence[str],
+        *,
+        authorized_version_uuids: Sequence[str] | None = None,
+    ) -> list[Row]:
+        if not memory_ids:
+            return []
+        params: list[Any] = []
+        conditions = [_in_clause("memory_id", list(memory_ids), params)]
+        if authorized_version_uuids is not None:
+            conditions.append(_in_clause("id", list(authorized_version_uuids), params))
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT memory_id, branch, id AS head_version_id "
+            "FROM ("
+            "  SELECT memory_id, branch, id, version_num, "
+            "         ROW_NUMBER() OVER (PARTITION BY memory_id, branch ORDER BY version_num DESC) AS rn "
+            "  FROM memory_versions "
+            f"  WHERE {' AND '.join(conditions)}"
+            ") ranked WHERE rn = 1",
+            params,
+        )
+
+    async def upsert_memory_branch_head(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        branch: str,
+        head_version_id: Any,
+    ) -> None:
+        await _execute(
+            self._conn(tx),
+            "INSERT INTO memory_branches (memory_id, name, head_version_id, created_by) VALUES (?, ?, ?, NULL) "
+            "ON CONFLICT(memory_id, name) DO UPDATE SET head_version_id = excluded.head_version_id",
+            (memory_id, branch, head_version_id),
+        )
+
+
+class SqliteCompressionRepository(_SqliteRepository, CompressionRepository):
+    async def fetch_compressed_variants_for_export(
+        self,
+        tx: Transaction,
+        *,
+        memory_ids: Sequence[str],
+        effective_owner: str | None,
+        hard_limit: int,
+    ) -> list[Row]:
+        return await _fetch_sidecar(
+            self._conn(tx),
+            table="memory_compressed_variants",
+            columns=(
+                "memory_id, owner_id, winner_candidate_id, engine_id, engine_version, "
+                "compressed_content, compressed_tokens, compression_ratio, quality_score, "
+                "composite_score, scoring_profile, judge_model, selected_at"
+            ),
+            memory_id_column="memory_id",
+            memory_ids=memory_ids,
+            effective_owner=effective_owner,
+            effective_ns=None,
+            bound_to_memories=True,
+            hard_limit=hard_limit,
+        )
+
+    async def compression_candidate_exists(
+        self,
+        tx: Transaction,
+        *,
+        candidate_id: str,
+        memory_id: str,
+        owner_id: str,
+    ) -> bool:
+        exists = await _fetch_val(
+            self._conn(tx),
+            "SELECT 1 FROM memory_compression_candidates WHERE id = ? AND memory_id = ? AND owner_id = ?",
+            (candidate_id, memory_id, owner_id),
+        )
+        return bool(exists)
+
+    async def insert_compressed_variant(
+        self,
+        tx: Transaction,
+        *,
+        memory_id: str,
+        owner_id: str,
+        winner_candidate_id: str | None,
+        engine_id: str,
+        engine_version: str | None,
+        compressed_content: str | None,
+        compressed_tokens: int | None,
+        compression_ratio: float | None,
+        quality_score: float | None,
+        composite_score: float | None,
+        scoring_profile: str | None,
+        judge_model: str | None,
+        selected_at: Any,
+    ) -> str:
+        await _execute(
+            self._conn(tx),
+            """
+            INSERT OR IGNORE INTO memory_compressed_variants (
+                memory_id, owner_id, winner_candidate_id,
+                engine_id, engine_version, compressed_content,
+                compressed_tokens, compression_ratio,
+                quality_score, composite_score,
+                scoring_profile, judge_model, selected_at
+            )
+            VALUES (
+                ?, ?, ?,
+                ?, ?, ?,
+                ?, ?,
+                ?, ?,
+                COALESCE(?, 'balanced'), ?,
+                COALESCE(?, CURRENT_TIMESTAMP)
+            )
+            """,
+            (
+                memory_id,
+                owner_id,
+                winner_candidate_id,
+                engine_id,
+                engine_version,
+                compressed_content,
+                compressed_tokens,
+                compression_ratio,
+                quality_score,
+                composite_score,
+                scoring_profile,
+                judge_model,
+                selected_at,
+            ),
+        )
+        return "INSERT 0 1"
+
+    async def fetch_compressed_variant_by_memory_id(self, tx: Transaction, memory_id: str) -> Row | None:
+        return await _fetch_one(
+            self._conn(tx),
+            "SELECT owner_id, winner_candidate_id, engine_id, engine_version, compressed_content, "
+            "compressed_tokens, compression_ratio, quality_score, composite_score, scoring_profile, "
+            "judge_model, selected_at FROM memory_compressed_variants WHERE memory_id = ?",
+            (memory_id,),
+        )
+
+
+class SqliteWebhookRepository(_SqliteRepository, WebhookRepository):
+    async def insert_subscription(
+        self,
+        tx: Transaction,
+        *,
+        subscription_id: str | None = None,
+        url: str,
+        events: Sequence[str],
+        secret: str | None = None,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> str:
+        subscription_id = subscription_id or str(uuid.uuid4())
+        await _execute(
+            self._conn(tx),
+            "INSERT INTO webhook_subscriptions (id, url, events, secret, owner_id, namespace) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (subscription_id, url, json.dumps(list(events)), secret, owner_id, namespace),
+        )
+        return subscription_id
+
+    async def dispatch_event(
+        self,
+        tx: Transaction,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        owner_id: str | None = None,
+        namespace: str | None = None,
+    ) -> list[str]:
+        conn = self._conn(tx)
+        conditions = ["revoked = 0"]
+        params: list[Any] = []
+        if owner_id is not None:
+            conditions.append("owner_id = ?")
+            params.append(owner_id)
+        if namespace is not None:
+            conditions.append("namespace = ?")
+            params.append(namespace)
+        subscriptions = await _fetch_all(
+            conn,
+            f"SELECT id, events FROM webhook_subscriptions WHERE {' AND '.join(conditions)}",
+            params,
+        )
+        body = json.dumps(
+            {"event": event_type, "timestamp": _now_iso(), "data": payload},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        delivery_ids: list[str] = []
+        for sub in subscriptions:
+            if event_type not in _json_list(sub["events"]):
+                continue
+            delivery_id = str(uuid.uuid4())
+            await _execute(
+                conn,
+                "INSERT INTO webhook_deliveries "
+                "(id, subscription_id, event_type, payload, payload_hash, status, writer_revision) "
+                "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+                (delivery_id, sub["id"], event_type, body, body_hash, 2),
+            )
+            delivery_ids.append(delivery_id)
+        return delivery_ids
+
+    async def fetch_deliveries(self, tx: Transaction, subscription_id: str | None = None) -> list[Row]:
+        if subscription_id is None:
+            return await _fetch_all(self._conn(tx), "SELECT * FROM webhook_deliveries ORDER BY created_at ASC")
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT * FROM webhook_deliveries WHERE subscription_id = ? ORDER BY created_at ASC",
+            (subscription_id,),
+        )
+
+
+class SqliteConsultationAuditRepository(_SqliteRepository, ConsultationAuditRepository):
+    async def fetch_recommended_model(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float,
+        quality_floor: float,
+    ) -> tuple[dict[str, Any] | None, list[str]]:
+        capability_map = {
+            "code_generation": ["coding"],
+            "reasoning": ["reasoning", "logic"],
+            "architecture_design": ["reasoning"],
+            "summarization": ["reasoning"],
+            "web_search": ["online", "search"],
+        }
+        required_caps = capability_map.get(task_type, ["reasoning"])
+        rows = await _fetch_all(
+            self._conn(tx),
+            "SELECT provider, model_id, display_name, input_cost_per_mtok, output_cost_per_mtok, "
+            "capabilities, graeae_weight, context_window "
+            "FROM model_registry WHERE available = 1 AND deprecated = 0",
+        )
+
+        def _avg_cost(row: Row) -> float:
+            return (float(row["input_cost_per_mtok"] or 0) + float(row["output_cost_per_mtok"] or 0)) / 2.0
+
+        eligible = [
+            row for row in rows
+            if float(row["graeae_weight"] or 0) >= quality_floor
+            and _avg_cost(row) <= cost_budget
+            and all(cap in _json_list(row["capabilities"]) for cap in required_caps)
+        ]
+        chosen_rows = sorted(eligible, key=_avg_cost)
+        if not chosen_rows:
+            chosen_rows = sorted(rows, key=_avg_cost)
+        if not chosen_rows:
+            return None, required_caps
+        model = chosen_rows[0]
+        return {
+            "provider": model["provider"],
+            "model_id": model["model_id"],
+            "display_name": model["display_name"],
+            "cost_per_mtok": _avg_cost(model),
+            "quality_score": float(model["graeae_weight"] or 0),
+            "context_window": model["context_window"],
+        }, required_caps
+
+    async def fetch_model_recommendation(
+        self,
+        tx: Transaction,
+        task_type: str,
+        cost_budget: float = 10.0,
+        quality_floor: float = 0.85,
+    ) -> dict[str, Any] | None:
+        model, _required = await self.fetch_recommended_model(tx, task_type, cost_budget, quality_floor)
+        return model
+
+    async def lookup_provider_for_model(self, tx: Transaction, model: str) -> str | None:
+        row = await _fetch_one(
+            self._conn(tx),
+            "SELECT provider FROM model_registry WHERE model_id = ? AND available = 1 AND deprecated = 0",
+            (model,),
+        )
+        if row is not None:
+            return row["provider"]
+        if "/" not in model:
+            return None
+        head, tail = model.split("/", 1)
+        row = await _fetch_one(
+            self._conn(tx),
+            "SELECT provider FROM model_registry WHERE provider = ? AND model_id = ? "
+            "AND available = 1 AND deprecated = 0",
+            (head, tail),
+        )
+        return row["provider"] if row is not None else None
+
+    async def fetch_available_models(self, tx: Transaction) -> list[Row]:
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT provider, model_id, display_name FROM model_registry "
+            "WHERE available = 1 AND deprecated = 0 "
+            "ORDER BY graeae_weight IS NULL, graeae_weight DESC, model_id ASC",
+        )
+
+    async def fetch_model_provider(self, tx: Transaction, model_id: str) -> str | None:
+        row = await _fetch_one(
+            self._conn(tx),
+            "SELECT provider FROM model_registry WHERE model_id = ? AND available = 1 AND deprecated = 0 LIMIT 1",
+            (model_id,),
+        )
+        return row["provider"] if row is not None else None
+
+
+class SqliteFederationRepository(_SqliteRepository, FederationRepository):
+    async def fetch_memory_page(
+        self,
+        tx: Transaction,
+        *,
+        updated_after: str | None = None,
+        id_after: str | None = None,
+        limit: int = 100,
+    ) -> list[Row]:
+        params: list[Any] = []
+        where = ""
+        if updated_after is not None and id_after is not None:
+            where = "WHERE updated > ? OR (updated = ? AND id > ?)"
+            params.extend([updated_after, updated_after, id_after])
+        params.append(limit)
+        return await _fetch_all(
+            self._conn(tx),
+            "SELECT id, content, category, subcategory, metadata, owner_id, namespace, updated "
+            f"FROM memories {where} ORDER BY updated ASC, id ASC LIMIT ?",
+            params,
+        )
+
+    async def upsert_peer(
+        self,
+        tx: Transaction,
+        *,
+        peer_id: str,
+        base_url: str,
+        name: str | None = None,
+        enabled: bool = True,
+    ) -> None:
+        await _execute(
+            self._conn(tx),
+            "INSERT INTO federation_peers (id, base_url, name, enabled) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET base_url = excluded.base_url, "
+            "name = excluded.name, enabled = excluded.enabled",
+            (peer_id, base_url, name, int(enabled)),
+        )
+
+
+class SqliteStateRepository(_SqliteRepository, StateRepository):
+    async def get(self, tx: Transaction, key: str, *, owner_id: str = "default", namespace: str = "default") -> Row | None:
+        return await _fetch_one(
+            self._conn(tx),
+            "SELECT key, value, owner_id, namespace FROM state WHERE owner_id = ? AND namespace = ? AND key = ?",
+            (owner_id, namespace, key),
+        )
+
+    async def set(
+        self,
+        tx: Transaction,
+        key: str,
+        value: str,
+        *,
+        owner_id: str = "default",
+        namespace: str = "default",
+    ) -> None:
+        await _execute(
+            self._conn(tx),
+            "INSERT INTO state (owner_id, namespace, key, value) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(owner_id, namespace, key) DO UPDATE SET value = excluded.value, updated = CURRENT_TIMESTAMP",
+            (owner_id, namespace, key, value),
+        )
+
+    async def delete(self, tx: Transaction, key: str, *, owner_id: str = "default", namespace: str = "default") -> None:
+        await _execute(
+            self._conn(tx),
+            "DELETE FROM state WHERE owner_id = ? AND namespace = ? AND key = ?",
+            (owner_id, namespace, key),
+        )
+
+
+class SqliteBackend(PersistenceBackend):
+    """SQLite persistence facade backed by one serialized connection."""
+
+    supports_listen_notify = False
+    supports_advisory_locks = False
+    supports_row_level_security = False
+    supports_pgvector = False
+    uses_sqlite_vec = True
+    uses_fts5 = True
+
+    def __init__(self, db_path: Path | str, settings: Any):
+        self._db_path = Path(db_path)
+        self._settings = settings
+        self._conn: Any | None = None
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._vec_loaded = False
+        self._memories = SqliteMemoryRepository()
+        self._kg_triples = SqliteKGRepository()
+        self._memory_versions = SqliteVersionRepository()
+        self._memory_branches = SqliteBranchRepository()
+        self._compression = SqliteCompressionRepository()
+        self._webhooks = SqliteWebhookRepository()
+        self._consultations_audit = SqliteConsultationAuditRepository()
+        self._federation = SqliteFederationRepository()
+        self._state_kv = SqliteStateRepository()
+
+    @property
+    def settings(self) -> Any:
+        return self._settings
+
+    @property
+    def vec_loaded(self) -> bool:
+        return self._vec_loaded
+
+    async def open(self) -> None:
+        if self._conn is not None:
+            return
+        if self._db_path != Path(":memory:"):
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        if aiosqlite is not None:
+            conn = await aiosqlite.connect(str(self._db_path))
+        else:
+            conn = sqlite3.connect(str(self._db_path))
+        conn.row_factory = _dict_factory
+        self._conn = conn
+        await _execute(conn, "PRAGMA journal_mode=WAL")
+        await _execute(conn, "PRAGMA foreign_keys=ON")
+        await self._register_functions(conn)
+        await self._load_sqlite_vec(conn)
+        await self._apply_migrations(conn)
+        await self._create_vec_virtual_table(conn)
+        await _commit(conn)
+
+    async def _register_functions(self, conn: Any) -> None:
+        await _call(conn.create_function, "mnemos_cosine_similarity", 2, _cosine_similarity)
+
+    async def _load_sqlite_vec(self, conn: Any) -> None:
+        try:
+            await _call(conn.enable_load_extension, True)
+            try:
+                await _call(conn.load_extension, "vec0")
+            finally:
+                await _call(conn.enable_load_extension, False)
+            self._vec_loaded = True
+            return
+        except Exception as exc:
+            logger.debug("sqlite-vec load_extension('vec0') unavailable: %s", exc)
+
+        try:  # pragma: no cover - depends on optional sqlite-vec wheel.
+            import sqlite_vec
+
+            raw_conn = getattr(conn, "_conn", conn)
+            sqlite_vec.load(raw_conn)
+            self._vec_loaded = True
+        except Exception as exc:  # pragma: no cover - optional path.
+            logger.debug("sqlite-vec Python loader unavailable; using cosine UDF fallback: %s", exc)
+
+    async def _apply_migrations(self, conn: Any) -> None:
+        migrations_dir = Path(__file__).resolve().parents[2] / "db" / "migrations_sqlite"
+        for migration_name in SQLITE_MIGRATION_FILES:
+            migration_path = migrations_dir / migration_name
+            if not migration_path.exists():
+                continue
+            await _executescript(conn, migration_path.read_text())
+
+    async def _create_vec_virtual_table(self, conn: Any) -> None:
+        if not self._vec_loaded:
+            return
+        try:
+            await _execute(
+                conn,
+                "CREATE VIRTUAL TABLE IF NOT EXISTS memory_embedding_vec USING vec0(embedding float[768])",
+            )
+        except Exception as exc:
+            self._vec_loaded = False
+            logger.debug("sqlite-vec virtual table creation failed; using fallback memory_embeddings table: %s", exc)
+
+    @asynccontextmanager
+    async def transactional(self) -> AsyncIterator[Transaction]:
+        if self._closed:
+            raise RuntimeError("SQLite backend is closed")
+        async with self._lock:
+            await self.open()
+            assert self._conn is not None
+            await _execute(self._conn, "BEGIN IMMEDIATE")
+            tx = SqliteTransaction(self._conn)
+            try:
+                yield tx
+            except BaseException:
+                if not tx.closed:
+                    await tx.rollback()
+                raise
+            else:
+                if not tx.closed:
+                    await tx.commit()
+
+    @property
+    def memories(self) -> MemoryRepository:
+        return self._memories
+
+    @property
+    def kg_triples(self) -> KGRepository:
+        return self._kg_triples
+
+    @property
+    def memory_versions(self) -> VersionRepository:
+        return self._memory_versions
+
+    @property
+    def memory_branches(self) -> BranchRepository:
+        return self._memory_branches
+
+    @property
+    def compression(self) -> CompressionRepository:
+        return self._compression
+
+    @property
+    def webhooks(self) -> WebhookRepository:
+        return self._webhooks
+
+    @property
+    def consultations_audit(self) -> ConsultationAuditRepository:
+        return self._consultations_audit
+
+    @property
+    def federation(self) -> FederationRepository:
+        return self._federation
+
+    @property
+    def state_kv(self) -> StateRepository:
+        return self._state_kv
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        if self._conn is not None:
+            await _call(self._conn.close)
+        self._conn = None
+        self._closed = True

--- a/mnemos/webhooks/chain.py
+++ b/mnemos/webhooks/chain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import asyncpg
 
@@ -59,8 +59,15 @@ async def _insert_successor_delivery(
     )
 
 
+def _is_sqlite_connection(conn: Any) -> bool:
+    module = type(conn).__module__
+    return module.startswith("sqlite3") or module.startswith("aiosqlite")
+
+
 async def _lock_delivery_chain(conn: asyncpg.Connection, delivery: asyncpg.Record) -> None:
     """Serialize new-code recovery claims and successor inserts per chain."""
+    if _is_sqlite_connection(conn):
+        return
     await conn.execute("SELECT pg_advisory_xact_lock($1)", _delivery_chain_lock_key(delivery))
 
 

--- a/mnemos/webhooks/finalize.py
+++ b/mnemos/webhooks/finalize.py
@@ -16,6 +16,48 @@ from .types import _DeliveryResult, _LeaseExpiredBeforeSend, _PostHeaderDelivery
 logger = logging.getLogger(__name__)
 
 
+def _pool_uses_sqlite_backend(pool: Any) -> bool:
+    backend = getattr(pool, "persistence_backend", None)
+    if backend is None:
+        try:
+            from mnemos.core.lifecycle import get_persistence_backend
+
+            backend = get_persistence_backend()
+        except Exception:
+            return False
+    return bool(getattr(backend, "uses_sqlite_vec", False))
+
+
+async def _guard_sqlite_succeeded_terminal(
+    conn: Any,
+    pool: Any,
+    delivery_id: str,
+    attempted_status: str,
+) -> bool:
+    """Return True when SQLite app-level terminal-state enforcement blocks an update."""
+    if attempted_status == "succeeded" or not _pool_uses_sqlite_backend(pool):
+        return False
+
+    row = None
+    for sql, args in (
+        ("SELECT status FROM webhook_deliveries WHERE id=$1::uuid", (delivery_id,)),
+        ("SELECT status FROM webhook_deliveries WHERE id = ?", (delivery_id,)),
+    ):
+        try:
+            row = await conn.fetchrow(sql, *args)
+            break
+        except Exception:
+            continue
+    if row is not None and row["status"] == "succeeded":
+        logger.warning(
+            "webhook delivery %s SQLite terminal-state guard blocked status=%s",
+            delivery_id,
+            attempted_status,
+        )
+        return True
+    return False
+
+
 async def _finalize_delivery(
     pool: asyncpg.Pool,
     delivery: asyncpg.Record,
@@ -61,6 +103,9 @@ async def _finalize_delivery_row(
     async with pool.acquire() as conn:
         async with conn.transaction():
             await webhook_chain._lock_delivery_chain(conn, delivery)
+
+            if await _guard_sqlite_succeeded_terminal(conn, pool, delivery_id, "abandoned"):
+                return False
 
             if delivery["revoked"]:
                 finalized = await conn.fetchrow(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ tracing = [
 structlog = [
   "structlog>=25.0.0",
 ]
+sqlite = [
+  "aiosqlite>=0.20.0",
+  "sqlite-vec>=0.1.6",
+]
 full = ["sentence-transformers>=2.7.0", "spacy>=3.7.0", "networkx>=3.3"]
 # Note: the `phi` extras are optional GPU-dependent OpenVINO/FastEmbed support. Most installs don't need it.
 phi = ["openvino-genai>=2024.4.0", "fastembed>=0.3.0"]

--- a/tests/test_persistence_parity.py
+++ b/tests/test_persistence_parity.py
@@ -1,0 +1,1069 @@
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+import mnemos.core.lifecycle as lifecycle
+from mnemos.core.auth_context import UserContext
+from mnemos.persistence import (
+    BranchRepository,
+    CompressionRepository,
+    ConsultationAuditRepository,
+    FederationRepository,
+    KGRepository,
+    MemoryRepository,
+    PersistenceBackend,
+    PostgresBackend,
+    SqliteBackend,
+    SqliteTransaction,
+    StateRepository,
+    VersionRepository,
+    WebhookRepository,
+)
+from mnemos.persistence import sqlite as sqlite_persistence
+
+
+PG_URL = os.environ.get("MNEMOS_TEST_DB")
+
+
+@dataclass
+class BackendCase:
+    name: str
+    backend: PersistenceBackend
+    prefix: str
+
+
+def _backend_params() -> list[str]:
+    params = ["sqlite"]
+    if PG_URL:
+        params.append("postgres")
+    return params
+
+
+@pytest_asyncio.fixture(params=_backend_params())
+async def backend_case(request, tmp_path, monkeypatch):
+    prefix = f"parity_{request.param}_{uuid.uuid4().hex[:10]}"
+    old_pool = lifecycle._pool
+    if request.param == "sqlite":
+        backend = SqliteBackend(tmp_path / "mnemos.sqlite3", SimpleNamespace())
+        await backend.open()
+        yield BackendCase("sqlite", backend, prefix)
+        await backend.close()
+        return
+
+    pool = await asyncpg.create_pool(PG_URL, min_size=1, max_size=2)
+    backend = PostgresBackend(pool, SimpleNamespace())
+    monkeypatch.setattr(lifecycle, "_pool", pool)
+    try:
+        yield BackendCase("postgres", backend, prefix)
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                DELETE FROM webhook_deliveries d
+                USING webhook_subscriptions s
+                WHERE d.subscription_id = s.id AND s.owner_id LIKE $1
+                """,
+                f"{prefix}%",
+            )
+            await conn.execute("DELETE FROM webhook_subscriptions WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM memory_compressed_variants WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM memory_compression_candidates WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM kg_triples WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM memory_branches WHERE memory_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM memory_versions WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM memories WHERE owner_id LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM model_registry WHERE provider LIKE $1", f"{prefix}%")
+            await conn.execute("DELETE FROM users WHERE id LIKE $1", f"{prefix}%")
+        monkeypatch.setattr(lifecycle, "_pool", old_pool)
+        await backend.close()
+
+
+def _root() -> UserContext:
+    return UserContext(user_id="root", group_ids=[], role="root", namespace="default", authenticated=True)
+
+
+def _user(user_id: str, namespace: str = "default", groups: list[str] | None = None) -> UserContext:
+    return UserContext(
+        user_id=user_id,
+        group_ids=groups or [],
+        role="user",
+        namespace=namespace,
+        authenticated=True,
+    )
+
+
+def _dicts(rows: list[Any]) -> list[dict[str, Any]]:
+    return [dict(row) for row in rows]
+
+
+async def _raw_execute(case: BackendCase, tx: Any, pg_sql: str, *pg_args: Any, sqlite_sql: str | None = None) -> None:
+    if case.name == "sqlite":
+        await sqlite_persistence._execute(tx.conn, sqlite_sql or pg_sql, pg_args)
+    else:
+        await tx.conn.execute(pg_sql, *pg_args)
+
+
+async def _raw_fetchval(case: BackendCase, tx: Any, pg_sql: str, *pg_args: Any, sqlite_sql: str | None = None) -> Any:
+    if case.name == "sqlite":
+        return await sqlite_persistence._fetch_val(tx.conn, sqlite_sql or pg_sql, pg_args)
+    return await tx.conn.fetchval(pg_sql, *pg_args)
+
+
+async def _ensure_user(case: BackendCase, tx: Any, user_id: str, namespace: str = "default") -> None:
+    if case.name == "sqlite":
+        await _raw_execute(
+            case,
+            tx,
+            "",
+            user_id,
+            user_id,
+            namespace,
+            sqlite_sql=(
+                "INSERT OR IGNORE INTO users (id, username, role, namespace) "
+                "VALUES (?, ?, 'user', ?)"
+            ),
+        )
+    else:
+        await _raw_execute(
+            case,
+            tx,
+            "INSERT INTO users (id, username, role, namespace) VALUES ($1, $2, 'user', $3) "
+            "ON CONFLICT (id) DO NOTHING",
+            user_id,
+            user_id,
+            namespace,
+        )
+
+
+async def _insert_memory(
+    case: BackendCase,
+    tx: Any,
+    *,
+    suffix: str = "mem",
+    content: str = "alpha persistence memory",
+    category: str = "solutions",
+    owner_id: str | None = None,
+    namespace: str = "default",
+    permission_mode: int = 600,
+) -> str:
+    memory_id = f"{case.prefix}-{suffix}-{uuid.uuid4().hex[:8]}"
+    await case.backend.memories.insert_memory(
+        tx,
+        memory_id=memory_id,
+        content=content,
+        category=category,
+        subcategory=None,
+        metadata_json='{"source":"parity"}',
+        quality_rating=75,
+        owner_id=owner_id or f"{case.prefix}-owner",
+        namespace=namespace,
+        permission_mode=permission_mode,
+        source_model=None,
+        source_provider=None,
+        source_session=None,
+        source_agent=None,
+        created=None,
+        updated=None,
+    )
+    return memory_id
+
+
+async def _insert_version(
+    case: BackendCase,
+    tx: Any,
+    memory_id: str,
+    *,
+    version_num: int,
+    content: str,
+    branch: str = "main",
+    parent_version_id: str | None = None,
+    merge_parents: list[str] | None = None,
+    owner_id: str | None = None,
+    namespace: str = "default",
+    permission_mode: int = 600,
+) -> tuple[str, str]:
+    version_id = str(uuid.uuid4())
+    commit_hash = f"{case.prefix}-{branch}-{version_num}-{uuid.uuid4().hex[:8]}"
+    await case.backend.memory_versions.insert_memory_version(
+        tx,
+        version_id=version_id,
+        memory_id=memory_id,
+        version_num=version_num,
+        content=content,
+        category="solutions",
+        subcategory=None,
+        metadata_json='{"source":"parity"}',
+        verbatim_content=content,
+        owner_id=owner_id or f"{case.prefix}-owner",
+        namespace=namespace,
+        permission_mode=permission_mode,
+        source_model=None,
+        source_provider=None,
+        source_session=None,
+        source_agent=None,
+        snapshot_at=None,
+        snapshot_by="tester",
+        change_type="update" if version_num > 1 else "create",
+        commit_hash=commit_hash,
+        parent_version_id=parent_version_id,
+        branch=branch,
+        merge_parents=merge_parents or [],
+    )
+    return version_id, commit_hash
+
+
+async def _seed_versioned_memory(case: BackendCase, tx: Any) -> tuple[str, str, str]:
+    memory_id = await _insert_memory(case, tx)
+    version_id, commit_hash = await _insert_version(case, tx, memory_id, version_num=1, content="v1 content")
+    await case.backend.memory_branches.upsert_memory_branch_head(
+        tx,
+        memory_id=memory_id,
+        branch="main",
+        head_version_id=version_id,
+    )
+    return memory_id, version_id, commit_hash
+
+
+@pytest.mark.asyncio
+async def test_backend_exposes_all_repository_properties(backend_case: BackendCase):
+    backend = backend_case.backend
+    assert isinstance(backend.memories, MemoryRepository)
+    assert isinstance(backend.kg_triples, KGRepository)
+    assert isinstance(backend.memory_versions, VersionRepository)
+    assert isinstance(backend.memory_branches, BranchRepository)
+    assert isinstance(backend.compression, CompressionRepository)
+    assert isinstance(backend.webhooks, WebhookRepository)
+    assert isinstance(backend.consultations_audit, ConsultationAuditRepository)
+    assert isinstance(backend.federation, FederationRepository)
+    assert isinstance(backend.state_kv, StateRepository)
+
+
+def test_sqlite_backend_feature_flags(tmp_path):
+    backend = SqliteBackend(tmp_path / "flags.sqlite3", SimpleNamespace())
+    assert backend.supports_listen_notify is False
+    assert backend.supports_advisory_locks is False
+    assert backend.supports_row_level_security is False
+    assert backend.supports_pgvector is False
+    assert backend.uses_sqlite_vec is True
+    assert backend.uses_fts5 is True
+
+
+@pytest.mark.asyncio
+async def test_memory_commit_roundtrip(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, content="commit roundtrip")
+    async with backend_case.backend.transactional() as tx:
+        row = await backend_case.backend.memories.fetch_memory_by_id(tx, memory_id)
+    assert row["content"] == "commit roundtrip"
+
+
+@pytest.mark.asyncio
+async def test_transaction_exception_rolls_back_memory(backend_case: BackendCase):
+    memory_id = f"{backend_case.prefix}-rollback-{uuid.uuid4().hex[:8]}"
+    with pytest.raises(RuntimeError):
+        async with backend_case.backend.transactional() as tx:
+            await backend_case.backend.memories.insert_memory(
+                tx,
+                memory_id=memory_id,
+                content="rollback",
+                category="solutions",
+                subcategory=None,
+                metadata_json="{}",
+                quality_rating=75,
+                owner_id=f"{backend_case.prefix}-owner",
+                namespace="default",
+                permission_mode=600,
+                source_model=None,
+                source_provider=None,
+                source_session=None,
+                source_agent=None,
+                created=None,
+                updated=None,
+            )
+            raise RuntimeError("boom")
+    async with backend_case.backend.transactional() as tx:
+        assert await backend_case.backend.memories.fetch_memory_by_id(tx, memory_id) is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_transaction_rollback_discards_memory(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, content="explicit rollback")
+        await tx.rollback()
+    async with backend_case.backend.transactional() as tx:
+        assert await backend_case.backend.memories.fetch_memory_by_id(tx, memory_id) is None
+
+
+@pytest.mark.asyncio
+async def test_memory_export_filters_category_owner_namespace(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        keep = await _insert_memory(backend_case, tx, suffix="keep", category="solutions", owner_id=owner)
+        await _insert_memory(backend_case, tx, suffix="drop-cat", category="notes", owner_id=owner)
+        await _insert_memory(backend_case, tx, suffix="drop-owner", category="solutions", owner_id=f"{owner}-other")
+        rows = await backend_case.backend.memories.fetch_memory_export(
+            tx,
+            effective_owner=owner,
+            effective_ns="default",
+            category="solutions",
+            limit=10,
+            offset=0,
+        )
+    assert [row["id"] for row in rows] == [keep]
+
+
+@pytest.mark.asyncio
+async def test_referenced_memory_allowlist_empty_and_scoped(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner)
+        assert await backend_case.backend.memories.fetch_referenced_memory_allowlist(tx, referenced_ids=[]) == []
+        rows = await backend_case.backend.memories.fetch_referenced_memory_allowlist(
+            tx,
+            referenced_ids=[memory_id],
+            scope_owner=owner,
+            scope_namespace="default",
+        )
+    assert rows[0]["id"] == memory_id
+
+
+@pytest.mark.asyncio
+async def test_group_read_visibility_uses_unix_group_bits(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    reader = f"{backend_case.prefix}-reader"
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner, permission_mode=640)
+        if backend_case.name == "sqlite":
+            await _raw_execute(
+                backend_case,
+                tx,
+                "",
+                "group-a",
+                memory_id,
+                sqlite_sql="UPDATE memories SET group_id = ? WHERE id = ?",
+            )
+        else:
+            await _raw_execute(
+                backend_case,
+                tx,
+                "UPDATE memories SET group_id = $1 WHERE id = $2",
+                "group-a",
+                memory_id,
+            )
+        await backend_case.backend.memories.assert_memory_readable(tx, memory_id, _user(reader, groups=["group-a"]))
+        with pytest.raises(PermissionError):
+            await backend_case.backend.memories.assert_memory_readable(tx, memory_id, _user(reader))
+
+
+@pytest.mark.asyncio
+async def test_assert_memory_readable_owner_root_and_world(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        private_id, _version_id, _commit = await _seed_versioned_memory(backend_case, tx)
+        await backend_case.backend.memories.assert_memory_readable(tx, private_id, _root())
+        await backend_case.backend.memories.assert_memory_readable(tx, private_id, _user(owner))
+        with pytest.raises(PermissionError):
+            await backend_case.backend.memories.assert_memory_readable(tx, private_id, _user(f"{owner}-other"))
+        public_id = await _insert_memory(
+            backend_case,
+            tx,
+            suffix="public",
+            owner_id=owner,
+            permission_mode=604,
+        )
+        await backend_case.backend.memories.assert_memory_readable(tx, public_id, _user(f"{owner}-other"))
+
+
+@pytest.mark.asyncio
+async def test_version_fetch_by_id_and_ids(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        memory_id, version_id, _commit = await _seed_versioned_memory(backend_case, tx)
+        row = await backend_case.backend.memory_versions.fetch_memory_version_by_id(tx, version_id)
+        rows = await backend_case.backend.memory_versions.fetch_memory_versions_by_ids(tx, [version_id])
+    assert row["memory_id"] == memory_id
+    assert _dicts(rows) == [
+        {"id": version_id, "memory_id": memory_id, "owner_id": f"{backend_case.prefix}-owner", "namespace": "default"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_version_export_ordering(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        memory_id, version_id, _commit = await _seed_versioned_memory(backend_case, tx)
+        v2, _commit2 = await _insert_version(
+            backend_case,
+            tx,
+            memory_id,
+            version_num=2,
+            content="v2 content",
+            parent_version_id=version_id,
+        )
+        rows = await backend_case.backend.memory_versions.fetch_memory_versions_for_export(
+            tx,
+            memory_ids=[memory_id],
+            effective_owner=f"{backend_case.prefix}-owner",
+            effective_ns="default",
+            hard_limit=10,
+        )
+    assert [row["id"] for row in rows] == [version_id, v2]
+
+
+@pytest.mark.asyncio
+async def test_branch_create_idempotent_and_missing_commit(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id, _version_id, commit_hash = await _seed_versioned_memory(backend_case, tx)
+        created = await backend_case.backend.memory_branches.create_memory_branch(
+            tx,
+            memory_id,
+            "exp",
+            commit_hash,
+            _user(owner),
+        )
+        again = await backend_case.backend.memory_branches.create_memory_branch(
+            tx,
+            memory_id,
+            "exp",
+            commit_hash,
+            _user(owner),
+        )
+        missing = await backend_case.backend.memory_branches.create_memory_branch(
+            tx,
+            memory_id,
+            "missing",
+            "does-not-exist",
+            _user(owner),
+        )
+    assert created["success"] is True
+    assert again["success"] is True
+    assert missing["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_branches_for_memories(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        memory_id, _version_id, _commit = await _seed_versioned_memory(backend_case, tx)
+        await backend_case.backend.memory_branches.delete_memory_branches_for_memories(tx, [memory_id])
+        count = await _raw_fetchval(
+            backend_case,
+            tx,
+            "SELECT COUNT(*) FROM memory_branches WHERE memory_id = $1",
+            memory_id,
+            sqlite_sql="SELECT COUNT(*) FROM memory_branches WHERE memory_id = ?",
+        )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_dag_log_diff_checkout_branch_heads_and_head_checks(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id, v1, c1 = await _seed_versioned_memory(backend_case, tx)
+        v2, c2 = await _insert_version(
+            backend_case,
+            tx,
+            memory_id,
+            version_num=2,
+            content="v2 content",
+            parent_version_id=v1,
+        )
+        await backend_case.backend.memory_branches.upsert_memory_branch_head(
+            tx,
+            memory_id=memory_id,
+            branch="main",
+            head_version_id=v2,
+        )
+        v3, _c3 = await _insert_version(
+            backend_case,
+            tx,
+            memory_id,
+            version_num=3,
+            content="branch content",
+            branch="exp",
+            parent_version_id=v1,
+        )
+        await backend_case.backend.memory_branches.upsert_memory_branch_head(
+            tx,
+            memory_id=memory_id,
+            branch="exp",
+            head_version_id=v3,
+        )
+        v4, c4 = await _insert_version(
+            backend_case,
+            tx,
+            memory_id,
+            version_num=4,
+            content="merged content",
+            parent_version_id=v2,
+            merge_parents=[v3],
+        )
+        await backend_case.backend.memory_branches.upsert_memory_branch_head(
+            tx,
+            memory_id=memory_id,
+            branch="main",
+            head_version_id=v4,
+        )
+        log_rows = await backend_case.backend.memories.fetch_memory_log(tx, memory_id, "main", 10, _user(owner))
+        diff_a, diff_b = await backend_case.backend.memories.fetch_diff_commit_pair(tx, memory_id, c1, c2, _user(owner))
+        checkout = await backend_case.backend.memories.fetch_checkout_commit(tx, memory_id, c4, _user(owner))
+        heads = await backend_case.backend.memory_branches.fetch_memory_branch_heads(tx, [memory_id])
+        authorized = await backend_case.backend.memory_branches.fetch_memory_branch_heads(
+            tx,
+            [memory_id],
+            authorized_version_uuids=[v3],
+        )
+        checks = await backend_case.backend.memories.fetch_memory_head_checks(tx, [memory_id])
+        versioned = await backend_case.backend.memories.fetch_versioned_memory_ids(tx, [memory_id])
+    assert [row["commit_hash"] for row in log_rows] == [c4, c2, c1]
+    assert diff_a["content"] == "v1 content"
+    assert diff_b["content"] == "v2 content"
+    assert checkout["content"] == "merged content"
+    assert {row["branch"]: row["head_version_id"] for row in heads} == {"main": v4, "exp": v3}
+    assert _dicts(authorized) == [{"memory_id": memory_id, "branch": "exp", "head_version_id": v3}]
+    assert checks[0]["head_content"] == "merged content"
+    assert _dicts(versioned) == [{"memory_id": memory_id}]
+
+
+@pytest.mark.asyncio
+async def test_kg_insert_fetch_export_and_timeline_search(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner)
+        triple_id = str(uuid.uuid4())
+        await backend_case.backend.kg_triples.insert_kg_triple(
+            tx,
+            triple_id=triple_id,
+            subject="Athena",
+            predicate="guides",
+            obj="Odysseus",
+            subject_type="person",
+            object_type="person",
+            valid_from=None,
+            valid_until=None,
+            memory_id=memory_id,
+            confidence=0.9,
+            created=None,
+            owner_id=owner,
+            namespace="default",
+        )
+        row = await backend_case.backend.kg_triples.fetch_kg_triple_by_id(tx, triple_id)
+        attached = await backend_case.backend.kg_triples.fetch_kg_triples_for_export(
+            tx,
+            memory_ids=[memory_id],
+            effective_owner=owner,
+            effective_ns="default",
+            include_unattached=False,
+            hard_limit=10,
+        )
+        unattached_id = str(uuid.uuid4())
+        await backend_case.backend.kg_triples.insert_kg_triple(
+            tx,
+            triple_id=unattached_id,
+            subject="Hermes",
+            predicate="visits",
+            obj="Ithaca",
+            subject_type=None,
+            object_type=None,
+            valid_from=None,
+            valid_until=None,
+            memory_id=None,
+            confidence=None,
+            created=None,
+            owner_id=owner,
+            namespace="default",
+        )
+        with_unattached = await backend_case.backend.kg_triples.fetch_kg_triples_for_export(
+            tx,
+            memory_ids=[],
+            effective_owner=owner,
+            effective_ns="default",
+            include_unattached=True,
+            hard_limit=10,
+        )
+        if hasattr(backend_case.backend.kg_triples, "search_triples"):
+            timeline = await backend_case.backend.kg_triples.search_triples(
+                tx,
+                "Athena",
+                owner_id=owner,
+                namespace="default",
+            )
+        else:
+            timeline = attached
+    assert row["subject"] == "Athena"
+    assert [item["id"] for item in attached] == [triple_id]
+    assert [item["id"] for item in with_unattached] == [unattached_id]
+    assert timeline[0]["predicate"] == "guides"
+
+
+@pytest.mark.asyncio
+async def test_compression_candidate_variant_and_export(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner)
+        candidate_id = str(uuid.uuid4())
+        assert not await backend_case.backend.compression.compression_candidate_exists(
+            tx,
+            candidate_id=candidate_id,
+            memory_id=memory_id,
+            owner_id=owner,
+        )
+        if backend_case.name == "sqlite":
+            await _raw_execute(
+                backend_case,
+                tx,
+                "",
+                candidate_id,
+                memory_id,
+                owner,
+                "contest",
+                "engine",
+                sqlite_sql=(
+                    "INSERT INTO memory_compression_candidates "
+                    "(id, memory_id, owner_id, contest_id, engine_id) VALUES (?, ?, ?, ?, ?)"
+                ),
+            )
+        else:
+            await _raw_execute(
+                backend_case,
+                tx,
+                "INSERT INTO memory_compression_candidates "
+                "(id, memory_id, owner_id, contest_id, engine_id) "
+                "VALUES ($1::uuid, $2, $3, $4::uuid, $5)",
+                candidate_id,
+                memory_id,
+                owner,
+                str(uuid.uuid4()),
+                "engine",
+            )
+        assert await backend_case.backend.compression.compression_candidate_exists(
+            tx,
+            candidate_id=candidate_id,
+            memory_id=memory_id,
+            owner_id=owner,
+        )
+        await backend_case.backend.compression.insert_compressed_variant(
+            tx,
+            memory_id=memory_id,
+            owner_id=owner,
+            winner_candidate_id=candidate_id,
+            engine_id="engine",
+            engine_version="1",
+            compressed_content="short",
+            compressed_tokens=1,
+            compression_ratio=0.5,
+            quality_score=0.9,
+            composite_score=0.8,
+            scoring_profile="balanced",
+            judge_model="judge",
+            selected_at=None,
+        )
+        row = await backend_case.backend.compression.fetch_compressed_variant_by_memory_id(tx, memory_id)
+        exported = await backend_case.backend.compression.fetch_compressed_variants_for_export(
+            tx,
+            memory_ids=[memory_id],
+            effective_owner=owner,
+            hard_limit=10,
+        )
+    assert row["compressed_content"] == "short"
+    assert exported[0]["memory_id"] == memory_id
+
+
+@pytest.mark.asyncio
+async def test_compressed_variant_insert_is_idempotent(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner)
+        for content in ("first", "second"):
+            await backend_case.backend.compression.insert_compressed_variant(
+                tx,
+                memory_id=memory_id,
+                owner_id=owner,
+                winner_candidate_id=None,
+                engine_id="engine",
+                engine_version="1",
+                compressed_content=content,
+                compressed_tokens=1,
+                compression_ratio=0.5,
+                quality_score=0.9,
+                composite_score=0.8,
+                scoring_profile="balanced",
+                judge_model="judge",
+                selected_at=None,
+            )
+        row = await backend_case.backend.compression.fetch_compressed_variant_by_memory_id(tx, memory_id)
+    assert row["compressed_content"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_model_recommendation_lookup_and_available_models(backend_case: BackendCase):
+    provider = f"{backend_case.prefix}_provider"
+    async with backend_case.backend.transactional() as tx:
+        if backend_case.name == "sqlite":
+            await _raw_execute(
+                backend_case,
+                tx,
+                "",
+                provider,
+                "reasoner",
+                "Reasoner",
+                '["reasoning","logic"]',
+                1.0,
+                1.0,
+                0.95,
+                128000,
+                sqlite_sql=(
+                    "INSERT INTO model_registry "
+                    "(provider, model_id, display_name, capabilities, input_cost_per_mtok, "
+                    "output_cost_per_mtok, graeae_weight, context_window) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                ),
+            )
+        else:
+            await _raw_execute(
+                backend_case,
+                tx,
+                "INSERT INTO model_registry "
+                "(provider, model_id, display_name, capabilities, input_cost_per_mtok, "
+                "output_cost_per_mtok, graeae_weight, context_window, available, deprecated) "
+                "VALUES ($1, $2, $3, $4::text[], $5, $6, $7, $8, TRUE, FALSE) "
+                "ON CONFLICT (provider, model_id) DO UPDATE SET available = TRUE, deprecated = FALSE",
+                provider,
+                "reasoner",
+                "Reasoner",
+                ["reasoning", "logic"],
+                1.0,
+                1.0,
+                0.95,
+                128000,
+            )
+    async with backend_case.backend.transactional() as tx:
+        recommended, required = await backend_case.backend.consultations_audit.fetch_recommended_model(
+            tx,
+            "reasoning",
+            cost_budget=10.0,
+            quality_floor=0.8,
+        )
+        fallback = await backend_case.backend.consultations_audit.fetch_model_recommendation(
+            tx,
+            "web_search",
+            cost_budget=0.01,
+            quality_floor=1.0,
+        )
+        provider_lookup = await backend_case.backend.consultations_audit.lookup_provider_for_model(tx, "reasoner")
+        available = await backend_case.backend.consultations_audit.fetch_available_models(tx)
+        model_provider = await backend_case.backend.consultations_audit.fetch_model_provider(tx, "reasoner")
+    assert required == ["reasoning", "logic"]
+    assert recommended["model_id"] == "reasoner"
+    assert fallback["model_id"] == "reasoner"
+    assert provider_lookup == provider
+    assert any(row["model_id"] == "reasoner" for row in available)
+    assert model_provider == provider
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_omits_deprecated_and_unavailable(backend_case: BackendCase):
+    provider = f"{backend_case.prefix}_provider"
+    async with backend_case.backend.transactional() as tx:
+        if backend_case.name == "sqlite":
+            await _raw_execute(
+                backend_case,
+                tx,
+                "",
+                provider,
+                "available",
+                "Available",
+                '["reasoning"]',
+                provider,
+                "deprecated",
+                "Deprecated",
+                '["reasoning"]',
+                provider,
+                "unavailable",
+                "Unavailable",
+                '["reasoning"]',
+                sqlite_sql=(
+                    "INSERT INTO model_registry "
+                    "(provider, model_id, display_name, capabilities, deprecated, available) "
+                    "VALUES (?, ?, ?, ?, 0, 1), (?, ?, ?, ?, 1, 1), (?, ?, ?, ?, 0, 0)"
+                ),
+            )
+        else:
+            await _raw_execute(
+                backend_case,
+                tx,
+                "INSERT INTO model_registry "
+                "(provider, model_id, display_name, capabilities, deprecated, available) "
+                "VALUES ($1, $2, $3, $4::text[], FALSE, TRUE), "
+                "($5, $6, $7, $8::text[], TRUE, TRUE), "
+                "($9, $10, $11, $12::text[], FALSE, FALSE) "
+                "ON CONFLICT (provider, model_id) DO NOTHING",
+                provider,
+                "available",
+                "Available",
+                ["reasoning"],
+                provider,
+                "deprecated",
+                "Deprecated",
+                ["reasoning"],
+                provider,
+                "unavailable",
+                "Unavailable",
+                ["reasoning"],
+            )
+    async with backend_case.backend.transactional() as tx:
+        available = await backend_case.backend.consultations_audit.fetch_available_models(tx)
+    ids = {row["model_id"] for row in available if row["provider"] == provider}
+    assert ids == {"available"}
+
+
+@pytest.mark.asyncio
+async def test_memory_context_respects_visibility(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    other = f"{backend_case.prefix}-other"
+    async with backend_case.backend.transactional() as tx:
+        own_id = await _insert_memory(backend_case, tx, content="context needle own", owner_id=owner)
+        await _insert_memory(backend_case, tx, content="context needle private", owner_id=other)
+    async with backend_case.backend.transactional() as tx:
+        root_rows = await backend_case.backend.memories.fetch_memory_context(tx, "needle", _root(), limit=10)
+        user_rows = await backend_case.backend.memories.fetch_memory_context(tx, "needle", _user(owner), limit=10)
+    assert own_id in {row["id"] for row in root_rows}
+    assert {row["id"] for row in user_rows} == {own_id}
+
+
+@pytest.mark.asyncio
+async def test_webhook_outbox_commits_with_memory(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        await _ensure_user(backend_case, tx, owner)
+        subscription_id = str(uuid.uuid4())
+        await backend_case.backend.webhooks.insert_subscription(
+            tx,
+            subscription_id=subscription_id,
+            url="https://example.com/webhook",
+            events=["memory.created"],
+            secret="secret",
+            owner_id=owner,
+            namespace="default",
+        )
+        memory_id = await _insert_memory(backend_case, tx, owner_id=owner)
+        delivery_ids = await backend_case.backend.webhooks.dispatch_event(
+            tx,
+            "memory.created",
+            {"memory_id": memory_id},
+            owner_id=owner,
+            namespace="default",
+        )
+    async with backend_case.backend.transactional() as tx:
+        row = await backend_case.backend.memories.fetch_memory_by_id(tx, memory_id)
+        deliveries = await backend_case.backend.webhooks.fetch_deliveries(tx, subscription_id)
+    assert row is not None
+    assert len(delivery_ids) == 1
+    assert len(deliveries) == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_event_filter_does_not_enqueue_unmatched_event(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    subscription_id = str(uuid.uuid4())
+    async with backend_case.backend.transactional() as tx:
+        await _ensure_user(backend_case, tx, owner)
+        await backend_case.backend.webhooks.insert_subscription(
+            tx,
+            subscription_id=subscription_id,
+            url="https://example.com/webhook",
+            events=["consultation.completed"],
+            secret="secret",
+            owner_id=owner,
+            namespace="default",
+        )
+        delivery_ids = await backend_case.backend.webhooks.dispatch_event(
+            tx,
+            "memory.created",
+            {"memory_id": "nope"},
+            owner_id=owner,
+            namespace="default",
+        )
+    assert delivery_ids == []
+
+
+@pytest.mark.asyncio
+async def test_webhook_outbox_rolls_back_with_memory(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    memory_id = f"{backend_case.prefix}-rollback-webhook"
+    subscription_id = str(uuid.uuid4())
+    with pytest.raises(RuntimeError):
+        async with backend_case.backend.transactional() as tx:
+            await _ensure_user(backend_case, tx, owner)
+            await backend_case.backend.webhooks.insert_subscription(
+                tx,
+                subscription_id=subscription_id,
+                url="https://example.com/webhook",
+                events=["memory.created"],
+                secret="secret",
+                owner_id=owner,
+                namespace="default",
+            )
+            await backend_case.backend.memories.insert_memory(
+                tx,
+                memory_id=memory_id,
+                content="rollback webhook",
+                category="solutions",
+                subcategory=None,
+                metadata_json="{}",
+                quality_rating=75,
+                owner_id=owner,
+                namespace="default",
+                permission_mode=600,
+                source_model=None,
+                source_provider=None,
+                source_session=None,
+                source_agent=None,
+                created=None,
+                updated=None,
+            )
+            await backend_case.backend.webhooks.dispatch_event(
+                tx,
+                "memory.created",
+                {"memory_id": memory_id},
+                owner_id=owner,
+                namespace="default",
+            )
+            raise RuntimeError("rollback")
+    async with backend_case.backend.transactional() as tx:
+        assert await backend_case.backend.memories.fetch_memory_by_id(tx, memory_id) is None
+        assert await backend_case.backend.webhooks.fetch_deliveries(tx, subscription_id) == []
+
+
+@pytest.mark.asyncio
+async def test_federation_compound_cursor_pages(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        first = await _insert_memory(backend_case, tx, suffix="fed-a", content="fed a")
+        second = await _insert_memory(backend_case, tx, suffix="fed-b", content="fed b")
+        page1 = await backend_case.backend.federation.fetch_memory_page(tx, limit=1)
+        page2 = await backend_case.backend.federation.fetch_memory_page(
+            tx,
+            updated_after=page1[-1]["updated"],
+            id_after=page1[-1]["id"],
+            limit=10,
+        )
+    assert page1[0]["id"] in {first, second}
+    assert {row["id"] for row in [*page1, *page2]} >= {first, second}
+
+
+@pytest.mark.asyncio
+async def test_federation_upsert_peer(backend_case: BackendCase):
+    peer_id = str(uuid.uuid4())
+    peer_name = f"peer-{uuid.uuid4().hex[:8]}"
+    async with backend_case.backend.transactional() as tx:
+        await backend_case.backend.federation.upsert_peer(
+            tx,
+            peer_id=peer_id,
+            base_url=f"https://{peer_name}.example.com",
+            name=peer_name,
+            enabled=True,
+        )
+        count = await _raw_fetchval(
+            backend_case,
+            tx,
+            "SELECT COUNT(*) FROM federation_peers WHERE id = $1::uuid AND enabled = TRUE",
+            peer_id,
+            sqlite_sql="SELECT COUNT(*) FROM federation_peers WHERE id = ? AND enabled = 1",
+        )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_state_kv_roundtrip_and_delete(backend_case: BackendCase):
+    async with backend_case.backend.transactional() as tx:
+        await backend_case.backend.state_kv.set(
+            tx,
+            "answer",
+            "42",
+            owner_id=f"{backend_case.prefix}-owner",
+            namespace="default",
+        )
+        row = await backend_case.backend.state_kv.get(
+            tx,
+            "answer",
+            owner_id=f"{backend_case.prefix}-owner",
+            namespace="default",
+        )
+        await backend_case.backend.state_kv.delete(
+            tx,
+            "answer",
+            owner_id=f"{backend_case.prefix}-owner",
+            namespace="default",
+        )
+        missing = await backend_case.backend.state_kv.get(
+            tx,
+            "answer",
+            owner_id=f"{backend_case.prefix}-owner",
+            namespace="default",
+        )
+    assert row["value"] == "42"
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_state_kv_is_namespace_scoped(backend_case: BackendCase):
+    owner = f"{backend_case.prefix}-owner"
+    async with backend_case.backend.transactional() as tx:
+        await backend_case.backend.state_kv.set(tx, "shared", "a", owner_id=owner, namespace="a")
+        await backend_case.backend.state_kv.set(tx, "shared", "b", owner_id=owner, namespace="b")
+        row_a = await backend_case.backend.state_kv.get(tx, "shared", owner_id=owner, namespace="a")
+        row_b = await backend_case.backend.state_kv.get(tx, "shared", owner_id=owner, namespace="b")
+    assert row_a["value"] == "a"
+    assert row_b["value"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_vector_semantic_search(tmp_path):
+    backend = SqliteBackend(tmp_path / "vector.sqlite3", SimpleNamespace())
+    await backend.open()
+    async with backend.transactional() as tx:
+        near = await _insert_memory(BackendCase("sqlite", backend, "sqlite_vector"), tx, suffix="near", content="near")
+        far = await _insert_memory(BackendCase("sqlite", backend, "sqlite_vector"), tx, suffix="far", content="far")
+        assert isinstance(tx, SqliteTransaction)
+        await backend.memories.upsert_memory_embedding(tx, near, [1.0, 0.0, 0.0])
+        await backend.memories.upsert_memory_embedding(tx, far, [0.0, 1.0, 0.0])
+        rows = await backend.memories.semantic_search(tx, [0.9, 0.1, 0.0], limit=2)
+    await backend.close()
+    assert [row["id"] for row in rows] == [near, far]
+    assert rows[0]["similarity"] > rows[1]["similarity"]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_fts5_relevance_ordering(tmp_path):
+    backend = SqliteBackend(tmp_path / "fts.sqlite3", SimpleNamespace())
+    await backend.open()
+    case = BackendCase("sqlite", backend, "sqlite_fts")
+    async with backend.transactional() as tx:
+        best = await _insert_memory(case, tx, suffix="best", content="apollo apollo apollo sqlite")
+        other = await _insert_memory(case, tx, suffix="other", content="apollo persistence")
+        rows = await backend.memories.fts_search(tx, "apollo", limit=2)
+    await backend.close()
+    assert [row["id"] for row in rows] == [best, other]
+
+
+def test_sqlite_migration_chain_mirrors_postgres_chain():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    sqlite_dir = os.path.join(repo_root, "db", "migrations_sqlite")
+    sqlite_files = sorted(name for name in os.listdir(sqlite_dir) if name.endswith(".sql"))
+    assert len(sqlite_files) == len(sqlite_persistence.SQLITE_MIGRATION_FILES)
+    assert set(sqlite_files) == set(sqlite_persistence.SQLITE_MIGRATION_FILES)
+
+
+def test_sqlite_migration_files_are_nonempty():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    sqlite_dir = os.path.join(repo_root, "db", "migrations_sqlite")
+    for name in sqlite_persistence.SQLITE_MIGRATION_FILES:
+        path = os.path.join(sqlite_dir, name)
+        assert os.path.getsize(path) > 0


### PR DESCRIPTION
SqliteBackend implements the D.1 PersistenceBackend ABC. Foundation for D.3 deployment profiles (edge / dev) and D.4 single-binary build. Enables Pi 5 / Samsung S21 / dev laptop deployments without Postgres.

mnemos/persistence/sqlite.py (1682 LOC): aiosqlite + sqlite-vec (vector) + FTS5 (text) + JSON1 (jsonb-shaped). All 9 sub-repositories implemented. WAL mode + foreign_keys ON.

db/migrations_sqlite/ (38 SQL files): full v3.x → v3.5 → v4.0 schema chain in SQLite dialect.

Backend feature flags: PostgresBackend supports listen/notify, advisory locks, RLS, pgvector. SqliteBackend uses sqlite-vec + FTS5 + app-level lock + visibility predicate. Slice-2 round-24 webhook terminal trigger replaced with app-level guard in mnemos/webhooks/finalize.py for the SQLite path.

docs/SQLITE_PROFILE.md (82 lines): constraints, tradeoffs, when to choose.

tests/test_persistence_parity.py (1069 LOC): parameterized over both backends; 1024 passed total (+31), ruff clean, 7 import-linter contracts KEPT.

Per docs/V4_PLAN.md Track 5b §3.3.

Authored-By: Codex