### PR TITLE
v4.0 D.5: GRAEAE modes + empty-body fix

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -436,6 +436,10 @@ curl -X GET http://localhost:5002/v1/providers/health \
   -H "Authorization: Bearer $MNEMOS_API_KEY"
 ```
 
+Consultation mode selection should match the task risk: use `single` for fast
+low-stakes checks, `auto` or `all` for general reasoning, `majority` for binary
+decisions where disagreement matters, and `debate` for high-stakes design calls.
+
 ### OpenAI-Compatible Gateway
 ```bash
 # POST /v1/chat/completions - OpenAI-compatible (with auto memory injection)

--- a/docs/GRAEAE_FEATURES.md
+++ b/docs/GRAEAE_FEATURES.md
@@ -41,6 +41,21 @@ these guards to shared/external coordination is future horizontal-scaling work.
   `GET /v1/providers/recommend` — provider inventory, status, and cost-aware
   recommendation.
 
+## Consultation Modes
+
+`POST /v1/consultations` accepts seven modes. Unknown modes are rejected by
+request validation with HTTP 422.
+
+| Mode | Shape | Semantics |
+|---|---|---|
+| `auto` | Routing strategy | Use the engine's default routing for the task type. |
+| `local` | Routing strategy | Force local-only muses where configured. |
+| `external` | Routing strategy | Force external commercial muses where configured. |
+| `all` | Routing strategy | Fan out to every available muse. |
+| `single` | Reasoning shape | Pick exactly one highest-weighted muse; use for fast, low-stakes, or cost-floor consultations. |
+| `debate` | Reasoning shape | Run a two-round cross-muse argument: round 1 fans out, round 2 gives each muse the others' responses for refinement. |
+| `majority` | Reasoning shape | Query up to three muses and report whether pairwise similarity reached the quorum threshold. If quorum is missed, responses still return with `quorum_reached: false`. |
+
 OpenAI-compatible access is separate but uses the same routing engine:
 `POST /v1/chat/completions`, `GET /v1/models`, and `GET /v1/models/{model_id}`.
 In v3.5.x, generation controls propagate when the selected provider supports

--- a/mnemos/api/routes/consultations.py
+++ b/mnemos/api/routes/consultations.py
@@ -20,6 +20,7 @@ from mnemos.domain.models import (
     ConsultationArtifact,
     ConsultationRequest,
     ConsultationResponse,
+    SUPPORTED_CONSULTATION_MODES,
 )
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,19 @@ def _extract_memory_ids(result: dict) -> List[str]:
     return memory_ids
 
 
+def _require_non_empty_consultation_result(result: object, mode: str) -> dict:
+    """Fail loudly instead of letting an empty engine result serialize as success."""
+    if not isinstance(result, dict) or not result:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "GRAEAE consultation returned an empty result "
+                f"for mode={mode!r}; refusing to return HTTP 200 with an empty body."
+            ),
+        )
+    return result
+
+
 # ── Consultation endpoint ─────────────────────────────────────────────────────
 
 @router.post("/consultations", response_model=ConsultationResponse)
@@ -339,8 +353,9 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
         )
 
         result = await engine.consult(
-            body.prompt, body.task_type, selection=selection,
+            body.prompt, body.task_type, selection=selection, mode=body.mode,
         )
+        result = _require_non_empty_consultation_result(result, body.mode)
 
         if body.limit_chars and result.get("all_responses"):
             for provider, resp in result["all_responses"].items():
@@ -398,7 +413,7 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
                             winning_muse,
                             engine_cost,
                             engine_latency_ms,
-                            body.mode or "auto",
+                            body.mode,
                             user.user_id,
                             user.namespace,
                         )
@@ -456,8 +471,13 @@ async def consult_graeae(request: Request, body: ConsultationRequest, user: User
             winning_muse=result.get("winning_muse"),
             cost=result.get("cost"),
             latency_ms=result.get("latency_ms"),
-            mode=body.mode or "auto",
+            mode=body.mode,
             timestamp=result.get("timestamp", ""),
+            round_1=result.get("round_1"),
+            round_2=result.get("round_2"),
+            quorum_reached=result.get("quorum_reached"),
+            quorum_threshold=result.get("quorum_threshold"),
+            similarity_pairs=result.get("similarity_pairs"),
         )
 
     except HTTPException:
