### PR TITLE
v4.0 D.3: deployment profiles (server / edge / dev)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,10 +4,33 @@
 
 ---
 
+## Choose Your Profile
+
+Pick one profile first. The profile sets safe defaults; explicit environment
+variables or `config.toml` entries still override those defaults.
+
+| Profile | Default stack | Use it for |
+|---------|---------------|------------|
+| `server` | Postgres + Redis + single worker by default, multi-worker safe when Redis is present | Production deployments and shared service installs |
+| `edge` | SQLite + in-process rate limits + one worker | Laptop, Pi, edge appliance, Consumer MNEMOS, bigpi/clawpi/zeropi, Termux on S21 |
+| `dev` | SQLite + in-process rate limits + debug logging | Local development and test loops |
+
+Examples:
+
+```bash
+mnemos serve --profile server
+mnemos serve --profile edge
+mnemos serve --profile dev
+```
+
+`MNEMOS_PROFILE=personal` is a legacy v3.x alias and resolves to `edge`.
+
+---
+
 ## Quick Start
 
 ### Prerequisites
-- PostgreSQL 12+ (for memory storage, audit logs, sessions, DAG versioning)
+- PostgreSQL 12+ for the `server` profile, or SQLite for `edge`/`dev`
 - Python 3.10+
 - LLM provider API keys (Together AI or Groq free tier recommended)
 - (Optional) GPU or local inference endpoint for APOLLO's LLM fallback and self-hosted LLMs
@@ -50,10 +73,10 @@ circuit-breaker state; see `docs/SCALING.md`.
 
 ## SQLite Profile
 
