### PR TITLE
v4.0 D.4: single-binary mnemos build — closes Phase D

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Publish single-binary release assets
+
+on:
+  release:
+    types: [created]
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-binary:
+    name: build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-latest
+          - platform: linux-aarch64
+            runner: ubuntu-22.04-arm
+          - platform: macos-aarch64
+            runner: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[build]"
+
+      - name: Build binary
+        run: bash scripts/build-binary.sh
+        env:
+          MNEMOS_EXPECTED_PLATFORM: ${{ matrix.platform }}
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}
+          files: dist/mnemos-${{ matrix.platform }}
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@
 #   - lint:   ruff (the test the GitHub mirror has been failing on for days)
 #   - test:   pytest unit tests + integration tests against real Postgres + pgvector
 #   - build:  docker image build (publishing handled separately, see release-docker)
+#   - release: platform-native single-binary artifacts for tagged releases
 #
 # The integration job is the high-leverage win over the previous GitHub CI:
 # it runs the suite against a real pgvector-enabled Postgres so the FakePool
@@ -34,6 +35,7 @@ stages:
   - lint
   - test
   - build
+  - release
 
 # ---- lint --------------------------------------------------------------
 
@@ -353,3 +355,44 @@ build:docker:
     - if: $CI_COMMIT_BRANCH == "master"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_TAG