@@ -745,14 +765,46 @@ async def list_muses(_: UserContext = Depends(get_current_user)):
 
 @router.get("/consultations/modes")
 async def list_modes(_: UserContext = Depends(get_current_user)):
-    """List supported consultation routing modes."""
+    """List supported consultation routing and reasoning-shape modes."""
     return {
         "modes": [
-            {"name": "auto",     "description": "engine picks based on task_type"},
-            {"name": "local",    "description": "force local-only muses (no commercial APIs)"},
-            {"name": "external", "description": "force external commercial muses"},
-            {"name": "all",      "description": "fan out to every available muse"},
-        ]
+            {
+                "name": "auto",
+                "description": "engine picks the default routing strategy based on task_type",
+            },
+            {
+                "name": "local",
+                "description": "force local-only muses where configured (no commercial APIs)",
+            },
+            {
+                "name": "external",
+                "description": "force external commercial muses where configured",
+            },
+            {
+                "name": "all",
+                "description": "fan out to every available muse",
+            },
+            {
+                "name": "single",
+                "description": "pick exactly one highest-weighted muse; fastest and lowest-cost path",
+            },
+            {
+                "name": "debate",
+                "description": "run a two-round cross-muse debate and return the refined round",
+            },
+            {
+                "name": "majority",
+                "description": "fan out to up to three muses and report whether quorum agreement was reached",
+            },
+        ],
+        "validation": {
+            "supported": list(SUPPORTED_CONSULTATION_MODES),
+            "unknown_mode_status": 422,
+            "unknown_mode_detail": (
+                "The request schema validates mode with a Pydantic Literal; "
+                "unknown modes are rejected before business logic runs."
+            ),
+        },
     }
 
 

--- a/mnemos/domain/graeae/engine.py
+++ b/mnemos/domain/graeae/engine.py
@@ -33,10 +33,13 @@ Reliability stack (innermost to outermost):
 import asyncio
 import json
 import logging
+import math
 import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from itertools import combinations
 from typing import Any, Dict, Optional
 
 import httpx
@@ -587,6 +590,7 @@ class GraeaeEngine:
         task_type: str = "reasoning",
         timeout: int = 180,
         selection: Optional[Dict[str, Optional[str]]] = None,
+        mode: str = "auto",
     ) -> Dict:
         """Query eligible providers in parallel and return all responses.
 
@@ -601,6 +605,21 @@ class GraeaeEngine:
         registered provider is considered (current auto-lineup).
         """
         task_type = task_type or "reasoning"
+        mode = mode or "auto"
+        if mode == "single":
+            return await self.route_single(
+                prompt, task_type, timeout=timeout, selection=selection,
+            )
+        if mode == "debate":
+            return await self.route_debate(
+                prompt, task_type, timeout=timeout, selection=selection,
+            )
+        if mode == "majority":
+            return await self.route_majority(
+                prompt, task_type, timeout=timeout, selection=selection,
+            )
+        if mode not in {"auto", "local", "external", "all"}:
+            raise ValueError(f"unsupported consultation mode {mode!r}")
 
         # ── Cache check ──────────────────────────────────────────────────────
         # Include the selection (or lack thereof) in the cache key so a
@@ -611,7 +630,7 @@ class GraeaeEngine:
         cached = self._cache.get(prompt, cache_key_task)
         if cached is not None:
             logger.info(f"[GRAEAE] cache hit (task_type={cache_key_task})")
-            return {"all_responses": cached, "cache_hit": True}
+            return {"all_responses": cached, "cache_hit": True, **_compute_consensus(cached)}
 
         concurrency = self._get_concurrency()
 
@@ -714,6 +733,189 @@ class GraeaeEngine:
         # aspirational.
         consensus = _compute_consensus(all_responses)
         return {"all_responses": all_responses, **consensus}