-The SQLite profile is available for local development, laptops, and edge
-single-user deployments. Set `MNEMOS_PERSISTENCE_BACKEND=sqlite` with
-`MNEMOS_SQLITE_PATH=/path/to/mnemos.sqlite3`, or set
-`MNEMOS_PERSISTENCE_BACKEND=auto` with a `sqlite:///...` `MNEMOS_DATABASE_URL`.
+Use the `edge` or `dev` deployment profile for SQLite-backed installs. The
+default SQLite path is `~/.mnemos/mnemos.db`; override it with
+`MNEMOS_SQLITE_PATH=/path/to/mnemos.db` or `[database].sqlite_path` in
+`config.toml`.
 
 See `docs/SQLITE_PROFILE.md` for the constraints: no RLS, no LISTEN/NOTIFY, no
 advisory locks, FTS5 instead of PostgreSQL tsvector, and sqlite-vec instead of

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can treat MNEMOS like a memory storage provider if you want — `POST /v1/me
 
 **What it is, concretely:**
 
-- A FastAPI service (port 5002), PostgreSQL + pgvector backed. Python 3.11+. Apache-2.0.
+- A FastAPI service (port 5002), with `server` (Postgres + Redis), `edge` (SQLite), and `dev` (SQLite + debug logging) deployment profiles. Python 3.11+. Apache-2.0.
 - A single `/v1/*` REST surface covering memories, consultations, providers, sessions, webhooks, federation, and an OpenAI-compatible chat-completions gateway.
 - A multi-LLM consensus reasoning layer (GRAEAE) that distributes one prompt across multiple providers, scores the responses, and writes a tamper-evident SHA-256 hash-chained audit entry — every time.
 - Git-like DAG versioning on memory: `log`, `branch`, `merge`, `revert`. Every mutation snapshots. In v3.5.x, history reads are filtered per snapshot and branch writers refuse cross-memory parent edges.
@@ -59,7 +59,7 @@ Current MCP tools come from one registry shared by stdio and HTTP/SSE: `search_m
 
 The integrations bundle under [`integrations/`](./integrations/) is the living inventory. New integrations ship as SKILL.md + MCP config + enforcement snippet per framework, plus idempotent install/uninstall scripts where the target framework supports them.
 
-MNEMOS runs as a network service — you deploy it once, alongside PostgreSQL and Redis, and every agent in your stack shares the same memory kernel over REST. It is not a desktop library, not an in-process helper, not a framework you import. Different form factor, different user, and specifically not a replacement for projects like MemPalace that serve the desktop / single-user case well.
+MNEMOS runs as a network service. In the `server` profile you deploy it alongside PostgreSQL and Redis so every agent in your stack shares the same memory kernel over REST; in the `edge` profile it runs as an all-in-one SQLite-backed node for laptops, Pi-class systems, and phone-adjacent installs. It is not an in-process helper or a framework you import.
 
 ---
 
@@ -224,15 +224,18 @@ Each memory carries full ownership and LLM provenance. Since v3.2, tenancy is tw
 - `source_session` — session ID at time of creation
 - `source_agent` — agent name or identifier
 
-**Row Level Security** is defined in PostgreSQL but inactive for personal installs. Team/enterprise installs activate it via `install.py`, which enforces per-row access at the database layer. The application layer mirrors the RLS read contract so personal-mode and RLS-backed installs behave consistently. v3.5.x closes task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
+**Row Level Security** is defined in PostgreSQL and remains opt-in for multi-user server deployments. The application layer mirrors the RLS read contract so SQLite/edge installs and RLS-backed server installs behave consistently. v3.5.x closes task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
 
-**Deployment profiles** — selected at install time via `python install.py`:
+**Deployment topologies** — selected with `mnemos install --profile ...`,
+`mnemos serve --profile ...`, or `MNEMOS_PROFILE`:
 
-| Profile | Auth | RLS | Use case |
-|---------|------|-----|---------|
-| Personal | off | off | Single developer, localhost |
-| Team | API key | on | 2–20 users, shared PostgreSQL |
-| Enterprise | API key | on | 20+ users, full namespace isolation |
+| Profile | Backend | Shared state | Use case |
+|---------|---------|--------------|----------|
+| `server` | PostgreSQL | Redis | Production service, shared agents, multi-worker capable |
+| `edge` | SQLite | In-process | Laptop, Pi/edge appliance, Consumer MNEMOS, Termux on S21 |
+| `dev` | SQLite | In-process | Local development with debug logging |
+
+`personal` is the legacy v3.x profile name and now resolves to `edge`.
 
 Search hits update recall telemetry in the background: `recall_count` increments and `last_recalled_at` is set for the returned memory IDs. The counters are observability and future archival input, not authorization state; failures are logged and do not block the user-visible search response.
 
@@ -596,7 +599,7 @@ knowledge_graph
 
 ## Quick start
 
-### Personal install (Docker Compose)
+### Edge install (Docker Compose)
 
 ```bash
 git clone <your-repo-url>
@@ -613,8 +616,8 @@ git clone <your-repo-url>
 cd mnemos
 pip install -r requirements.txt
 python install.py
-# Prompts for: deployment profile, database connection, provider API keys
-# Writes config.toml, runs migrations, creates root API key (team/enterprise)
+# Prompts for: server, edge, or dev profile; database path/connection; provider API keys
+# Writes config.toml and initializes SQLite or Postgres as appropriate
 ```
 
 ### Manual database setup (if not using install.py)

--- a/config.toml.example
+++ b/config.toml.example
@@ -8,6 +8,8 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 [database]
+backend = "postgres"        # postgres for server, sqlite for edge/dev
+sqlite_path = "~/.mnemos/mnemos.db"
 host = "localhost"
 port = 5432
 database = "mnemos"
@@ -197,13 +199,14 @@ audit_logging = true
 semantic_search = true
 
 # ── Deployment profile ─────────────────────────────────────────────────────────
-# personal  — single user, no auth, no RLS
-# team      — multi-user, bearer auth, RLS enabled
-# enterprise — team + namespace isolation
+# server — Postgres + Redis production deployment
+# edge   — SQLite all-in-one laptop/Pi/edge deployment
+# dev    — SQLite + debug logging for local development
+# legacy personal resolves to edge
 [deployment]
-profile = "personal"
+profile = "server"
 
-# ── Auth (personal profile: disabled by default) ───────────────────────────────
+# ── Auth (edge/dev profiles: disabled by default) ──────────────────────────────
 [auth]
 enabled = true          # Enable bearer token auth; create root key with: python3 install.py
 personal_user_id = "default"

--- a/docs/SQLITE_PROFILE.md
+++ b/docs/SQLITE_PROFILE.md
@@ -6,6 +6,9 @@ the same persistence interface as `PostgresBackend`, but uses SQLite storage,
 FTS5, JSON1-compatible JSON text, and `sqlite-vec` when the extension is
 available.
 
+For profile selection and the server/edge/dev deployment matrix, start with
+the "Choose Your Profile" section in [`DEPLOYMENT.md`](../DEPLOYMENT.md#choose-your-profile).
+
 ## When To Use It
 
 Use SQLite when you want a local MNEMOS node with minimal operational surface:
@@ -56,21 +59,28 @@ Install the optional dependencies:
 pip install "mnemos-os[sqlite]"
 ```
 
-Select SQLite explicitly:
+Prefer the profile flag:
+
+```bash
+mnemos serve --profile edge
+mnemos serve --profile dev
+```
+
+Select SQLite explicitly when you need to override the profile default:
 
 ```bash
 MNEMOS_PERSISTENCE_BACKEND=sqlite
-MNEMOS_SQLITE_PATH=/var/lib/mnemos/mnemos.sqlite3
+MNEMOS_SQLITE_PATH=/var/lib/mnemos/mnemos.db
 ```
 
 Or use URI auto-detection:
 
 ```bash
 MNEMOS_PERSISTENCE_BACKEND=auto
-MNEMOS_DATABASE_URL=sqlite:////var/lib/mnemos/mnemos.sqlite3
+MNEMOS_DATABASE_URL=sqlite:////var/lib/mnemos/mnemos.db
 ```
 
-Postgres remains the default backend.
+The legacy `personal` profile name resolves to `edge`.
 
 ## Operational Notes
 

--- a/mnemos.service
+++ b/mnemos.service
@@ -11,11 +11,12 @@ WorkingDirectory=/opt/mnemos
 Environment="PATH=/opt/mnemos/venv/bin"
 Environment="MNEMOS_BIND=0.0.0.0"
 Environment="MNEMOS_PORT=5002"
+Environment="MNEMOS_PROFILE=edge"
 EnvironmentFile=/opt/mnemos/.env
 # Canonical port is 5002; this overrides [api].port in config.toml if different
-# MNEMOS v3.5 is single-worker by design; do not configure multiple Uvicorn workers.
+# MNEMOS_PROFILE is read from /opt/mnemos/.env; edge is the all-in-one default.
 # Keep the venv path explicit so systemd uses the installed console script.
-ExecStart=/opt/mnemos/venv/bin/mnemos serve
+ExecStart=/opt/mnemos/venv/bin/mnemos serve --profile ${MNEMOS_PROFILE}
 
 # Auto-restart on failure
 Restart=on-failure

--- a/mnemos/api/main.py
+++ b/mnemos/api/main.py
@@ -45,7 +45,11 @@ except ImportError:
     _document_import_available = False
     document_import_router = None
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(name)s: %(message)s')
+_settings = get_settings()
+logging.basicConfig(
+    level=getattr(logging, _settings.logging.level.upper(), logging.INFO),
+    format=_settings.logging.format,
+)
 
 # v3.2 observability foundation: request-ID correlation across logs +
 # response headers. Must run BEFORE any handler emits log records so
@@ -67,7 +71,7 @@ install_tracing()  # no-op unless opentelemetry is installed
 # parsers expect the default format. Without `structlog` installed,
 # or without the env flag set, the standard formatter (with
 # [req:<id>]) is used.
-if get_settings().observability.structured_logs:
+if _settings.observability.structured_logs:
     install_structured_logging()
 
 from mnemos._version import __version__ as _MNEMOS_VERSION  # noqa: E402
@@ -83,7 +87,7 @@ app = FastAPI(title="MNEMOS API", version=_MNEMOS_VERSION, description="Unified 
 # Transfer-Encoding: chunked and omit Content-Length. The previous
 # BaseHTTPMiddleware version only inspected Content-Length and was bypassed
 # by chunked uploads, which Starlette then buffered into memory unbounded.
-_MAX_BODY_BYTES = get_settings().server.max_body_bytes
+_MAX_BODY_BYTES = _settings.server.max_body_bytes
 
 
 class _BodySizeLimitASGI:
@@ -193,7 +197,7 @@ import secrets as _secrets
 
 from starlette.middleware.sessions import SessionMiddleware as _SessionMiddleware
 
-_oauth_state_secret = get_settings().server.session_secret
+_oauth_state_secret = _settings.server.session_secret
 if not _oauth_state_secret:
     logging.getLogger(__name__).warning(
         "MNEMOS_SESSION_SECRET is not set — generating a random key for this "
@@ -212,7 +216,7 @@ app.add_middleware(
 
 # CORS: set CORS_ORIGINS env var to restrict in production (comma-separated list).
 # Defaults to "*" for local dev. Example: CORS_ORIGINS=https://app.example.com
-_cors_origins_raw = get_settings().server.cors_origins
+_cors_origins_raw = _settings.server.cors_origins
 _cors_origins = [o.strip() for o in _cors_origins_raw.split(",")]
 app.add_middleware(
     CORSMiddleware,

--- a/mnemos/api/routes/health.py
+++ b/mnemos/api/routes/health.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException
 
 import mnemos.core.lifecycle as _lc
 from mnemos._version import __version__ as _MNEMOS_VERSION
+from mnemos.core.config import get_settings
 from mnemos.domain.models import HealthResponse, StatsResponse
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,8 @@ async def health_check() -> HealthResponse:
             db_ok = True
         except Exception as e:
             logger.warning(f"[HEALTH] DB probe failed: {e}")
+    elif _lc._persistence_backend is not None:
+        db_ok = True
 
     # Get worker status
     worker_status = _lc._worker_status.get("distillation_worker", "unknown")
@@ -35,6 +38,7 @@ async def health_check() -> HealthResponse:
         database_connected=db_ok,
         version=_MNEMOS_VERSION,
         distillation_worker=worker_status,
+        profile=get_settings().profile,
     )
 
 

--- a/mnemos/cli/main.py
+++ b/mnemos/cli/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import json
+import os
 import sys
 from contextlib import contextmanager
 from enum import Enum
@@ -13,7 +14,7 @@ from typing import Any, Callable, Optional, Sequence
 import httpx
 import typer
 
-from mnemos.core.config import get_settings
+from mnemos.core.config import get_settings, reload_settings
 
 
 def _patch_typer_click_compat() -> None:
@@ -109,6 +110,12 @@ class ConsultMode(str, Enum):
     consensus = "consensus"
     debate = "debate"
     single = "single"
+
+
+class DeploymentProfile(str, Enum):
+    server = "server"
+    edge = "edge"
+    dev = "dev"
 
 
 EXPORT_DISPATCH: dict[str, str] = {
@@ -296,6 +303,14 @@ def _parse_consult_mode(mode: str) -> ConsultMode:
         raise typer.Exit(2) from exc
 
 
+def _apply_profile_flag(profile: Optional[DeploymentProfile]) -> None:
+    if profile is None:
+        return
+    os.environ["MNEMOS_PROFILE_OVERRIDE"] = profile.value
+    os.environ["MNEMOS_PROFILE"] = profile.value
+    reload_settings()
+
+
 def _adapter_source_args(import_from: ImportSource, source: Path) -> list[str]:
     source_text = str(source)
 
@@ -328,6 +343,12 @@ def serve(
     ctx: typer.Context,
     host: str = typer.Option("0.0.0.0", "--host", help="API bind address.", is_flag=False),
     port: int = typer.Option(5002, "--port", help="API listen port.", is_flag=False),
+    profile: Optional[DeploymentProfile] = typer.Option(
+        None,
+        "--profile",
+        help="Deployment profile: server, edge, or dev.",
+        is_flag=False,
+    ),
     workers: Optional[int] = typer.Option(
         None,
         "--workers",
@@ -338,6 +359,8 @@ def serve(
     """Run the MNEMOS FastAPI server."""
     if ctx.invoked_subcommand is not None:
         return
+
+    _apply_profile_flag(profile)
 
     import uvicorn
 
@@ -377,6 +400,12 @@ def install(
     unattended: bool = typer.Option(False, "--unattended", help="Non-interactive environment-driven install."),
     upgrade: bool = typer.Option(False, "--upgrade", help="Re-run migrations only."),
     check: bool = typer.Option(False, "--check", help="Run environment checks only."),
+    profile: Optional[DeploymentProfile] = typer.Option(
+        None,
+        "--profile",
+        help="Deployment profile: server, edge, or dev.",
+        is_flag=False,
+    ),
 ) -> None:
     """Run the MNEMOS install wizard."""
     selected_modes = sum(bool(value) for value in (agent, wizard, unattended))
@@ -395,6 +424,8 @@ def install(
         argv.append("--upgrade")
     if check:
         argv.append("--check")
+    if profile is not None:
+        argv.extend(["--profile", profile.value])
 
     _run_module_main("mnemos.installer.__main__", argv, prog="mnemos install")
 

--- a/mnemos/core/config.py
+++ b/mnemos/core/config.py
@@ -15,8 +15,51 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, PrivateAttr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "server": {
+        "backend": "postgres",
+        "rate_limit_storage": "redis://localhost:6379/1",
+        "workers": 1,
+        "graeae_mode_default": "auto",
+        "log_level": "INFO",
+        "compression_workers": 4,
+    },
+    "edge": {
+        "backend": "sqlite",
+        "rate_limit_storage": "memory://",
+        "workers": 1,
+        "graeae_mode_default": "single",
+        "log_level": "INFO",
+        "compression_workers": 1,
+    },
+    "dev": {
+        "backend": "sqlite",
+        "rate_limit_storage": "memory://",
+        "workers": 1,
+        "graeae_mode_default": "auto",
+        "log_level": "DEBUG",
+        "compression_workers": 1,
+        "loose_timeouts": True,
+    },
+}
+
+PROFILE_ALIASES = {
+    "personal": "edge",
+}
+
+_PROFILE_DEFAULT_TARGETS = {
+    "backend": ("database", "backend"),
+    "rate_limit_storage": ("rate_limit", "storage_uri"),
+    "workers": ("server", "workers"),
+    "graeae_mode_default": ("graeae", "mode_default"),
+    "log_level": ("logging", "level"),
+    "compression_workers": ("compression", "workers"),
+    "loose_timeouts": ("runtime", "loose_timeouts"),
+}
 
 
 def _config_model_config(*, env_prefix: str = "", extra: str = "ignore") -> SettingsConfigDict:
@@ -34,12 +77,16 @@ class _DatabaseSettings(BaseSettings):
         "auto",
         validation_alias=AliasChoices("MNEMOS_PERSISTENCE_BACKEND", "PERSISTENCE_BACKEND", "PG_BACKEND"),
     )
+    dsn: str = Field(
+        "",
+        validation_alias=AliasChoices("MNEMOS_DATABASE_DSN", "DATABASE_DSN", "PG_DSN"),
+    )
     url: str = Field(
         "",
         validation_alias=AliasChoices("MNEMOS_DATABASE_URL", "DATABASE_URL", "PG_URL"),
     )
     sqlite_path: Path = Field(
-        Path("mnemos.sqlite3"),
+        default_factory=lambda: (Path.home() / ".mnemos" / "mnemos.db"),
         validation_alias=AliasChoices("MNEMOS_SQLITE_PATH", "SQLITE_DB_PATH", "PG_SQLITE_PATH"),
     )
     host: str = "localhost"
@@ -50,11 +97,17 @@ class _DatabaseSettings(BaseSettings):
     pool_min_size: int = Field(5, validation_alias="PG_POOL_MIN")
     pool_max_size: int = Field(20, validation_alias="PG_POOL_MAX")
 
+    @field_validator("sqlite_path", mode="before")
+    @classmethod
+    def _expand_sqlite_path(cls, raw: Any) -> Path:
+        return Path(raw).expanduser()
+
 
 class _GraeaeSettings(BaseSettings):
     model_config = _config_model_config(extra="allow")
 
     providers: dict[str, Any] = Field(default_factory=dict)
+    mode_default: str = Field("auto", validation_alias="GRAEAE_MODE_DEFAULT")
     providers_enabled: str = Field("together,groq,openai,anthropic", validation_alias="GRAEAE_PROVIDERS")
     consensus_mode: bool = Field(True, validation_alias="GRAEAE_CONSENSUS_MODE")
     consensus_quorum_size: int = Field(3, validation_alias="GRAEAE_CONSENSUS_QUORUM_SIZE")
@@ -223,6 +276,7 @@ class _ObservabilitySettings(BaseSettings):
 class _CompressionSettings(BaseSettings):
     model_config = _config_model_config()
 
+    workers: int = Field(1, validation_alias="MNEMOS_COMPRESSION_WORKERS")
     contest_enabled: bool = Field(True, validation_alias="MNEMOS_CONTEST_ENABLED")
     contest_min_content_length: int = Field(0, validation_alias="MNEMOS_CONTEST_MIN_CONTENT_LENGTH")
     contest_stale_threshold_secs: int = Field(600, validation_alias="MNEMOS_CONTEST_STALE_THRESHOLD_SECS")
@@ -272,6 +326,7 @@ class _RuntimeSettings(BaseSettings):
 
     worker_shutdown_cancel_seconds: float = Field(10.0, validation_alias="WORKER_SHUTDOWN_CANCEL_SECONDS")
     pool_acquire_timeout: float = Field(10.0, validation_alias="MNEMOS_POOL_ACQUIRE_TIMEOUT")
+    loose_timeouts: bool = Field(False, validation_alias="MNEMOS_LOOSE_TIMEOUTS")
 
 
 class _ToolSettings(BaseSettings):
@@ -284,8 +339,20 @@ class _ToolSettings(BaseSettings):
     falkordb_password: str | None = Field(None, validation_alias="FALKORDB_PASSWORD")
 
 
+class _LoggingSettings(BaseSettings):
+    model_config = _config_model_config()
+
+    level: str = Field("INFO", validation_alias="MNEMOS_LOG_LEVEL")
+    format: str = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    file: str = "/tmp/mnemos.log"
+    max_bytes: int = 10_485_760
+    backup_count: int = 5
+
+
 class Settings(BaseSettings):
     model_config = _config_model_config()
+
+    _explicit_fields: dict[str, set[str]] = PrivateAttr(default_factory=dict)
 
     database: _DatabaseSettings
     graeae: _GraeaeSettings
@@ -302,6 +369,18 @@ class Settings(BaseSettings):
     oauth: _OAuthSettings
     runtime: _RuntimeSettings
     tools: _ToolSettings
+    logging: _LoggingSettings
+
+    @property
+    def profile(self) -> str:
+        return self.server.profile
+
+    @property
+    def log_level(self) -> str:
+        return self.logging.level
+
+    def explicit_fields(self, group: str) -> set[str]:
+        return set(self._explicit_fields.get(group, set()))
 
 
 _settings: Settings | None = None
@@ -317,28 +396,100 @@ def get_settings() -> Settings:
     return _settings
 
 
+def normalize_profile(raw_profile: str | None) -> str:
+    """Return the canonical deployment profile name.
+
+    ``personal`` was the v3.x single-user profile name. In v4 it is an alias
+    for the all-in-one ``edge`` profile.
+    """
+    profile = (raw_profile or "personal").strip().lower()
+    profile = PROFILE_ALIASES.get(profile, profile)
+    if profile not in PROFILE_DEFAULTS:
+        valid = ", ".join(PROFILE_DEFAULTS)
+        raise ValueError(
+            f"Unsupported MNEMOS profile {raw_profile!r}; expected one of: {valid}. "
+            "Legacy profile 'personal' is now an alias for 'edge'."
+        )
+    return profile
+
+
 def _build_settings() -> Settings:
     toml_config = _load_toml()
     server_toml = _toml_section(toml_config, "server")
     server = _ServerSettings(**server_toml)
+    server.profile = normalize_profile(_profile_from_sources(toml_config, server_toml, server))
     server.base_configured = "MNEMOS_BASE" in os.environ or "base" in server_toml
-    return Settings(
-        database=_DatabaseSettings(**_toml_section(toml_config, "database")),
-        graeae=_GraeaeSettings(**_toml_section(toml_config, "graeae")),
-        server=server,
-        webhook=_WebhookSettings(**_toml_section(toml_config, "webhook")),
-        providers=_ProviderSettings(**_toml_section(toml_config, "providers")),
-        mcp=_MCPSettings(**_toml_section(toml_config, "mcp")),
-        rate_limit=_RateLimitSettings(**_toml_section(toml_config, "rate_limit")),
-        resilience=_ResilienceSettings(**_toml_section(toml_config, "resilience")),
-        observability=_ObservabilitySettings(**_toml_section(toml_config, "observability")),
-        compression=_CompressionSettings(**_toml_section(toml_config, "compression")),
-        morpheus=_MorpheusSettings(**_toml_section(toml_config, "morpheus")),
-        federation=_FederationSettings(**_toml_section(toml_config, "federation")),
-        oauth=_OAuthSettings(**_toml_section(toml_config, "oauth")),
-        runtime=_RuntimeSettings(**_toml_section(toml_config, "runtime")),
-        tools=_ToolSettings(**_toml_section(toml_config, "tools")),
+    groups = {
+        "database": _DatabaseSettings(**_toml_section(toml_config, "database")),
+        "graeae": _GraeaeSettings(**_toml_section(toml_config, "graeae")),
+        "server": server,
+        "webhook": _WebhookSettings(**_toml_section(toml_config, "webhook")),
+        "providers": _ProviderSettings(**_toml_section(toml_config, "providers")),
+        "mcp": _MCPSettings(**_toml_section(toml_config, "mcp")),
+        "rate_limit": _RateLimitSettings(**_toml_section(toml_config, "rate_limit")),
+        "resilience": _ResilienceSettings(**_toml_section(toml_config, "resilience")),
+        "observability": _ObservabilitySettings(**_toml_section(toml_config, "observability")),
+        "compression": _CompressionSettings(**_toml_section(toml_config, "compression")),
+        "morpheus": _MorpheusSettings(**_toml_section(toml_config, "morpheus")),
+        "federation": _FederationSettings(**_toml_section(toml_config, "federation")),
+        "oauth": _OAuthSettings(**_toml_section(toml_config, "oauth")),
+        "runtime": _RuntimeSettings(**_toml_section(toml_config, "runtime")),
+        "tools": _ToolSettings(**_toml_section(toml_config, "tools")),
+        "logging": _LoggingSettings(**_toml_section(toml_config, "logging")),
+    }
+    settings = Settings(
+        database=groups["database"],
+        graeae=groups["graeae"],
+        server=groups["server"],
+        webhook=groups["webhook"],
+        providers=groups["providers"],
+        mcp=groups["mcp"],
+        rate_limit=groups["rate_limit"],
+        resilience=groups["resilience"],
+        observability=groups["observability"],
+        compression=groups["compression"],
+        morpheus=groups["morpheus"],
+        federation=groups["federation"],
+        oauth=groups["oauth"],
+        runtime=groups["runtime"],
+        tools=groups["tools"],
+        logging=groups["logging"],
     )
+    settings._explicit_fields = {
+        group_name: set(group.model_fields_set)
+        for group_name, group in groups.items()
+        if isinstance(group, BaseSettings)
+    }
+    _apply_profile_defaults(settings)
+    return settings
+
+
+def _profile_from_sources(
+    toml_config: dict[str, Any],
+    server_toml: dict[str, Any],
+    server: _ServerSettings,
+) -> str:
+    override = os.environ.get("MNEMOS_PROFILE_OVERRIDE", "").strip()
+    if override:
+        return override
+    if "profile" in server_toml:
+        return str(server_toml["profile"])
+    deployment_toml = _toml_section(toml_config, "deployment")
+    if "profile" in deployment_toml:
+        return str(deployment_toml["profile"])
+    return server.profile
+
+
+def _apply_profile_defaults(settings: Settings) -> None:
+    profile_defaults = PROFILE_DEFAULTS[settings.profile]
+    for profile_key, value in profile_defaults.items():
+        target = _PROFILE_DEFAULT_TARGETS.get(profile_key)
+        if target is None:
+            continue
+        group_name, field_name = target
+        if field_name in settings.explicit_fields(group_name):
+            continue
+        setattr(getattr(settings, group_name), field_name, value)
 
 
 def _load_toml() -> dict[str, Any]:
@@ -385,15 +536,21 @@ def _sync_compat_exports(settings: Settings) -> None:
     GRAEAE_CONFIG.update(settings.graeae.model_dump(mode="python"))
 
 
+def reload_settings() -> Settings:
+    """Rebuild the settings singleton after changing env/config inputs."""
+    global _settings
+    _settings = _build_settings()
+    _sync_compat_exports(_settings)
+    return _settings
+
+
 def _reset_settings_for_tests() -> None:
     """Clear the singleton and refresh compatibility dicts.
 
     This is intentionally not used by application code. It exists so tests can
     exercise environment/config-file overrides without process isolation.
     """
-    global _settings
-    _settings = None
-    _sync_compat_exports(get_settings())
+    reload_settings()
 
 
 _sync_compat_exports(get_settings())

--- a/mnemos/core/lifecycle.py
+++ b/mnemos/core/lifecycle.py
@@ -12,6 +12,7 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Optional, Protocol
 from urllib.parse import urlparse
 
@@ -222,33 +223,92 @@ def _select_persistence_backend(settings) -> str:
     database_settings = getattr(settings, "database", None)
     if database_settings is None:
         return "postgres"
+    explicit_database_fields = _explicit_fields(settings, "database")
     configured = getattr(database_settings, "backend", "auto").strip().lower()
-    database_url = getattr(database_settings, "url", "").strip().lower()
+    for field_name in ("dsn", "url"):
+        database_url = getattr(database_settings, field_name, "").strip().lower()
+        if database_url and field_name in explicit_database_fields:
+            url_backend = _backend_from_database_url(database_url)
+            return url_backend or "postgres"
+
+    if "backend" in explicit_database_fields and configured != "auto":
+        return _normalize_backend_name(configured)
+    if _has_explicit_postgres_connection_config(settings):
+        return "postgres"
+    if configured != "auto":
+        return _normalize_backend_name(configured)
+
+    for field_name in ("dsn", "url"):
+        database_url = getattr(database_settings, field_name, "").strip().lower()
+        url_backend = _backend_from_database_url(database_url)
+        if url_backend is not None:
+            return url_backend
+
+    profile = getattr(settings, "profile", getattr(getattr(settings, "server", None), "profile", "server"))
+    if profile in {"edge", "dev"}:
+        return "sqlite"
+    return "postgres"
+
+
+def _normalize_backend_name(configured: str) -> str:
     if configured in {"postgres", "postgresql", "pg"}:
         return "postgres"
     if configured in {"sqlite", "sqlite3"}:
         return "sqlite"
     if configured == "auto":
-        if database_url.startswith("sqlite:"):
-            return "sqlite"
-        if database_url.startswith(("postgres:", "postgresql:")):
-            return "postgres"
-        return "postgres"
+        return "auto"
     raise ValueError(
-        "Unsupported persistence backend "
-        f"{settings.database.backend!r}; expected postgres, sqlite, or auto"
+        f"Unsupported persistence backend {configured!r}; expected postgres, sqlite, or auto"
     )
+
+
+def _backend_from_database_url(database_url: str) -> str | None:
+    if database_url.startswith("sqlite:"):
+        return "sqlite"
+    if database_url.startswith(("postgres:", "postgresql:")):
+        return "postgres"
+    return None
+
+
+def _explicit_fields(settings, group: str) -> set[str]:
+    explicit_fields = getattr(settings, "explicit_fields", None)
+    if callable(explicit_fields):
+        return explicit_fields(group)
+    return set()
+
+
+def _has_explicit_postgres_connection_config(settings) -> bool:
+    explicit_database_fields = _explicit_fields(settings, "database")
+    return bool(explicit_database_fields & {"host", "port", "database", "user"})
+
+
+def _database_dsn_from_settings(settings) -> str:
+    database_settings = getattr(settings, "database", None)
+    if database_settings is None:
+        return ""
+    for field_name in ("dsn", "url"):
+        database_url = getattr(database_settings, field_name, "").strip()
+        if database_url.startswith(("postgres:", "postgresql:")):
+            return database_url
+    return ""
 
 
 def _sqlite_path_from_settings(settings):
     database_settings = getattr(settings, "database", None)
-    database_url = getattr(database_settings, "url", "").strip() if database_settings is not None else ""
-    if database_url.startswith("sqlite:"):
+    database_urls = []
+    if database_settings is not None:
+        database_urls = [
+            getattr(database_settings, "dsn", "").strip(),
+            getattr(database_settings, "url", "").strip(),
+        ]
+    for database_url in database_urls:
+        if not database_url.startswith("sqlite:"):
+            continue
         parsed = urlparse(database_url)
         if parsed.path in {"", "/:memory:"}:
             return parsed.netloc or ":memory:"
         return parsed.path
-    return getattr(database_settings, "sqlite_path", "mnemos.sqlite3")
+    return Path(getattr(database_settings, "sqlite_path", "~/.mnemos/mnemos.db")).expanduser()
 
 
 def _load_config() -> dict:
@@ -374,15 +434,22 @@ async def lifespan(app):
             app.state.persistence_backend = _persistence_backend
             logger.info("SQLite persistence backend initialized (%s)", sqlite_path)
         else:
-            _pool = await asyncpg.create_pool(
-                user=PG_CONFIG['user'],
-                password=PG_CONFIG['password'],
-                database=PG_CONFIG['database'],
-                host=PG_CONFIG['host'],
-                port=PG_CONFIG['port'],
-                min_size=PG_CONFIG['pool_min_size'],
-                max_size=PG_CONFIG['pool_max_size'],
-            )
+            database_dsn = _database_dsn_from_settings(settings)
+            pool_kwargs = {
+                "min_size": PG_CONFIG["pool_min_size"],
+                "max_size": PG_CONFIG["pool_max_size"],
+            }
+            if database_dsn:
+                _pool = await asyncpg.create_pool(database_dsn, **pool_kwargs)
+            else:
+                _pool = await asyncpg.create_pool(
+                    user=PG_CONFIG["user"],
+                    password=PG_CONFIG["password"],
+                    database=PG_CONFIG["database"],
+                    host=PG_CONFIG["host"],
+                    port=PG_CONFIG["port"],
+                    **pool_kwargs,
+                )
             _pool_manager = PoolManager(_pool)
             _persistence_backend = _build_postgres_backend(_pool, settings)
             app.state.pool = _pool   # auth.py reads this via request.app.state.pool

--- a/mnemos/domain/models.py
+++ b/mnemos/domain/models.py
@@ -53,6 +53,7 @@ class HealthResponse(BaseModel):
     timestamp: str
     database_connected: bool
     version: str
+    profile: str = "edge"
     distillation_worker: Optional[str] = None  # idle, healthy, error, disabled, unavailable
 
 

--- a/mnemos/installer/__main__.py
+++ b/mnemos/installer/__main__.py
@@ -3,6 +3,7 @@ MNEMOS Installer — entry point.
 
 Usage:
     python -m mnemos.installer [--agent] [--wizard] [--unattended] [--upgrade] [--check]
+                              [--profile server|edge|dev]
 
 Options:
     --agent       LLM-guided installation (default)
@@ -13,7 +14,8 @@ Options:
 
 Environment variables for --unattended:
     MNEMOS_PROFILE, MNEMOS_DB_HOST, MNEMOS_DB_NAME, MNEMOS_DB_USER,
-    MNEMOS_DB_PASSWORD, MNEMOS_LISTEN_PORT, MNEMOS_SERVICE_USER
+    MNEMOS_DB_PASSWORD, MNEMOS_SQLITE_PATH, MNEMOS_LISTEN_PORT,
+    MNEMOS_SERVICE_USER
 """
 
 from __future__ import annotations
@@ -21,6 +23,26 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+
+
+_PROFILE_ALIASES = {"personal": "edge"}
+_VALID_PROFILES = {"server", "edge", "dev"}
+
+
+def _canonical_profile(raw_profile: str | None) -> str:
+    profile = (raw_profile or "personal").strip().lower()
+    profile = _PROFILE_ALIASES.get(profile, profile)
+    if profile not in _VALID_PROFILES:
+        valid = ", ".join(sorted(_VALID_PROFILES))
+        raise argparse.ArgumentTypeError(
+            f"unsupported profile {raw_profile!r}; expected one of: {valid}. "
+            "Legacy profile 'personal' maps to 'edge'."
+        )
+    return profile
+
+
+def _profile_uses_sqlite(profile: str) -> bool:
+    return profile in {"edge", "dev"}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -56,6 +78,12 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Environment check only; no changes made",
     )
+    parser.add_argument(
+        "--profile",
+        type=_canonical_profile,
+        choices=sorted(_VALID_PROFILES),
+        help="Deployment profile: server, edge, or dev. Legacy personal maps to edge.",
+    )
     return parser.parse_args()
 
 
@@ -64,16 +92,17 @@ def _config_from_env() -> "Config":
     from .wizard import Config
 
     cfg = Config()
-    cfg.profile = os.environ.get("MNEMOS_PROFILE", "personal")
+    cfg.profile = _canonical_profile(os.environ.get("MNEMOS_PROFILE", "personal"))
     cfg.db_host = os.environ.get("MNEMOS_DB_HOST", "localhost")
     cfg.db_port = int(os.environ.get("MNEMOS_DB_PORT", "5432"))
     cfg.db_name = os.environ.get("MNEMOS_DB_NAME", "mnemos")
     cfg.db_user = os.environ.get("MNEMOS_DB_USER", "mnemos_user")
     cfg.db_password = os.environ.get("MNEMOS_DB_PASSWORD", "")
+    cfg.sqlite_path = os.environ.get("MNEMOS_SQLITE_PATH", "~/.mnemos/mnemos.db")
     cfg.listen_port = int(os.environ.get("MNEMOS_LISTEN_PORT", "5002"))
     cfg.service_user = os.environ.get("MNEMOS_SERVICE_USER", "mnemos")
-    cfg.auth_enabled = cfg.profile in ("team", "enterprise")
-    cfg.rls_enabled = cfg.profile == "enterprise"
+    cfg.auth_enabled = False
+    cfg.rls_enabled = False
     cfg.create_new_db = os.environ.get("MNEMOS_CREATE_DB", "true").lower() == "true"
     cfg.install_docling = os.environ.get("MNEMOS_INSTALL_DOCLING", "true").lower() == "true"
     cfg.create_service = os.environ.get("MNEMOS_CREATE_SERVICE", "true").lower() == "true"
@@ -88,7 +117,7 @@ def _config_from_env() -> "Config":
         if key:
             cfg.graeae_providers[p] = key
 
-    if not cfg.db_password:
+    if not _profile_uses_sqlite(cfg.profile) and not cfg.db_password:
         print(
             "ERROR: MNEMOS_DB_PASSWORD is required for unattended install.",
             file=sys.stderr,
@@ -115,18 +144,33 @@ def _write_config_toml(cfg, repo_path: str) -> None:
         import shutil
         shutil.copy(example_path, config_path)
 
+    profile_defaults = {
+        "server": {
+            "backend": "postgres",
+            "rate_limit_storage": "redis://localhost:6379/1",
+            "graeae_mode_default": "auto",
+            "log_level": "INFO",
+            "compression_workers": 4,
+        },
+        "edge": {
+            "backend": "sqlite",
+            "rate_limit_storage": "memory://",
+            "graeae_mode_default": "single",
+            "log_level": "INFO",
+            "compression_workers": 1,
+        },
+        "dev": {
+            "backend": "sqlite",
+            "rate_limit_storage": "memory://",
+            "graeae_mode_default": "auto",
+            "log_level": "DEBUG",
+            "compression_workers": 1,
+        },
+    }[cfg.profile]
+
     if not os.path.exists(config_path):
         # No example either — write a minimal config
-        content = (
-            "[database]\n"
-            f'host = "{cfg.db_host}"\n'
-            f"port = {cfg.db_port}\n"
-            f'database = "{cfg.db_name}"\n'
-            f'user = "{cfg.db_user}"\n'
-            f'password = "{cfg.db_password}"\n'
-            "\n[api]\n"
-            f"port = {cfg.listen_port}\n"
-        )
+        content = _render_minimal_config(cfg, profile_defaults)
         # Write with restricted permissions (contains DB password)
         import tempfile as _tf
         dir_ = os.path.dirname(config_path) or "."
@@ -147,36 +191,58 @@ def _write_config_toml(cfg, repo_path: str) -> None:
 
     content = open(config_path).read()
 
-    def _set(section_active, key, value):
-        """Replace key = ... inside the active [database] section."""
-        nonlocal content
-        pattern = rf'((?:^|\n)\[{section_active}\][^\[]*?)({re.escape(key)}\s*=\s*[^\n]*)'
+    def _toml_value(value):
         if isinstance(value, str):
-            escaped = value.replace("\\", "\\\\").replace("", "\\")
-            quoted = f'"{escaped}"'
-        else:
-            quoted = str(value)
-        replacement = rf'\1{key} = {quoted}'
-        content, n = re.subn(pattern, replacement, content, flags=re.DOTALL)
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _set(section_active, key, value):
+        """Replace or append key = ... inside a TOML section."""
+        nonlocal content
+        quoted = _toml_value(value)
+        pattern = rf'((?:^|\n)\[{section_active}\][^\[]*?)({re.escape(key)}\s*=\s*[^\n]*)'
+        content, n = re.subn(
+            pattern,
+            lambda match: f"{match.group(1)}{key} = {quoted}",
+            content,
+            flags=re.DOTALL,
+        )
         if n == 0:
-            # Key absent — append to end of section (simplistic)
-            if isinstance(value, str):
-                _esc2 = value.replace("\\", "\\\\").replace("", "\\")
-                quoted = f'"{_esc2}"'
-            else:
-                quoted = str(value)
+            if f"[{section_active}]" not in content:
+                if not content.endswith("\n"):
+                    content += "\n"
+                content += f"\n[{section_active}]\n{key} = {quoted}\n"
+                return
             content = re.sub(
-                rf'(\[{section_active}\])',
-                rf'\1\n{key} = {quoted}',
+                rf'(\[{section_active}\][^\[]*)',
+                lambda match: f"{match.group(1)}{key} = {quoted}\n",
                 content,
+                count=1,
+                flags=re.DOTALL,
             )
 
-    _set("database", "host", cfg.db_host)
-    _set("database", "port", cfg.db_port)
-    _set("database", "database", cfg.db_name)
-    _set("database", "user", cfg.db_user)
-    _set("database", "password", cfg.db_password)
+    _set("server", "profile", cfg.profile)
+    _set("server", "port", cfg.listen_port)
+    _set("deployment", "profile", cfg.profile)
     _set("api", "port", cfg.listen_port)
+    _set("database", "backend", profile_defaults["backend"])
+    if _profile_uses_sqlite(cfg.profile):
+        _set("database", "sqlite_path", cfg.sqlite_path)
+    else:
+        _set("database", "host", cfg.db_host)
+        _set("database", "port", cfg.db_port)
+        _set("database", "database", cfg.db_name)
+        _set("database", "user", cfg.db_user)
+        _set("database", "password", cfg.db_password)
+    _set("rate_limit", "storage_uri", profile_defaults["rate_limit_storage"])
+    _set("graeae", "mode_default", profile_defaults["graeae_mode_default"])
+    _set("logging", "level", profile_defaults["log_level"])
+    _set("compression", "workers", profile_defaults["compression_workers"])
+    if cfg.profile == "dev":
+        _set("runtime", "loose_timeouts", True)
 
     import tempfile as _tf
     _dir = os.path.dirname(config_path) or "."
@@ -193,6 +259,55 @@ def _write_config_toml(cfg, repo_path: str) -> None:
             pass
         raise
     print(f"[installer] Updated {config_path}")
+
+
+def _render_minimal_config(cfg, profile_defaults: dict) -> str:
+    sqlite = _profile_uses_sqlite(cfg.profile)
+    lines = [
+        "[server]",
+        f'profile = "{cfg.profile}"',
+        f"port = {cfg.listen_port}",
+        "",
+        "[deployment]",
+        f'profile = "{cfg.profile}"',
+        "",
+        "[database]",
+        f'backend = "{profile_defaults["backend"]}"',
+    ]
+    if sqlite:
+        lines.append(f'sqlite_path = "{cfg.sqlite_path}"')
+    else:
+        lines.extend(
+            [
+                f'host = "{cfg.db_host}"',
+                f"port = {cfg.db_port}",
+                f'database = "{cfg.db_name}"',
+                f'user = "{cfg.db_user}"',
+                f'password = "{cfg.db_password}"',
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "[api]",
+            f"port = {cfg.listen_port}",
+            "",
+            "[rate_limit]",
+            f'storage_uri = "{profile_defaults["rate_limit_storage"]}"',
+            "",
+            "[graeae]",
+            f'mode_default = "{profile_defaults["graeae_mode_default"]}"',
+            "",
+            "[logging]",
+            f'level = "{profile_defaults["log_level"]}"',
+            "",
+            "[compression]",
+            f"workers = {profile_defaults['compression_workers']}",
+        ]
+    )
+    if cfg.profile == "dev":
+        lines.extend(["", "[runtime]", "loose_timeouts = true"])
+    return "\n".join(lines) + "\n"
 
 
 def _print_completion(cfg: "Config", api_key: str | None, repo_path: str) -> None:
@@ -216,6 +331,8 @@ def _print_completion(cfg: "Config", api_key: str | None, repo_path: str) -> Non
 
 def main() -> int:
     args = _parse_args()
+    if args.profile:
+        os.environ["MNEMOS_PROFILE"] = args.profile
 
     # ------------------------------------------------------------------ #
     # Step 1: Always detect environment
@@ -281,24 +398,28 @@ def main() -> int:
     if args.unattended:
         print("Running in unattended mode (reading config from environment)...")
         cfg = _config_from_env()
+        if args.profile:
+            cfg.profile = args.profile
 
     elif args.wizard:
         from .wizard import run_wizard
-        cfg = run_wizard(info)
+        cfg = run_wizard(info, selected_profile=args.profile)
 
     else:
         # Default: --agent (try LLM-guided, fall back to wizard)
         try:
             from .agent import run_agent
             cfg = run_agent(info)
+            if args.profile:
+                cfg.profile = args.profile
         except (ImportError, ModuleNotFoundError):
             print("[installer] agent module not available — falling back to wizard.")
             from .wizard import run_wizard
-            cfg = run_wizard(info)
+            cfg = run_wizard(info, selected_profile=args.profile)
         except Exception as exc:
             print(f"[installer] Agent error ({exc}) — falling back to wizard.")
             from .wizard import run_wizard
-            cfg = run_wizard(info)
+            cfg = run_wizard(info, selected_profile=args.profile)
 
     if cfg is None:
         print("ERROR: No configuration obtained.", file=sys.stderr)
@@ -331,19 +452,26 @@ def main() -> int:
     # ------------------------------------------------------------------ #
     # Step 8: Setup database
     # ------------------------------------------------------------------ #
-    from .db import create_api_key, run_migrations, setup_database, verify_connection
+    from .db import create_api_key, run_migrations, setup_database, setup_sqlite_database, verify_connection
 
-    if cfg.create_new_db:
+    if _profile_uses_sqlite(cfg.profile):
+        print("\n[installer] Initializing SQLite database...")
+        ok = setup_sqlite_database(cfg)
+        if not ok:
+            print("ERROR: SQLite setup failed.", file=sys.stderr)
+            return 1
+    elif cfg.create_new_db:
         print("\n[installer] Setting up database...")
         ok = setup_database(cfg, info)
         if not ok:
             print("ERROR: Database setup failed.", file=sys.stderr)
             return 1
 
-    print("\n[installer] Running migrations...")
-    ok = run_migrations(cfg)
-    if not ok:
-        print("WARNING: Some migrations failed.", file=sys.stderr)
+    if not _profile_uses_sqlite(cfg.profile):
+        print("\n[installer] Running migrations...")
+        ok = run_migrations(cfg)
+        if not ok:
+            print("WARNING: Some migrations failed.", file=sys.stderr)
 
     # ------------------------------------------------------------------ #
     # Step 8b: Write config.toml
@@ -436,7 +564,11 @@ def _load_existing_config(repo_path: str):
             data = tomllib.load(fh)
 
         cfg = Config()
+        server = data.get("server", {})
+        deployment = data.get("deployment", {})
+        cfg.profile = _canonical_profile(server.get("profile", deployment.get("profile", "personal")))
         db = data.get("database", {})
+        cfg.sqlite_path = db.get("sqlite_path", "~/.mnemos/mnemos.db")
         cfg.db_host = db.get("host", "localhost")
         cfg.db_port = db.get("port", 5432)
         # Key is "database" (matching what _write_config_toml writes), not "name"

--- a/mnemos/installer/db.py
+++ b/mnemos/installer/db.py
@@ -48,6 +48,10 @@ def _run(
         return 1, "", str(exc)
 
 
+def _profile_uses_sqlite(profile: str) -> bool:
+    return profile in {"edge", "dev"}
+
+
 def _psql_superuser(sql: str, dbname: str = "postgres", timeout: int = 30) -> tuple[int, str, str]:
     """Run SQL as the postgres superuser via sudo."""
     return _run(
@@ -68,6 +72,9 @@ def _psql_superuser_file(filepath: str, dbname: str, timeout: int = 120) -> tupl
 
 def verify_connection(config: Config) -> bool:
     """Verify we can connect to the target database."""
+    if _profile_uses_sqlite(config.profile):
+        return Path(config.sqlite_path).expanduser().exists()
+
     env = os.environ.copy()
     env["PGPASSWORD"] = config.db_password
 
@@ -111,6 +118,32 @@ def verify_connection(config: Config) -> bool:
         pass
 
     return False
+
+
+def setup_sqlite_database(config: Config) -> bool:
+    """Create and migrate the SQLite database through the SQLite backend."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from mnemos.persistence.sqlite import SqliteBackend
+
+    db_path = Path(config.sqlite_path).expanduser()
+    print(f"[db] Initializing SQLite database at {db_path}...")
+
+    async def _setup() -> bool:
+        backend = SqliteBackend(db_path, SimpleNamespace())
+        try:
+            await backend.open()
+            print(f"[db] SQLite database ready. sqlite-vec loaded: {backend.vec_loaded}")
+            return True
+        finally:
+            await backend.close()
+
+    try:
+        return asyncio.run(_setup())
+    except Exception as exc:
+        print(f"[db] ERROR initializing SQLite database: {exc}", file=sys.stderr)
+        return False
 
 
 def pgvector_installed(config: Config) -> bool:

--- a/mnemos/installer/service.py
+++ b/mnemos/installer/service.py
@@ -64,11 +64,13 @@ def _write_env_file(config: Config, env_path: str) -> bool:
 
         lines = [
             "# MNEMOS environment — managed by installer",
+            f"MNEMOS_PROFILE={config.profile}",
             f"PG_HOST={config.db_host}",
             f"PG_PORT={config.db_port}",
             f"PG_DATABASE={config.db_name}",
             f"PG_USER={config.db_user}",
             f"PG_PASSWORD={config.db_password}",
+            f"MNEMOS_SQLITE_PATH={config.sqlite_path}",
             f"MNEMOS_LISTEN_PORT={config.listen_port}",
             f"MNEMOS_SERVICE_USER={config.service_user}",
             f"INFERENCE_EMBED_HOST={config.inference_embed_host}",
@@ -122,7 +124,7 @@ def _write_env_file(config: Config, env_path: str) -> bool:
 def install_systemd(config: Config, repo_path: str) -> bool:
     """Write systemd unit file and environment file. Return True on success."""
     repo = Path(repo_path)
-    venv_python = repo / "venv" / "bin" / "python"
+    venv_mnemos = repo / "venv" / "bin" / "mnemos"
     service_path = "/etc/systemd/system/mnemos.service"
     env_path = "/etc/mnemos/mnemos.env"
 
@@ -144,7 +146,7 @@ User={config.service_user}
 Group={config.service_user}
 WorkingDirectory={repo_path}
 EnvironmentFile={env_path}
-ExecStart={venv_python} -m mnemos.api.main
+ExecStart={venv_mnemos} serve --profile ${{MNEMOS_PROFILE}}
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal
@@ -207,11 +209,13 @@ def install_launchd(config: Config, repo_path: str) -> bool:
     env_file = mnemos_dir / "mnemos.env"
 
     env_vars = {
+        "MNEMOS_PROFILE": config.profile,
         "PG_HOST": config.db_host,
         "PG_PORT": str(config.db_port),
         "PG_DATABASE": config.db_name,
         "PG_USER": config.db_user,
         "PG_PASSWORD": config.db_password,
+        "MNEMOS_SQLITE_PATH": config.sqlite_path,
         "MNEMOS_LISTEN_PORT": str(config.listen_port),
         "INFERENCE_EMBED_HOST": config.inference_embed_host,
     }

--- a/mnemos/installer/wizard.py
+++ b/mnemos/installer/wizard.py
@@ -14,12 +14,13 @@ from .detect import SystemInfo, check_port_free
 
 @dataclass
 class Config:
-    profile: str = "personal"       # 'personal', 'team', 'enterprise'
+    profile: str = "edge"           # 'server', 'edge', 'dev'
     db_host: str = "localhost"
     db_port: int = 5432
     db_name: str = "mnemos"
     db_user: str = "mnemos_user"
     db_password: str = ""
+    sqlite_path: str = "~/.mnemos/mnemos.db"
     listen_port: int = 5002
     service_user: str = "mnemos"
     auth_enabled: bool = False       # False for personal
@@ -96,7 +97,11 @@ def _section(title: str) -> None:
     print(f"\n--- {title} ---")
 
 
-def run_wizard(info: SystemInfo, existing_config: dict = None) -> Config:
+def _profile_uses_sqlite(profile: str) -> bool:
+    return profile in {"edge", "dev"}
+
+
+def run_wizard(info: SystemInfo, existing_config: dict = None, selected_profile: str | None = None) -> Config:
     """Run the interactive installation wizard and return a Config."""
     cfg = Config()
 
@@ -117,53 +122,57 @@ def run_wizard(info: SystemInfo, existing_config: dict = None) -> Config:
     # ------------------------------------------------------------------ #
     _section("Deployment Profile")
     print("  Profiles:")
-    print("    personal   — single user, no auth, simple setup")
-    print("    team       — multi-user, API key auth, row-level security")
-    print("    enterprise — team + advanced auditing and RBAC")
+    print("    server — Postgres + Redis + multi-worker production deployment")
+    print("    edge   — SQLite + single-worker laptop/Pi/edge appliance")
+    print("    dev    — SQLite + debug logging for local development")
 
-    while True:
-        raw = _prompt("Select profile", default="personal")
-        if raw in ("personal", "team", "enterprise"):
-            cfg.profile = raw
-            break
-        print("  Choose: personal, team, or enterprise.")
+    if selected_profile:
+        cfg.profile = selected_profile
+    else:
+        while True:
+            raw = _prompt("Select profile", default="edge")
+            if raw == "personal":
+                raw = "edge"
+            if raw in ("server", "edge", "dev"):
+                cfg.profile = raw
+                break
+            print("  Choose: server, edge, or dev. Legacy personal maps to edge.")
 
-    cfg.auth_enabled = cfg.profile in ("team", "enterprise")
-    cfg.rls_enabled = cfg.profile == "enterprise"
+    cfg.auth_enabled = False
+    cfg.rls_enabled = False
 
     # ------------------------------------------------------------------ #
     # 2. Database
     # ------------------------------------------------------------------ #
     _section("Database Configuration")
 
-    if cfg.profile == "personal":
-        cfg.create_new_db = _prompt_bool(
-            "Create a new PostgreSQL database (No = use existing)?", default=True
-        )
+    if _profile_uses_sqlite(cfg.profile):
+        cfg.create_new_db = True
+        cfg.sqlite_path = _prompt("SQLite database path", default=cfg.sqlite_path)
     else:
         cfg.create_new_db = _prompt_bool("Create a new PostgreSQL database?", default=True)
 
-    cfg.db_host = _prompt("Database host", default="localhost")
-    cfg.db_port = _prompt_int("Database port", default=5432)
-    cfg.db_name = _prompt("Database name", default="mnemos")
-    cfg.db_user = _prompt("Database user", default="mnemos_user")
+        cfg.db_host = _prompt("Database host", default="localhost")
+        cfg.db_port = _prompt_int("Database port", default=5432)
+        cfg.db_name = _prompt("Database name", default="mnemos")
+        cfg.db_user = _prompt("Database user", default="mnemos_user")
 
-    if cfg.create_new_db:
-        offer_generate = _prompt_bool("Generate a random database password?", default=True)
-        if offer_generate:
-            cfg.db_password = _generate_password()
-            print(f"  Generated password: {cfg.db_password}")
-            print("  (Save this — it will be written to /etc/mnemos/mnemos.env)")
+        if cfg.create_new_db:
+            offer_generate = _prompt_bool("Generate a random database password?", default=True)
+            if offer_generate:
+                cfg.db_password = _generate_password()
+                print(f"  Generated password: {cfg.db_password}")
+                print("  (Save this — it will be written to /etc/mnemos/mnemos.env)")
+            else:
+                while True:
+                    pw = getpass.getpass("  Database password: ")
+                    pw2 = getpass.getpass("  Confirm password: ")
+                    if pw == pw2 and pw:
+                        cfg.db_password = pw
+                        break
+                    print("  Passwords do not match or are empty. Try again.")
         else:
-            while True:
-                pw = getpass.getpass("  Database password: ")
-                pw2 = getpass.getpass("  Confirm password: ")
-                if pw == pw2 and pw:
-                    cfg.db_password = pw
-                    break
-                print("  Passwords do not match or are empty. Try again.")
-    else:
-        cfg.db_password = getpass.getpass("  Database password: ")
+            cfg.db_password = getpass.getpass("  Database password: ")
 
     # ------------------------------------------------------------------ #
     # 3. Listen port
@@ -196,7 +205,7 @@ def run_wizard(info: SystemInfo, existing_config: dict = None) -> Config:
     _section("GRAEAE Provider API Keys (optional)")
 
     configure_providers = False
-    if cfg.profile == "personal":
+    if cfg.profile in {"edge", "dev"}:
         configure_providers = _prompt_bool(
             "Configure LLM provider API keys for GRAEAE reasoning?", default=False
         )
@@ -247,8 +256,11 @@ def run_wizard(info: SystemInfo, existing_config: dict = None) -> Config:
     # ------------------------------------------------------------------ #
     _section("Confirm Configuration")
     print(f"  Profile:         {cfg.profile}")
-    print(f"  Database:        postgresql://{cfg.db_user}@{cfg.db_host}:{cfg.db_port}/{cfg.db_name}")
-    print(f"  Create new DB:   {cfg.create_new_db}")
+    if _profile_uses_sqlite(cfg.profile):
+        print(f"  Database:        sqlite:///{cfg.sqlite_path}")
+    else:
+        print(f"  Database:        postgresql://{cfg.db_user}@{cfg.db_host}:{cfg.db_port}/{cfg.db_name}")
+        print(f"  Create new DB:   {cfg.create_new_db}")
     print(f"  Listen port:     {cfg.listen_port}")
     print(f"  Service user:    {cfg.service_user}")
     print(f"  Auth enabled:    {cfg.auth_enabled}")

--- a/tests/test_deployment_profiles.py
+++ b/tests/test_deployment_profiles.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from mnemos.cli import main as cli_main
+from mnemos.core import config
+from mnemos.core import lifecycle
+from mnemos.persistence import PostgresBackend, SqliteBackend
+
+
+runner = CliRunner()
+
+_ENV_KEYS = (
+    "MNEMOS_CONFIG_PATH",
+    "MNEMOS_PROFILE",
+    "MNEMOS_PROFILE_OVERRIDE",
+    "MNEMOS_PERSISTENCE_BACKEND",
+    "PERSISTENCE_BACKEND",
+    "PG_BACKEND",
+    "MNEMOS_DATABASE_DSN",
+    "DATABASE_DSN",
+    "PG_DSN",
+    "MNEMOS_DATABASE_URL",
+    "DATABASE_URL",
+    "PG_URL",
+    "MNEMOS_SQLITE_PATH",
+    "SQLITE_DB_PATH",
+    "PG_SQLITE_PATH",
+    "PG_HOST",
+    "PG_PORT",
+    "PG_DATABASE",
+    "PG_USER",
+    "PG_PASSWORD",
+    "RATE_LIMIT_STORAGE_URI",
+    "RATE_LIMIT_STORAGE",
+    "MNEMOS_WORKERS",
+    "GRAEAE_MODE_DEFAULT",
+    "MNEMOS_LOG_LEVEL",
+    "MNEMOS_COMPRESSION_WORKERS",
+    "MNEMOS_LOOSE_TIMEOUTS",
+)
+
+
+@contextmanager
+def _isolated_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    *,
+    env: dict[str, str] | None = None,
+    config_text: str | None = None,
+) -> Iterator[config.Settings]:
+    with monkeypatch.context() as scoped:
+        for key in _ENV_KEYS:
+            scoped.delenv(key, raising=False)
+        if config_text is None:
+            config_path = tmp_path / "missing.toml"
+        else:
+            config_path = tmp_path / "config.toml"
+            config_path.write_text(config_text, encoding="utf-8")
+        scoped.setenv("MNEMOS_CONFIG_PATH", str(config_path))
+        for key, value in (env or {}).items():
+            scoped.setenv(key, value)
+        settings = config.reload_settings()
+        try:
+            yield settings
+        finally:
+            config.reload_settings()
+
+
+def test_profile_server_sets_server_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, tmp_path, env={"MNEMOS_PROFILE": "server"}) as settings:
+        assert settings.profile == "server"
+        assert settings.database.backend == "postgres"
+        assert settings.rate_limit.storage_uri == "redis://localhost:6379/1"
+        assert settings.graeae.mode_default == "auto"
+        assert settings.logging.level == "INFO"
+        assert settings.compression.workers == 4
+
+
+def test_profile_server_selects_and_instantiates_postgres(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, tmp_path, env={"MNEMOS_PROFILE": "server"}) as settings:
+        assert lifecycle._select_persistence_backend(settings) == "postgres"
+        backend = lifecycle._build_postgres_backend(SimpleNamespace(), settings)
+        assert isinstance(backend, PostgresBackend)
+
+
+@pytest.mark.asyncio
+async def test_profile_edge_selects_sqlite_and_loads_sqlite_vec(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def fake_load_sqlite_vec(self, _conn) -> None:
+        self._vec_loaded = True
+
+    async def fake_create_vec_virtual_table(self, _conn) -> None:
+        self._vec_loaded = True
+
+    monkeypatch.setattr(SqliteBackend, "_load_sqlite_vec", fake_load_sqlite_vec)
+    monkeypatch.setattr(SqliteBackend, "_create_vec_virtual_table", fake_create_vec_virtual_table)
+    sqlite_path = tmp_path / "edge.db"
+    with _isolated_settings(
+        monkeypatch,
+        tmp_path,
+        env={"MNEMOS_PROFILE": "edge", "MNEMOS_SQLITE_PATH": str(sqlite_path)},
+    ) as settings:
+        assert lifecycle._select_persistence_backend(settings) == "sqlite"
+        backend = await lifecycle._build_sqlite_backend(settings.database.sqlite_path, settings)
+        try:
+            assert isinstance(backend, SqliteBackend)
+            assert backend.vec_loaded is True
+            assert backend.uses_sqlite_vec is True
+        finally:
+            await backend.close()
+
+
+def test_profile_dev_selects_sqlite_and_debug_logging(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, tmp_path, env={"MNEMOS_PROFILE": "dev"}) as settings:
+        assert settings.profile == "dev"
+        assert settings.database.backend == "sqlite"
+        assert settings.logging.level == "DEBUG"
+        assert settings.runtime.loose_timeouts is True
+        assert lifecycle._select_persistence_backend(settings) == "sqlite"
+
+
+def test_profile_personal_aliases_to_edge(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(monkeypatch, tmp_path, env={"MNEMOS_PROFILE": "personal"}) as settings:
+        assert settings.profile == "edge"
+        assert settings.database.backend == "sqlite"
+        assert settings.graeae.mode_default == "single"
+
+
+def test_profile_unknown_fails_with_clear_message(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with monkeypatch.context() as scoped:
+        for key in _ENV_KEYS:
+            scoped.delenv(key, raising=False)
+        scoped.setenv("MNEMOS_CONFIG_PATH", str(tmp_path / "missing.toml"))
+        scoped.setenv("MNEMOS_PROFILE", "unknown")
+        with pytest.raises(ValueError, match="Unsupported MNEMOS profile 'unknown'"):
+            config.reload_settings()
+    config.reload_settings()
+
+
+def test_explicit_pg_host_overrides_edge_profile(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(
+        monkeypatch,
+        tmp_path,
+        env={"MNEMOS_PROFILE": "edge", "PG_HOST": "postgres.internal"},
+    ) as settings:
+        assert settings.database.backend == "sqlite"
+        assert lifecycle._select_persistence_backend(settings) == "postgres"
+
+
+def test_explicit_sqlite_dsn_overrides_server_profile(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(
+        monkeypatch,
+        tmp_path,
+        env={"MNEMOS_PROFILE": "server", "MNEMOS_DATABASE_DSN": "sqlite:///tmp/hybrid.db"},
+    ) as settings:
+        assert settings.database.backend == "postgres"
+        assert lifecycle._select_persistence_backend(settings) == "sqlite"
+
+
+def test_toml_backend_override_wins_over_profile_default(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    with _isolated_settings(
+        monkeypatch,
+        tmp_path,
+        config_text="""
+[server]
+profile = "server"
+
+[database]
+backend = "sqlite"
+sqlite_path = "/tmp/profile-override.db"
+""".lstrip(),
+    ) as settings:
+        assert settings.profile == "server"
+        assert settings.database.backend == "sqlite"
+        assert lifecycle._select_persistence_backend(settings) == "sqlite"
+
+
+def test_cli_serve_profile_flag_overrides_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_uvicorn_run(app_path: str, *, host: str, port: int, workers: int) -> None:
+        calls.update(
+            {
+                "app_path": app_path,
+                "host": host,
+                "port": port,
+                "workers": workers,
+                "profile": config.get_settings().profile,
+            }
+        )
+
+    with monkeypatch.context() as scoped:
+        for key in _ENV_KEYS:
+            scoped.delenv(key, raising=False)
+        scoped.setenv("MNEMOS_CONFIG_PATH", str(tmp_path / "missing.toml"))
+        scoped.setenv("MNEMOS_PROFILE", "server")
+        config.reload_settings()
+        import uvicorn
+
+        scoped.setattr(uvicorn, "run", fake_uvicorn_run)
+        result = runner.invoke(cli_main.app, ["serve", "--profile", "dev"])
+
+    assert result.exit_code == 0, result.output
+    assert calls["app_path"] == "mnemos.api.main:app"
+    assert calls["profile"] == "dev"
+    assert calls["workers"] == 1
+    config.reload_settings()
+
+
+def test_cli_install_profile_flag_forwards_to_installer(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, list[str], str | None]] = []
+
+    def fake_run_module_main(module_name: str, argv: list[str], *, prog: str | None = None) -> None:
+        calls.append((module_name, argv, prog))
+
+    monkeypatch.setattr(cli_main, "_run_module_main", fake_run_module_main)
+    result = runner.invoke(cli_main.app, ["install", "--profile", "edge", "--check"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [("mnemos.installer.__main__", ["--check", "--profile", "edge"], "mnemos install")]
+
+
+@pytest.mark.asyncio
+async def test_health_returns_active_profile(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from mnemos.api.routes import health
+
+    with _isolated_settings(monkeypatch, tmp_path, env={"MNEMOS_PROFILE": "edge"}):
+        monkeypatch.setattr(health._lc, "_pool", None)
+        monkeypatch.setattr(health._lc, "_persistence_backend", object())
+        monkeypatch.setattr(health._lc, "_worker_status", {"distillation_worker": "idle"})
+        response = await health.health_check()
+
+    assert response.profile == "edge"
+    assert response.database_connected is True


### PR DESCRIPTION
Profile-driven backend selection on top of D.1 (interface) + D.2 (SQLite). Three profiles: server (Postgres+Redis+multi-worker), edge (SQLite single-worker — Pi/laptop/S21), dev (SQLite + DEBUG logging). Profile defaults override Settings; explicit env still overrides profile. mnemos serve --profile flag; /health returns active profile. Legacy "personal" aliased to "edge". 1051 passed (+12), ruff clean, 7 contracts kept. Authored-By: Codex