+
+# ---- release -----------------------------------------------------------
+
+.release_binary_template:
+  stage: release
+  before_script:
+    - pip install --cache-dir=.cache/pip -e ".[build]"
+  script:
+    - bash scripts/build-binary.sh
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"
+    paths:
+      - dist/mnemos-$MNEMOS_EXPECTED_PLATFORM
+    expire_in: 2 weeks
+  rules:
+    - if: $CI_COMMIT_TAG
+      allow_failure: false
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      allow_failure: true
+    - when: never
+
+release:linux-x86_64:
+  extends: .release_binary_template
+  variables:
+    MNEMOS_EXPECTED_PLATFORM: linux-x86_64
+  tags:
+    - argos
+
+release:linux-aarch64:
+  extends: .release_binary_template
+  variables:
+    MNEMOS_EXPECTED_PLATFORM: linux-aarch64
+  tags:
+    - ultra-podman-arm64
+
+release:macos-aarch64:
+  extends: .release_binary_template
+  variables:
+    MNEMOS_EXPECTED_PLATFORM: macos-aarch64
+  tags:
+    - ultra-native

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ You can treat MNEMOS like a memory storage provider if you want — `POST /v1/me
 
 The current release line is **v3.5.x**. **v3.5.0 shipped on 2026-04-28** with audit-driven hardening, uniform owner+namespace tenancy, webhook retry and outbox repairs, the federation compound-cursor tie-breaker, MCP transport parity, faithful OpenAI-compatible gateway controls, and the PostgreSQL streaming-replication doctrine. **v3.5.1 is the 2026-04-28 documentation-triage patch**: no product behavior changes, just version metadata and documentation reconciliation. The active built-in compression stack is **APOLLO + ARTEMIS**.
 
+## Quick install — single binary
+
+For edge and dev hosts, download the matching binary from the
+[MNEMOS releases page](https://github.com/mnemos-os/mnemos/releases):
+
+```bash
+chmod +x mnemos-linux-x86_64
+sudo mv mnemos-linux-x86_64 /usr/local/bin/mnemos
+mnemos install --profile edge
+mnemos serve --profile edge
+```
+
+The v4.0 binary artifacts bundle Python, MNEMOS runtime dependencies, sqlite-vec,
+and the migration chain. No host Python or `pip install` is required. See
+[`docs/SINGLE_BINARY.md`](./docs/SINGLE_BINARY.md) for platform-specific
+filenames, macOS quarantine notes, limitations, and build-from-source
+instructions.
+
 ## Works with
 
 MNEMOS is designed to be the memory layer for the agentic tooling you already use — not a replacement for it. We interoperate on purpose, over three mechanisms, so there is no language lock-in and no pressure to rewrite your agent around us.

--- a/docs/SINGLE_BINARY.md
+++ b/docs/SINGLE_BINARY.md
@@ -1,0 +1,113 @@
+# MNEMOS Single-Binary Distribution
+
+MNEMOS v4.0 publishes platform-native `mnemos` executables that bundle the
+Python interpreter, runtime dependencies, and the sqlite-vec native extension.
+Operators can copy one file onto an edge host, mark it executable, and start the
+service without installing Python or running `pip`.
+
+## Why Single-Binary
+
+The single-binary build supports a zero-install edge appliance pattern:
+
+- Drop `mnemos-linux-aarch64` on a Pi-class Linux host.
+- Drop `mnemos-macos-aarch64` on an Apple Silicon laptop.
+- Drop `mnemos-linux-x86_64` on an Intel Linux dev box or appliance.
+- Use the same CLI shape as the Python package: `mnemos install`,
+  `mnemos serve`, `mnemos health`, and the import/export helpers.
+
+This is meant for operators who want the `edge` or `dev` profiles with no host
+Python lifecycle to manage. Termux-style hosts need a matching Linux ABI; the
+v4.0 official matrix builds glibc Linux and macOS artifacts, not Android-native
+Termux binaries.
+
+## Download
+
+Download the binary for your platform from the MNEMOS releases page:
+
+https://github.com/mnemos-os/mnemos/releases
+
+Published artifacts:
+
+- `mnemos-linux-x86_64`
+- `mnemos-linux-aarch64`
+- `mnemos-macos-aarch64`
+
+## Install
+
+Linux x86_64:
+
+```bash
+chmod +x mnemos-linux-x86_64
+sudo mv mnemos-linux-x86_64 /usr/local/bin/mnemos
+mnemos version
+```
+
+Linux aarch64:
+
+```bash
+chmod +x mnemos-linux-aarch64
+sudo mv mnemos-linux-aarch64 /usr/local/bin/mnemos
+mnemos version
+```
+
+macOS Apple Silicon:
+
+```bash
+chmod +x mnemos-macos-aarch64
+sudo mv mnemos-macos-aarch64 /usr/local/bin/mnemos
+mnemos version
+```
+
+If macOS Gatekeeper marks the downloaded file as quarantined, remove the
+download quarantine attribute before running it:
+
+```bash
+xattr -d com.apple.quarantine /usr/local/bin/mnemos
+```
+
+## First Run
+
+For an all-in-one SQLite edge node:
+
+```bash
+mnemos install --profile edge
+mnemos serve --profile edge
+```
+
+`mnemos install --profile edge` writes the local configuration and creates the
+SQLite database. The binary includes the SQLite migration chain and sqlite-vec,
+so first-run initialization does not need a source checkout.
+
+For a development node:
+
+```bash
+mnemos install --profile dev
+mnemos serve --profile dev
+```
+
+For a shared production service, use the `server` profile with PostgreSQL and
+Redis. The single binary can run the server profile too, but extension-heavy
+deployments are usually easier to operate from the package or container image.
+
+## Limitations
+
+- The artifact bundles a Python interpreter and runtime dependencies, so expect
+  a binary around 80 MB depending on platform and dependency wheel contents.
+- PyInstaller cannot cross-compile these artifacts. Each platform is built
+  natively on matching hardware.
+- A MNEMOS service running from the binary cannot `pip install` Python plugins
+  into itself. Use the `server` profile from a normal Python environment or a
+  container image when you need runtime extensibility.
+- The official v4.0 matrix does not include macOS x86_64 or Windows.
+
+## Build From Source
+
+From a clean checkout on the target platform:
+
+```bash
+python -m pip install -e ".[build]"
+bash scripts/build-binary.sh
+```
+
+The script writes `dist/mnemos-{platform}`, verifies `mnemos version`, and runs
+`mnemos health` if `MNEMOS_BASE` points at a reachable MNEMOS instance.

--- a/mnemos.spec
+++ b/mnemos.spec
@@ -1,0 +1,135 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+"""PyInstaller one-file build for the platform-native mnemos binary."""
+
+import os
+import platform
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+
+ENTRY_POINT = "mnemos.cli.main:app"
+ROOT = Path(SPECPATH).resolve() if "SPECPATH" in globals() else Path(__file__).resolve().parent
+DOCS_MAX_BUNDLE_BYTES = 5 * 1024 * 1024
+
+
+def _detect_platform() -> str:
+    override = os.environ.get("MNEMOS_BINARY_PLATFORM", "").strip()
+    if override:
+        return override
+
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux" and machine in {"x86_64", "amd64"}:
+        return "linux-x86_64"
+    if system == "linux" and machine in {"aarch64", "arm64"}:
+        return "linux-aarch64"
+    if system == "darwin" and machine == "arm64":
+        return "macos-aarch64"
+    raise SystemExit(f"Unsupported PyInstaller host platform: {system}-{machine}")
+
+
+def _files_matching(pattern: str, dest: str) -> list[tuple[str, str]]:
+    return [(str(path), dest) for path in sorted(ROOT.glob(pattern)) if path.is_file()]
+
+
+def _tree_size(root: Path) -> int:
+    if not root.exists():
+        return 0
+    return sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
+
+
+def _files_under(root: Path, dest: str) -> list[tuple[str, str]]:
+    if not root.exists():
+        return []
+    dest_root = Path(dest)
+    return [
+        (str(path), str(dest_root / path.relative_to(root).parent))
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    ]
+
+
+def _write_entry_script() -> Path:
+    entry_dir = ROOT / "build" / "pyinstaller-entry"
+    entry_dir.mkdir(parents=True, exist_ok=True)
+    entry_script = entry_dir / "mnemos_entry.py"
+    module_name, app_name = ENTRY_POINT.split(":", 1)
+    entry_script.write_text(
+        f"from {module_name} import {app_name}\n\n"
+        "if __name__ == '__main__':\n"
+        f"    {app_name}()\n",
+        encoding="utf-8",
+    )
+    return entry_script
+
+
+BINARY_PLATFORM = _detect_platform()
+BINARY_NAME = f"mnemos-{BINARY_PLATFORM}"
+
+# PyInstaller hiddenimports use importable module names. The sqlite-vec
+# distribution exposes the sqlite_vec module plus a native vec0 extension.
+HIDDEN_IMPORTS = [
+    "sqlite_vec",
+    "aiosqlite",
+    "asyncpg",
+    "redis",
+    "fastapi",
+    "uvicorn",
+    "starlette",
+    "pydantic",
+    "pydantic_settings",
+    "typer",
+    "click",
+    "openai",
+    "anthropic",
+    "google.genai",
+    "httpx",
+]
+
+datas = []
+datas += _files_matching("db/migrations*.sql", "db")
+datas += _files_matching("db/migrations_sqlite/*.sql", "db/migrations_sqlite")
+if _tree_size(ROOT / "docs") <= DOCS_MAX_BUNDLE_BYTES:
+    datas += _files_under(ROOT / "docs", "docs")
+datas += collect_data_files("sqlite_vec")
+
+binaries = []
+binaries += collect_dynamic_libs("sqlite_vec")
+
+a = Analysis(
+    [str(_write_entry_script())],
+    pathex=[str(ROOT)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=HIDDEN_IMPORTS,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=2,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name=BINARY_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=True,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ Repository = "https://github.com/mnemos-os/mnemos"
 Documentation = "https://github.com/mnemos-os/mnemos/blob/master/README.md"
 
 [project.optional-dependencies]
+build = ["pyinstaller>=6.0", "sqlite-vec"]
 docling = ["docling>=2.5.0", "docling-core>=2.0.0", "pillow>=10.0.0"]
 # OpenTelemetry tracing. Without this extra, `install_tracing()` is a
 # no-op and the tracing middleware passes through unchanged. Install

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v pyinstaller >/dev/null 2>&1; then
+  echo "ERROR: pyinstaller is required. Install with: pip install -e '.[build]'" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+detect_platform() {
+  local kernel machine
+  kernel="$(uname -s)"
+  machine="$(uname -m)"
+
+  case "${kernel}:${machine}" in
+    Linux:x86_64|Linux:amd64)
+      printf '%s\n' "linux-x86_64"
+      ;;
+    Linux:aarch64|Linux:arm64)
+      printf '%s\n' "linux-aarch64"
+      ;;
+    Darwin:arm64)
+      printf '%s\n' "macos-aarch64"
+      ;;
+    *)
+      echo "ERROR: unsupported build host platform: ${kernel} ${machine}" >&2
+      exit 2
+      ;;
+  esac
+}
+
+PLATFORM="${MNEMOS_BINARY_PLATFORM:-$(detect_platform)}"
+if [[ -n "${MNEMOS_EXPECTED_PLATFORM:-}" && "${PLATFORM}" != "${MNEMOS_EXPECTED_PLATFORM}" ]]; then
+  echo "ERROR: expected ${MNEMOS_EXPECTED_PLATFORM} build host, detected ${PLATFORM}" >&2
+  exit 2
+fi
+BINARY="dist/mnemos-${PLATFORM}"
+
+mkdir -p dist
+rm -f "${BINARY}"
+
+echo "[build-binary] building ${BINARY}"
+export MNEMOS_BINARY_PLATFORM="${PLATFORM}"
+export PYTHONOPTIMIZE=2
+pyinstaller --clean --noconfirm --distpath dist --workpath build mnemos.spec
+
+if [[ ! -x "${BINARY}" ]]; then
+  echo "ERROR: expected executable not found at ${BINARY}" >&2
+  exit 3
+fi
+
+echo "[build-binary] verifying version command"
+"./${BINARY}" version
+
+if [[ -n "${MNEMOS_BASE:-}" ]]; then
+  echo "[build-binary] running health smoke against ${MNEMOS_BASE}"
+  "./${BINARY}" health
+else
+  echo "[build-binary] MNEMOS_BASE not set; skipping health smoke"
+fi
+
+echo "[build-binary] built ./${BINARY}"

--- a/scripts/runners/ULTRA_SETUP.md
+++ b/scripts/runners/ULTRA_SETUP.md
@@ -1,0 +1,119 @@
+# ULTRA GitLab Runner Setup
+
+ULTRA provides the two non-Intel binary release paths for v4.0:
+
+- `ultra-native`: native macOS arm64 runner for `mnemos-macos-aarch64`
+- `ultra-podman-arm64`: arm64 Linux runner backed by Podman for
+  `mnemos-linux-aarch64`
+
+The GitLab release jobs are critical on tag pipelines. Register both runners
+against the MNEMOS project or group before cutting the v4.0 GA tag.
+
+## Prerequisites
+
+Install on ULTRA:
+
+```bash
+brew install gitlab-runner podman python@3.11
+python3.11 -m pip install --upgrade pip
+podman machine init --cpus 6 --memory 8192 --disk-size 80
+podman machine start
+```
+
+Confirm native tools:
+
+```bash
+uname -sm
+python3.11 --version
+podman run --rm --arch arm64 python:3.11-slim python -c 'import platform; print(platform.machine())'
+```
+
+## Cache Placement
+
+Use persistent caches outside transient build directories:
+
+- pip cache: `/Users/gitlab-runner/.cache/pip`
+- Cargo cache: `/Users/gitlab-runner/.cargo`
+- Podman volumes: `/Users/gitlab-runner/.local/share/containers`
+
+Cargo is not part of the MNEMOS build script, but Python wheels can pull Rust
+build backends when prebuilt wheels are unavailable. Keeping the Cargo cache
+warm prevents tag builds from paying that cost repeatedly.
+
+## Native macOS Runner
+
+Use the GitLab registration token from the project or group runner settings.
+Do not commit the token; paste it only during runner registration.
+
+```bash
+sudo gitlab-runner register \
+  --url "https://gitlab.com" \
+  --registration-token "<GITLAB_RUNNER_REGISTRATION_TOKEN>" \
+  --description "ULTRA native macOS arm64" \
+  --executor "shell" \
+  --tag-list "ultra-native" \
+  --run-untagged="false" \
+  --locked="true"
+```
+
+Expected `config.toml` shape:
+
+```toml
+[[runners]]
+  name = "ULTRA native macOS arm64"
+  executor = "shell"
+  tags = ["ultra-native"]
+  [runners.cache]
+    MaxUploadedArchiveSize = 0
+```
+
+The shell profile for the runner user should put Python 3.11 first on PATH:
+
+```bash
+export PATH="/opt/homebrew/bin:/opt/homebrew/opt/python@3.11/bin:$PATH"
+export PIP_CACHE_DIR="$HOME/.cache/pip"
+export CARGO_HOME="$HOME/.cargo"
+```
+
+## Linux arm64 Podman Runner
+
+The `ultra-podman-arm64` runner should execute jobs inside an arm64 Linux
+container, not on the macOS host. Reuse the existing Podman runner environment
+used for Rust builds and adapt the image to Python 3.11.
+
+Register the runner:
+
+```bash
+sudo gitlab-runner register \
+  --url "https://gitlab.com" \
+  --registration-token "<GITLAB_RUNNER_REGISTRATION_TOKEN>" \
+  --description "ULTRA Podman Linux arm64" \
+  --executor "custom" \
+  --tag-list "ultra-podman-arm64" \
+  --run-untagged="false" \
+  --locked="true"
+```
+
+The custom executor must start an arm64 Linux container with the project
+workspace mounted and Python 3.11 available. The job itself runs:
+
+```bash
+pip install --cache-dir=.cache/pip -e ".[build]"
+bash scripts/build-binary.sh
+```
+
+Validate the executor before tag day:
+
+```bash
+podman run --rm --arch arm64 -v "$PWD:/workspace:Z" -w /workspace python:3.11-slim \
+  bash -lc 'python -m pip install -e ".[build]" && bash scripts/build-binary.sh'
+```
+
+## Release Job Tags
+
+The GitLab jobs expect these runner tags:
+
+- `release:linux-aarch64` -> `ultra-podman-arm64`
+- `release:macos-aarch64` -> `ultra-native`
+
+ARGOS owns `release:linux-x86_64` through its `argos` runner tag.

--- a/tests/test_binary_build.py
+++ b/tests/test_binary_build.py
@@ -1,0 +1,61 @@
+import ast
+import importlib
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_build_extra_includes_pyinstaller_and_sqlite_vec():
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    build_extra = pyproject["project"]["optional-dependencies"]["build"]
+
+    assert "pyinstaller>=6.0" in build_extra
+    assert "sqlite-vec" in build_extra
+
+
+def test_mnemos_spec_parses_and_targets_cli_app():
+    spec_path = REPO_ROOT / "mnemos.spec"
+    source = spec_path.read_text(encoding="utf-8")
+
+    ast.parse(source, filename=str(spec_path))
+
+    assert 'ENTRY_POINT = "mnemos.cli.main:app"' in source
+    assert "optimize=2" in source
+    assert "strip=True" in source
+    assert '"sqlite_vec"' in source
+    assert '"google.genai"' in source
+    assert '"db/migrations_sqlite"' in source
+    assert 'name=BINARY_NAME' in source
+    assert 'collect_dynamic_libs("sqlite_vec")' in source
+
+
+def test_entrypoint_module_exports_typer_app():
+    module = importlib.import_module("mnemos.cli.main")
+
+    assert hasattr(module, "app")
+
+
+def test_build_binary_script_shebang_and_missing_pyinstaller_exit(tmp_path):
+    script = REPO_ROOT / "scripts" / "build-binary.sh"
+    first_line = script.read_text(encoding="utf-8").splitlines()[0]
+
+    assert first_line == "#!/usr/bin/env bash"
+
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "pyinstaller is required" in result.stderr


### PR DESCRIPTION
Last v4.0 slice. Produces platform-native single-binary mnemos executables bundling Python interpreter + sqlite-vec extension + migration chain.

Build matrix (native, no cross-compile):
- linux-x86_64    ARGOS gitlab-runner
- linux-aarch64   ULTRA Podman gitlab-runner  
- macos-aarch64   ULTRA native gitlab-runner

Files:
- mnemos.spec (135 LOC) — pyinstaller spec, one-file mode, bundles migrations
- scripts/build-binary.sh (65 LOC) — host-platform-detecting build wrapper
- .gitlab-ci.yml — 3 release jobs, parallel, tag-triggered, allow_failure on master
- .github/workflows/release.yml (NEW) — GH Actions equivalent; tag push attaches binaries to release
- docs/SINGLE_BINARY.md (113 LOC) — operator-facing distribution doc
- scripts/runners/ULTRA_SETUP.md (119 LOC) — runner registration guide
- tests/test_binary_build.py — structural tests (does not run pyinstaller)
- README — quick-install section linking to SINGLE_BINARY.md

After this lands, v4.0 GA tag publishes 3 binary artifacts on the GitHub release alongside the pip wheel.

1055 passed (+4), ruff clean, 7 contracts kept. Authored-By: Codex