+
+    async def route_single(
+        self,
+        prompt: str,
+        task_type: str = "reasoning",
+        timeout: int = 180,
+        selection: Optional[Dict[str, Optional[str]]] = None,
+    ) -> Dict:
+        """Run exactly one highest-weighted muse for the task."""
+        lineup = await self._ranked_lineup(
+            task_type=task_type, limit=1, selection=selection,
+        )
+        if not lineup:
+            return {"all_responses": {}, "error": "no providers available", **_compute_consensus({})}
+        return await self.consult(
+            prompt, task_type, timeout=timeout, selection=lineup, mode="all",
+        )
+
+    async def route_debate(
+        self,
+        prompt: str,
+        task_type: str = "reasoning",
+        timeout: int = 180,
+        rounds: int = 2,
+        selection: Optional[Dict[str, Optional[str]]] = None,
+    ) -> Dict:
+        """Run a two-round cross-muse debate and return refined responses."""
+        lineup = await self._ranked_lineup(
+            task_type=task_type, limit=3, selection=selection,
+        )
+        if not lineup:
+            empty = _compute_consensus({})
+            return {
+                "all_responses": {},
+                "round_1": {},
+                "round_2": {},
+                "error": "no providers available",
+                **empty,
+            }
+
+        round_1 = await self.consult(
+            prompt, task_type, timeout=timeout, selection=lineup, mode="all",
+        )
+        round_1_responses = round_1.get("all_responses", {})
+        if rounds < 2:
+            return {
+                "all_responses": round_1_responses,
+                "round_1": round_1_responses,
+                "round_2": {},
+                **_compute_consensus(round_1_responses),
+            }
+
+        round_2_responses: Dict[str, Dict] = {}
+        for provider_name, model_override in lineup.items():
+            refine_prompt = _debate_refinement_prompt(
+                prompt=prompt,
+                current_muse=provider_name,
+                round_1_responses=round_1_responses,
+            )
+            refined = await self.consult(
+                refine_prompt,
+                task_type,
+                timeout=timeout,
+                selection={provider_name: model_override},
+                mode="all",
+            )
+            round_2_responses[provider_name] = (
+                refined.get("all_responses", {}).get(provider_name)
+                or _unavailable(self.providers[provider_name]["model"])
+            )
+
+        consensus = _compute_consensus(round_2_responses)
+        return {
+            "all_responses": round_2_responses,
+            "round_1": round_1_responses,
+            "round_2": round_2_responses,
+            **consensus,
+            "cost": float(round_1.get("cost", 0.0) or 0.0) + float(consensus.get("cost", 0.0) or 0.0),
+            "latency_ms": int(round_1.get("latency_ms", 0) or 0) + int(consensus.get("latency_ms", 0) or 0),
+        }
+
+    async def route_majority(
+        self,
+        prompt: str,
+        task_type: str = "reasoning",
+        timeout: int = 180,
+        quorum: float = 0.66,
+        selection: Optional[Dict[str, Optional[str]]] = None,
+    ) -> Dict:
+        """Run up to three muses and report quorum agreement."""
+        lineup = await self._ranked_lineup(
+            task_type=task_type, limit=3, selection=selection,
+        )
+        result = await self.consult(
+            prompt, task_type, timeout=timeout, selection=lineup or selection, mode="all",
+        )
+        all_responses = result.get("all_responses", {})
+        quorum_result = _compute_quorum(all_responses, quorum)
+        consensus = _compute_consensus(all_responses)
+        consensus["consensus_score"] = quorum_result["consensus_score"]
+        if quorum_result["quorum_reached"] and quorum_result["quorum_muses"]:
+            winning_muse = max(
+                quorum_result["quorum_muses"],
+                key=lambda name: all_responses[name].get("final_score", 0.0),
+            )
+            consensus["winning_muse"] = winning_muse
+            consensus["consensus_response"] = all_responses[winning_muse].get("response_text", "")
+
+        return {
+            **result,
+            **consensus,
+            "quorum_reached": quorum_result["quorum_reached"],
+            "quorum_threshold": quorum,
+            "similarity_pairs": quorum_result["similarity_pairs"],
+        }
+
+    async def _ranked_lineup(
+        self,
+        task_type: str,
+        limit: int,
+        selection: Optional[Dict[str, Optional[str]]] = None,
+    ) -> Dict[str, Optional[str]]:
+        """Pick the highest-weighted providers, preferring model_registry weights."""
+        del task_type  # model_registry stores graeae_weight globally today.
+        candidates = [
+            name for name in (selection.keys() if selection is not None else self.providers.keys())
+            if name in self.providers
+        ]
+        if not candidates:
+            return {}
+
+        ranked: list[tuple[str, Optional[str], float]] = []
+        try:
+            import mnemos.core.lifecycle as _lc
+
+            if _lc._pool:
+                registry_names = [
+                    _REGISTRY_MAP.get(name, {}).get("registry_provider", name)
+                    for name in candidates
+                ]
+                registry_to_graeae = {
+                    cfg["registry_provider"]: name
+                    for name, cfg in _REGISTRY_MAP.items()
+                }
+                async with _lc._pool.acquire() as conn:
+                    rows = await conn.fetch(
+                        """
+                        SELECT provider, model_id, graeae_weight
+                        FROM model_registry
+                        WHERE provider = ANY($1::text[])
+                          AND available = true
+                          AND deprecated = false
+                        ORDER BY graeae_weight DESC NULLS LAST
+                        """,
+                        registry_names,
+                    )
+                seen: set[str] = set()
+                for row in rows:
+                    registry_provider = _row_get(row, "provider")
+                    name = registry_to_graeae.get(registry_provider, registry_provider)
+                    if name not in candidates or name in seen:
+                        continue
+                    model_override = selection.get(name) if selection else None
+                    ranked.append((
+                        name,
+                        model_override or _row_get(row, "model_id"),
+                        float(_row_get(row, "graeae_weight", self.providers[name].get("weight", 0.0)) or 0.0),
+                    ))
+                    seen.add(name)
+        except Exception as exc:
+            logger.debug("[GRAEAE] model_registry ranking unavailable: %s", exc)
+
+        ranked_names = {name for name, _, _ in ranked}
+        for name in candidates:
+            if name in ranked_names:
+                continue
+            ranked.append((
+                name,
+                selection.get(name) if selection else None,
+                float(self.providers[name].get("weight", 0.0) or 0.0),
+            ))
+        ranked.sort(key=lambda item: item[2], reverse=True)
+        return {name: model_override for name, model_override, _ in ranked[:limit]}
 
     async def route(
         self,
@@ -1349,6 +1551,107 @@ def _compute_consensus(all_responses: Dict[str, Dict]) -> Dict:
         "winning_muse": winner_name,
         "cost": total_cost,
         "latency_ms": max_latency,
+    }
+
+
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, TypeError):
+        return default
+
+
+def _debate_refinement_prompt(
+    prompt: str,
+    current_muse: str,
+    round_1_responses: Dict[str, Dict],
+) -> str:
+    others: list[str] = []
+    for name, response in round_1_responses.items():
+        if name == current_muse:
+            continue
+        text = str(response.get("response_text") or "").strip()
+        if text:
+            others.append(f"{name}: {text}")
+    context = "\n\n".join(others) if others else "No other round-1 responses were available."
+    return (
+        "Original consultation prompt:\n"
+        f"{prompt}\n\n"
+        "Round 1 responses from the other muses:\n"
+        f"{context}\n\n"
+        "Refine your answer. Address useful objections, keep what still holds, "
+        "and be explicit where you disagree."
+    )
+
+
+def _text_similarity(left: str, right: str) -> float:
+    left = " ".join(left.lower().split())
+    right = " ".join(right.lower().split())
+    if not left or not right:
+        return 0.0
+    return float(SequenceMatcher(None, left, right).ratio())
+
+
+def _compute_quorum(all_responses: Dict[str, Dict], quorum: float) -> Dict[str, Any]:
+    successes = {
+        name: str(resp.get("response_text") or "").strip()
+        for name, resp in all_responses.items()
+        if resp.get("status") == "success" and str(resp.get("response_text") or "").strip()
+    }
+    if len(successes) < 2:
+        return {
+            "quorum_reached": False,
+            "quorum_muses": [],
+            "consensus_score": 0.0,
+            "similarity_pairs": {},
+        }
+
+    parent = {name: name for name in successes}
+
+    def find(name: str) -> str:
+        while parent[name] != name:
+            parent[name] = parent[parent[name]]
+            name = parent[name]
+        return name
+
+    def union(left: str, right: str) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    similarity_pairs: dict[str, float] = {}
+    best_score = 0.0
+    for left, right in combinations(successes, 2):
+        score = _text_similarity(successes[left], successes[right])
+        similarity_pairs[f"{left}:{right}"] = round(score, 4)
+        best_score = max(best_score, score)
+        if score >= quorum:
+            union(left, right)
+
+    components: dict[str, list[str]] = {}
+    for name in successes:
+        components.setdefault(find(name), []).append(name)
+    quorum_size = max(2, math.ceil(quorum * len(successes)))
+    quorum_muses = max(components.values(), key=len)
+    quorum_reached = len(quorum_muses) >= quorum_size
+
+    if quorum_reached and len(quorum_muses) > 1:
+        component_scores = [
+            similarity_pairs.get(f"{left}:{right}", similarity_pairs.get(f"{right}:{left}", 0.0))
+            for left, right in combinations(quorum_muses, 2)
+        ]
+        consensus_score = max(component_scores) if component_scores else best_score
+    else:
+        consensus_score = min(best_score, max(0.0, quorum - 0.01))
+
+    return {
+        "quorum_reached": quorum_reached,
+        "quorum_muses": quorum_muses if quorum_reached else [],
+        "consensus_score": round(float(consensus_score), 4),
+        "similarity_pairs": similarity_pairs,
     }
 
 

--- a/mnemos/domain/models.py
+++ b/mnemos/domain/models.py
@@ -1,15 +1,27 @@
 """Pydantic models for MNEMOS API."""
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
 
+ConsultationMode = Literal["auto", "local", "external", "all", "single", "debate", "majority"]
+SUPPORTED_CONSULTATION_MODES: tuple[str, ...] = (
+    "auto",
+    "local",
+    "external",
+    "all",
+    "single",
+    "debate",
+    "majority",
+)
+
+
 class ConsultationRequest(BaseModel):
     prompt: str
-    task_type: Optional[str] = "reasoning"
+    task_type: str = "reasoning"
     context: Optional[str] = None
-    mode: Optional[str] = "auto"
+    mode: ConsultationMode = "auto"
     limit_chars: Optional[int] = None
     format: Optional[str] = "full"
 
@@ -364,6 +376,11 @@ class ConsultationResponse(BaseModel):
     latency_ms: Optional[float] = None
     mode: str
     timestamp: str
+    round_1: Optional[Dict[str, Any]] = None
+    round_2: Optional[Dict[str, Any]] = None
+    quorum_reached: Optional[bool] = None
+    quorum_threshold: Optional[float] = None
+    similarity_pairs: Optional[Dict[str, float]] = None
 
 
 class ConsultationArtifact(BaseModel):

--- a/tests/test_consultations_namespace_isolation.py
+++ b/tests/test_consultations_namespace_isolation.py
@@ -14,7 +14,7 @@ pytestmark = [
 
 
 class _FakeGraeae:
-    async def consult(self, prompt: str, task_type: str | None, selection=None):
+    async def consult(self, prompt: str, task_type: str | None, selection=None, mode: str = "auto"):
         return {
             "all_responses": {
                 "openai": {

--- a/tests/test_graeae_modes.py
+++ b/tests/test_graeae_modes.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from httpx import AsyncClient
+from pydantic import ValidationError
+
+from mnemos.domain.models import ConsultationRequest, SUPPORTED_CONSULTATION_MODES
+
+
+class _AllowAll:
+    def __init__(self):
+        self.successes: list[str] = []
+        self.failures: list[str] = []
+
+    def is_allowed(self, name: str) -> bool:
+        return True
+
+    def record_success(self, name: str) -> None:
+        self.successes.append(name)
+
+    def record_failure(self, name: str) -> None:
+        self.failures.append(name)
+
+    def status(self) -> dict:
+        return {}
+
+
+class _FakeConcurrency:
+    def __init__(self):
+        self.acquired: list[str] = []
+        self.released: list[str] = []
+
+    def acquire(self, name: str) -> bool:
+        self.acquired.append(name)
+        return True
+
+    def release(self, name: str) -> None:
+        self.released.append(name)
+
+    def status(self) -> dict:
+        return {}
+
+
+class _FakeQuality:
+    def __init__(self, weights: dict[str, float]):
+        self.weights = weights
+
+    def record_success(self, name: str, latency: int) -> None:
+        return None
+
+    def record_failure(self, name: str) -> None:
+        return None
+
+    def dynamic_weight(self, name: str) -> float:
+        return self.weights[name]
+
+    def status(self) -> dict:
+        return {}
+
+
+def _provider_config(model: str, weight: float) -> dict:
+    return {
+        "url": "https://example.invalid/v1/chat/completions",
+        "model": model,
+        "weight": weight,
+        "api": "openai",
+        "key_name": model,
+    }
+
+
+def _build_engine(monkeypatch, responses: dict[str, str] | Callable[[str, str], str] | None = None):
+    import mnemos.core.lifecycle as lc
+    import mnemos.domain.graeae.engine as graeae_engine
+    from mnemos.domain.graeae.engine import GraeaeEngine
+
+    monkeypatch.setattr(lc, "_pool", None)
+    monkeypatch.setattr(graeae_engine, "get_elo_weights", lambda force_refresh=False: None)
+    engine = GraeaeEngine()
+    engine.providers = {
+        "alpha": _provider_config("alpha-model", 0.95),
+        "beta": _provider_config("beta-model", 0.85),
+        "gamma": _provider_config("gamma-model", 0.75),
+        "delta": _provider_config("delta-model", 0.65),
+    }
+    engine._circuit_breakers = _AllowAll()
+    engine._rate_limiters = _AllowAll()
+    engine._concurrency = _FakeConcurrency()
+    engine._quality = _FakeQuality({
+        name: cfg["weight"] for name, cfg in engine.providers.items()
+    })
+    calls: list[dict] = []
+
+    async def _fake_query(provider_name, prompt, task_type, timeout, model_override=None, **kwargs):
+        calls.append({
+            "provider": provider_name,
+            "prompt": prompt,
+            "model_override": model_override,
+        })
+        if callable(responses):
+            text = responses(provider_name, prompt)
+        elif responses is not None:
+            text = responses.get(provider_name, f"{provider_name} response")
+        else:
+            text = f"{provider_name} response to {prompt}"
+        return {
+            "status": "success",
+            "response_text": text,
+            "latency_ms": 10,
+            "model_id": model_override or engine.providers[provider_name]["model"],
+            "final_score": engine.providers[provider_name]["weight"],
+        }
+
+    monkeypatch.setattr(engine, "_query_provider", _fake_query)
+    return engine, calls
+
+
+def test_consultation_request_defaults_mode_to_auto():
+    request = ConsultationRequest(prompt="short", task_type="architecture_design")
+    assert request.mode == "auto"
+
+
+@pytest.mark.asyncio
+async def test_auto_short_architecture_design_returns_body(
+    client: AsyncClient,
+    auth_headers: dict,
+    mock_graeae_engine,
+):
+    mock_graeae_engine.consult.reset_mock()
+    resp = await client.post(
+        "/v1/consultations",
+        json={
+            "prompt": "short",
+            "task_type": "architecture_design",
+            "mode": "auto",
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.content
+    data = resp.json()
+    assert data["mode"] == "auto"
+    assert data["all_responses"]
+    assert mock_graeae_engine.consult.await_args.kwargs["mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_unspecified_mode_defaults_to_auto(
+    client: AsyncClient,
+    auth_headers: dict,
+    mock_graeae_engine,
+):
+    mock_graeae_engine.consult.reset_mock()
+    resp = await client.post(
+        "/v1/consultations",
+        json={"prompt": "short", "task_type": "architecture_design"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mode"] == "auto"
+    assert mock_graeae_engine.consult.await_args.kwargs["mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_unknown_mode_rejected_by_pydantic(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    resp = await client.post(
+        "/v1/consultations",
+        json={
+            "prompt": "short",
+            "task_type": "architecture_design",
+            "mode": "consensus",
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "consensus" in resp.text
+
+
+def test_unknown_mode_rejected_in_request_model():
+    with pytest.raises(ValidationError):
+        ConsultationRequest(
+            prompt="short",
+            task_type="architecture_design",
+            mode="consensus",
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_engine_result_returns_502(
+    client: AsyncClient,
+    auth_headers: dict,
+    mock_graeae_engine,
+):
+    mock_graeae_engine.consult.return_value = {}
+    resp = await client.post(
+        "/v1/consultations",
+        json={"prompt": "short", "task_type": "architecture_design"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 502
+    assert "empty result" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_modes_endpoint_lists_all_seven_modes(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    resp = await client.get("/v1/consultations/modes", headers=auth_headers)
+
+    assert resp.status_code == 200, resp.text
+    names = {mode["name"] for mode in resp.json()["modes"]}
+    assert names == set(SUPPORTED_CONSULTATION_MODES)
+    assert resp.json()["validation"]["unknown_mode_status"] == 422
+
+
+@pytest.mark.parametrize("mode", ["auto", "local", "external", "all"])
+@pytest.mark.asyncio
+async def test_existing_routing_strategy_modes_still_work(
+    client: AsyncClient,
+    auth_headers: dict,
+    mock_graeae_engine,
+    mode: str,
+):
+    mock_graeae_engine.consult.reset_mock()
+    resp = await client.post(
+        "/v1/consultations",
+        json={"prompt": "route it", "task_type": "reasoning", "mode": mode},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mode"] == mode
+    assert mock_graeae_engine.consult.await_args.kwargs["mode"] == mode
+
+
+@pytest.mark.asyncio
+async def test_single_mode_calls_exactly_one_muse(monkeypatch):
+    engine, calls = _build_engine(monkeypatch)
+
+    result = await engine.consult("fast check", "reasoning", mode="single")
+
+    assert [call["provider"] for call in calls] == ["alpha"]
+    assert list(result["all_responses"]) == ["alpha"]
+    assert result["winning_muse"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_debate_mode_runs_three_muses_for_two_rounds(monkeypatch):
+    engine, calls = _build_engine(monkeypatch)
+
+    result = await engine.consult("design the cache", "architecture_design", mode="debate")
+
+    assert len(calls) == 6
+    assert [call["provider"] for call in calls[:3]] == ["alpha", "beta", "gamma"]
+    assert [call["provider"] for call in calls[3:]] == ["alpha", "beta", "gamma"]
+    assert all(call["prompt"] == "design the cache" for call in calls[:3])
+    assert all("Round 1 responses from the other muses" in call["prompt"] for call in calls[3:])
+    assert set(result["round_1"]) == {"alpha", "beta", "gamma"}
+    assert set(result["round_2"]) == {"alpha", "beta", "gamma"}
+    assert set(result["all_responses"]) == {"alpha", "beta", "gamma"}
+
+
+@pytest.mark.asyncio
+async def test_majority_mode_reports_quorum_reached(monkeypatch):
+    engine, calls = _build_engine(
+        monkeypatch,
+        responses={
+            "alpha": "approve the design because it has a stable cache boundary",
+            "beta": "approve the design because it has a stable cache boundary",
+            "gamma": "approve the design because it has a stable cache boundary",
+        },
+    )
+
+    result = await engine.consult("approve?", "architecture_design", mode="majority")
+
+    assert [call["provider"] for call in calls] == ["alpha", "beta", "gamma"]
+    assert result["quorum_reached"] is True
+    assert result["consensus_score"] >= result["quorum_threshold"]
+
+
+@pytest.mark.asyncio
+async def test_majority_mode_reports_quorum_not_reached(monkeypatch):
+    engine, _calls = _build_engine(
+        monkeypatch,
+        responses={
+            "alpha": "approve caching with a write-through database layer",
+            "beta": "reject the change and replace the API gateway first",
+            "gamma": "defer the decision until hardware telemetry arrives",
+        },
+    )
+
+    result = await engine.consult("approve?", "architecture_design", mode="majority")
+
+    assert result["quorum_reached"] is False
+    assert result["consensus_score"] < result["quorum_threshold"]

--- a/tests/test_v3_integration.py
+++ b/tests/test_v3_integration.py
@@ -15,7 +15,7 @@ class TestConsultationsV1:
             json={
                 "prompt": "What is the capital of France?",
                 "task_type": "reasoning",
-                "mode": "consensus",
+                "mode": "auto",
             },
             headers=auth_headers,
         )


### PR DESCRIPTION
Closes the STUDIO Claude handoff bug (mem_2bb8a6af18a2). Three fixes:

1. Empty-body bug — short prompt + arch_design + no mode silently returned HTTP 200 + 0 bytes. Default mode now resolves to "auto" at validation; defensive response-write check raises 502 instead of empty body.
2. Unknown mode values — pydantic Literal rejects with 422 (was silent fallthrough).
3. Three new reasoning-shape modes added — single, debate, majority — alongside the existing 4 routing-strategy modes (auto/local/external/all). Total 7.

mnemos/domain/graeae/engine.py +305 LOC for route_single, route_debate, route_majority. tests/test_graeae_modes.py (304 lines, 15 cases). 1039 passed (+15), ruff clean, 7 contracts kept.

Workaround for STUDIO Claude in flight (mode=auto) confirmed and now the default. Authored-By: Codex