### PR TITLE
v4.0 doc-triage — comprehensive update for v4.0.0

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,7 +1,7 @@
 # MNEMOS API Documentation
 
 **Base URL**: `http://localhost:5002`
-**Version**: v3.5.x current; v3.5.0 shipped 2026-04-28, v3.5.1 is the 2026-04-28 documentation-triage patch
+**Version**: v4.0.0 current; shipped 2026-04-29
 **Format**: JSON
 
 ---
@@ -61,9 +61,11 @@ Liveness + readiness check (no auth required).
 ```json
 {
   "status": "healthy",
-  "timestamp": "2026-04-21T14:30:00.000Z",
+  "timestamp": "2026-04-29T14:30:00.000Z",
   "database_connected": true,
-  "version": "3.5.1"
+  "version": "4.0.0",
+  "profile": "edge",
+  "distillation_worker": "idle"
 }
 ```
 
@@ -92,13 +94,13 @@ Read behavior is symmetric across REST, gateway context, and MCP:
 non-root callers can read a memory when they are the owner, when the
 row is federated, when the Unix world-read bit is set, or when the
 Unix group-read bit is set for one of their groups. The shared helper
-is `read_visibility_predicate` (`api/visibility.py:40-96`). Writes
+is `read_visibility_predicate` (`mnemos/core/visibility.py`). Writes
 remain owner+namespace scoped.
 
 ### POST /v1/memories
 
 Create a memory. This writes the memory row and emits a transactional
-`memory.created` webhook event. Compression is operator-batched in v3.5.x:
+`memory.created` webhook event. Compression is operator-batched in v4.0:
 root users enqueue memories through `/admin/compression/enqueue` or
 `/admin/compression/enqueue-all`; the distillation worker then drains
 `memory_compression_queue`.
@@ -125,7 +127,7 @@ Update content, category, subcategory, metadata, or verbatim content.
 The update is owner+namespace scoped. If the version trigger detects a
 missing, NULL, or cross-memory branch HEAD, the API returns `409` with
 manual reconciliation guidance (`handle_trigger_pgerror` in
-`api/visibility.py:24-37`).
+`mnemos/core/visibility.py`).
 
 ### DELETE /v1/memories/{memory_id}
 
@@ -144,7 +146,7 @@ Semantic + keyword search.
 
 Search hits update `recall_count` and `last_recalled_at` in the background.
 `compression_applied` and `compression_metadata` are reserved response fields
-on `MemoryListResponse`; v3.5.x search responses set
+on `MemoryListResponse`; v4.0 search responses set
 `compression_applied=false`. Use `/v1/memories/rehydrate` to receive compressed
 variants when present, or `/v1/memories/{id}/compression-manifests` to inspect
 contest output.
@@ -159,7 +161,7 @@ contest output.
 
 ### DAG versioning (git-like)
 
-- `GET /v1/memories/{id}/versions` — version summaries on a branch, filtered per snapshot by `version_visibility_predicate` (`api/visibility.py:99-137`).
+- `GET /v1/memories/{id}/versions` — version summaries on a branch, filtered per snapshot by `version_visibility_predicate` (`mnemos/core/visibility.py`).
 - `GET /v1/memories/{id}/versions/{n}` — one version on a branch, filtered by that snapshot's own owner/namespace/permission mode.
 - `GET /v1/memories/{id}/diff` — diff between visible snapshots.
 - `POST /v1/memories/{id}/revert/{n}` — revert to version n. Main-branch revert updates the live row under the trigger after a live-row/main-HEAD drift guard; feature-branch revert inserts a new DAG row and leaves `memories` tracking main.
@@ -167,7 +169,7 @@ contest output.
 - `GET /v1/memories/{id}/commits/{commit}` — one visible commit by hash.
 - `GET /v1/memories/{id}/branches` — branch list. Non-root callers do not see branches whose head snapshot is invisible; corrupt heads are omitted and logged.
 - `POST /v1/memories/{id}/branch` — create a branch from main HEAD or a specified commit. The handler locks the parent memory row with `FOR SHARE` and uses `ON CONFLICT DO NOTHING RETURNING`; duplicate branch names return `409`.
-- `POST /v1/memories/{id}/merge` — merge source branch into target branch. Latest-wins is implemented; manual strategy returns not-implemented. Merge commits copy content/provenance from source and tenancy from target, and branch writers serialize on `_branch_advisory_lock_key` (`api/handlers/dag.py:21-40`).
+- `POST /v1/memories/{id}/merge` — merge source branch into target branch. Latest-wins is implemented; manual strategy returns not-implemented. Merge commits copy content/provenance from source and tenancy from target, and branch writers serialize on `_branch_advisory_lock_key` (`mnemos/api/routes/dag.py`).
 
 See `ANTI_MEMORY_POISONING.md` for the rationale and drift-detection
 workflow.
@@ -192,6 +194,20 @@ standard across memory and entity surfaces in v3.2-v3.5.
 
 ## Consultations (GRAEAE)
 
+`ConsultationRequest.mode` is a literal string. The seven accepted modes are:
+
+| Mode | Type | Meaning |
+|---|---|---|
+| `auto` | routing strategy | Use the engine default for the task type. |
+| `local` | routing strategy | Prefer local/self-hosted muses. |
+| `external` | routing strategy | Prefer external provider muses. |
+| `all` | routing strategy | Fan out to every available muse. |
+| `single` | reasoning shape | Select one highest-weighted muse for a fast or low-cost answer. |
+| `debate` | reasoning shape | Run a two-round multi-muse debate and synthesize the result. |
+| `majority` | reasoning shape | Query up to three muses and report whether quorum was reached. |
+
+Unknown modes are rejected by request validation with HTTP 422.
+
 ### POST /v1/consultations
 
 Run a multi-LLM consensus consultation. Writes a tamper-evident audit row.
@@ -201,10 +217,20 @@ Run a multi-LLM consensus consultation. Writes a tamper-evident audit row.
 {
   "prompt": "Design a microservices architecture.",
   "task_type": "architecture_design",
-  "mode": "auto",
+  "mode": "debate",
   "context": "optional context to prepend",
-  "inject_memories": true
+  "limit_chars": 12000,
+  "format": "full",
+  "models": ["openai/gpt-5.2-chat-latest"],
+  "providers": null,
+  "tier": null
 }
+```
+
+Schema summary:
+
+```python
+mode: Literal["auto", "local", "external", "all", "single", "debate", "majority"] = "auto"
 ```
 
 **Response** includes: `id`, `consensus_response`, `consensus_score`,
@@ -279,7 +305,7 @@ Stateful multi-turn chat with memory injection at turn boundaries.
 
 ## MORPHEUS
 
-Dream-state generation is operator-triggered and append-only in v3.5.x.
+Dream-state generation is operator-triggered and append-only in v4.0.
 Generated memories are tagged with `morpheus_run_id`; rollback deletes
 generated memories for that run.
 
@@ -359,8 +385,8 @@ MNEMOS Portability Format (MPF) is the native import/export envelope.
   `preserve_owner=true` is for authoritative restore/migration; non-root
   imports are scoped to the caller's owner+namespace.
 
-CLI helpers: `tools/memory_export.py`, `tools/memory_import.py`, and
-`tools/mpf_validate.py`.
+CLI helpers: `mnemos export`, `mnemos import`, `mnemos validate-mpf`, and the
+modules under `mnemos/tools/`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to MNEMOS are documented here.
 
+## [4.0.0] — 2026-04-29
+
+Major refactor + multi-backend persistence + multi-worker support release.
+
+### Added
+
+- Persistence abstraction (`PersistenceBackend` ABC) plus SQLite implementation
+  using sqlite-vec / FTS5 / JSON1 / WAL.
+- Deployment profiles: server (Postgres + Redis + multi-worker), edge
+  (SQLite single-worker), dev (SQLite + DEBUG).
+- Multi-worker support via Redis-backed circuit breaker / rate limiter /
+  concurrency limiter; in-process fallback preserved.
+- Single-binary distribution via pyinstaller for linux-x86_64,
+  linux-aarch64, macos-aarch64 with sqlite-vec bundled.
+- Unified `mnemos` CLI: serve / install / worker / export / import /
+  consult / health / version.
+- 7 import-linter contracts enforce package boundaries in CI.
+- Pydantic Settings singleton replaces 105 ad-hoc `os.environ.get` calls;
+  CI bans `os.environ` outside `core.config` + `installer`.
+- 3 new GRAEAE reasoning modes: single, debate, majority.
+
+### Changed
+
+- Codebase restructured into `mnemos/` package (`api/routes` / `core` / `db` /
+  `domain` / `mcp` / `webhooks` / `workers` / `hooks` / `installer` / `tools` /
+  `cli`).
+- `portability.py` (2679 LOC) split into 10 focused files + repository
+  layer; route file is now 82 LOC.
+- `openai_compat.py` (1366 LOC) -> 7 focused files; route file 270 LOC.
+- `mcp_tools.py` (1278 LOC) -> 6 per-domain modules.
+- `webhook_dispatcher.py` (1748 LOC) -> 11 modules per concern.
+- `workers=1` pin removed; multi-worker safe with Redis.
+
+### Fixed
+
+- GRAEAE empty-body bug (HTTP 200 + 0 bytes on short prompts under
+  `arch_design` with no mode field).
+- Unknown mode values now 422-rejected (was silent fallthrough).
+
 ## [3.5.1] — 2026-04-28 (doc-triage patch)
 
 Documentation and version-state reconciliation only. No product behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ PRs without DCO sign-off on every commit will be asked to amend
 
 - Use a feature branch for non-trivial changes.
 - Keep commits focused and reviewable; split large changes.
+- Install from source through the v4 package entry points:
+
+```bash
+python -m pip install -e ".[dev,sqlite]"
+mnemos install --profile dev
+mnemos serve --profile dev
+```
+
 - Run the default test suite before opening a PR:
 
 ```bash
@@ -91,6 +99,35 @@ ruff check . --extend-exclude .venv-ci
 - For changes touching tenancy, DAG history, triggers, import/export, or
   auth, include focused regression tests and document the expected
   operator behavior for 404 vs 409 vs 403 outcomes.
+
+### Building single-binary artifacts
+
+The v4.0 binary release is built with PyInstaller. Use the `build` extra from a
+clean checkout on the target platform:
+
+```bash
+python -m pip install -e ".[build]"
+bash scripts/build-binary.sh
+```
+
+PyInstaller does not cross-compile these artifacts. Build linux-x86_64,
+linux-aarch64, and macos-aarch64 on matching hosts.
+
+### Multi-worker development
+
+The `dev` and `edge` profiles are intentionally single-worker SQLite profiles.
+For multi-worker work, use the `server` profile with Redis-backed shared state:
+
+```bash
+export MNEMOS_PROFILE=server
+export RATE_LIMIT_STORAGE_URI=redis://localhost:6379/1
+export MNEMOS_WORKERS=2
+mnemos serve --profile server
+```
+
+If `MNEMOS_WORKERS > 1` with `RATE_LIMIT_STORAGE_URI=memory://`, startup logs a
+warning because circuit-breaker, rate-limit, and concurrency state are only
+process-local.
 
 ## Guidelines
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # MNEMOS Deployment & Configuration Guide
 
-**Status**: v3.5.x current. v3.5.0 shipped 2026-04-28; v3.5.1 is the 2026-04-28 documentation-triage patch.
+**Status**: v4.0.0 current. v4.0.0 shipped 2026-04-29.
 
 ---
 
@@ -30,44 +30,37 @@ mnemos serve --profile dev
 ## Quick Start
 
 ### Prerequisites
-- PostgreSQL 12+ for the `server` profile, or SQLite for `edge`/`dev`
-- Python 3.10+
+- PostgreSQL 12+ and Redis for the `server` profile, or SQLite for `edge`/`dev`
+- Python 3.11+ when using the Python package; no host Python is required for the single-binary artifact
 - LLM provider API keys (Together AI or Groq free tier recommended)
 - (Optional) GPU or local inference endpoint for APOLLO's LLM fallback and self-hosted LLMs
 
 ### Installation
 
 ```bash
-# Clone repository
-git clone https://github.com/mnemos-os/mnemos.git
-cd mnemos
-
-# Copy environment template
-cp .env.example .env
-
-# Edit .env with your configuration
-nano .env
-
-# Install dependencies (with uv)
-uv pip install -r requirements.txt
-
-# Apply database migrations in canonical order
-python install.py
-
-# Start MNEMOS server
-export $(cat .env | grep -v '#' | xargs)
-python -m uvicorn api_server:app --host $MNEMOS_BIND --port $MNEMOS_PORT
+python -m pip install mnemos-os==4.0.0
+mnemos install --profile dev
+mnemos serve --profile dev
 ```
 
-The API will be available at `http://$MNEMOS_BIND:$MNEMOS_PORT`
+The API will be available at `http://localhost:5002`.
+
+For the no-Python edge path:
+
+```bash
+curl -L https://github.com/mnemos-os/mnemos/releases/download/v4.0.0/mnemos-linux-x86_64 -o mnemos
+chmod +x mnemos
+./mnemos install --profile edge
+./mnemos serve --profile edge
+```
 
 ---
 
 ## Runtime Scaling
 
-MNEMOS runs single-worker by default with `RATE_LIMIT_STORAGE_URI=memory://`.
-Horizontal scaling is supported when Redis backs shared rate-limit and
-circuit-breaker state; see `docs/SCALING.md`.
+MNEMOS runs one worker by default. Horizontal scaling is supported when Redis
+backs shared rate-limit, circuit-breaker, and concurrency state; see
+`docs/SCALING.md`.
 
 ---
 
@@ -96,7 +89,7 @@ For HTTP/SSE connectors, prefer per-user token issuance:
 ```bash
 MNEMOS_MCP_TOKENS=alice:<alice-mnemos-api-key>,bob:<bob-mnemos-api-key>
 MNEMOS_BASE=http://mnemos:5002
-python3 mcp_http_server.py --host 127.0.0.1 --port 5004
+mnemos serve mcp-http --host 127.0.0.1 --port 5004
 ```
 
 Each `MNEMOS_MCP_TOKENS` entry is `user_id:token`. The token is accepted at the
@@ -258,7 +251,7 @@ export GPU_PROVIDER_HOST=http://localhost
 export GPU_PROVIDER_PORT=11434
 
 # Start MNEMOS
-python -m uvicorn api_server:app
+mnemos serve --profile dev
 ```
 
 **Option 2: vLLM (CPU or GPU)**
@@ -276,7 +269,7 @@ export GPU_PROVIDER_HOST=http://localhost
 export GPU_PROVIDER_PORT=8000
 
 # Start MNEMOS
-python -m uvicorn api_server:app
+mnemos serve --profile dev
 ```
 
 **The real question:** Do you need any of this? **Probably not.** Just use Together AI or Groq (free tier).
@@ -284,7 +277,7 @@ python -m uvicorn api_server:app
 export TOGETHER_API_KEY=your_key
 export GROQ_API_KEY=your_key
 
-python -m uvicorn api_server:app
+mnemos serve --profile dev
 # That's it. No GPU, no inference server, no hassle.
 ```
 
@@ -309,13 +302,13 @@ existing volumes.
 Postgres image init scripts under `/docker-entrypoint-initdb.d` only run
 when the data directory is first initialized. They do not re-run when an
 existing `postgres_data` volume starts with newer migration files mounted.
-For v3.5.x, `docker-compose.yml` and `docker-compose.staging.yml`
+For current installs, `docker-compose.yml` and `docker-compose.staging.yml`
 therefore include `postgres-upgrade`, which waits for Postgres health and
-then applies the v3.5 upgrade tail before the MNEMOS service starts.
+then applies the ordered migration tail before the MNEMOS service starts.
 
-The canonical order lives in `install.py` and `installer/db.py`; compose must
-mirror those loaders. Current v3.5.x upgrade tail is prefixes 24-38, in
-order:
+The canonical order lives in `mnemos/installer/db.py`; compose must mirror that
+loader. The v3.5 upgrade tail remains relevant for pre-v4 databases and is
+followed by the v4 profile/persistence additions where needed.
 `trigger-same-memory-parent`, `rls-group-select-unix-bits`,
 `webhook-retry-terminal-state`, `webhook-attempt-lease`,
 `webhook-writer-revision`, `webhook-status-updated-at`,
@@ -342,8 +335,7 @@ read-only standbys promoted on failure.
 
 Federation is for genuinely-remote replication scenarios — multi-site
 deployments, multi-org curated feeds, developer laptop replicas with
-intermittent connectivity, and v4 deployment profiles with planned
-SQLite-based laptop/local-replica mode.
+intermittent connectivity, and v4 SQLite-backed edge profiles.
 
 | Mode | Use when | Latency model | Write model | Layer | Configuration |
 |------|----------|---------------|-------------|-------|---------------|
@@ -364,19 +356,19 @@ promotion, and HAProxy/PgBouncer-style writer endpoints.
 MPF portability is available through `GET /v1/export` and `POST /v1/import`.
 Use root plus `preserve_owner=true` only for authoritative restores or
 migrations; non-root imports are scoped to the caller's owner+namespace. The
-CLI helpers are `tools/memory_export.py`, `tools/memory_import.py`, and
-`tools/mpf_validate.py`.
+CLI helpers are available through `mnemos export`, `mnemos import`, and the
+modules under `mnemos/tools/`.
 
 MORPHEUS dream-state runs are operator-triggered through
 `POST /admin/morpheus/runs` and inspected through `/v1/morpheus/runs*`.
-Runs are synchronous in v3.5.x, append generated memories tagged with
+Runs are synchronous in v4.0, append generated memories tagged with
 `morpheus_run_id`, and roll back by deleting memories from that run.
 
 Compression is operator-batched. Use `POST /admin/compression/enqueue` or
 `POST /admin/compression/enqueue-all` to feed the contest worker. The active
 built-in engines are APOLLO and ARTEMIS; the retired LETHE / ANAMNESIS /
 ALETHEIA engines and the legacy session compression columns are not part of
-the v3.5.x runtime.
+the v4.0 runtime.
 
 ---
 
@@ -512,14 +504,14 @@ curl -X DELETE http://localhost:5002/v1/sessions/{id} \
 sudo -u postgres createdb mnemos
 sudo -u postgres createuser -P mnemos  # Enter password interactively
 
-# Run migrations in canonical order
-python install.py
+# Run migrations in canonical order through the installer
+mnemos install --profile server
 
-# Existing DBs on v3.4.1 must apply v3.5 migrations 24-38 in order.
+# Existing DBs on v3.4.1 must apply v3.5 migrations 24-38 in order before the v4 tail.
 # The compose one-shot is the canonical example for existing volumes:
 docker compose up postgres-upgrade
 
-# For non-compose installs, follow the same order as install.py / installer/db.py:
+# For non-compose installs, follow the same order as mnemos/installer/db.py:
 psql -U mnemos -d mnemos -v ON_ERROR_STOP=1 \
   -f db/migrations_v3_5_trigger_same_memory_parent.sql \
   -f db/migrations_v3_5_rls_group_select_unix_bits.sql \
@@ -582,9 +574,9 @@ Type=notify
 User=mnemos
 WorkingDirectory=/opt/mnemos
 EnvironmentFile=/opt/mnemos/.env
-ExecStart=/usr/bin/python3 -m uvicorn api_server:app \
-  --host ${MNEMOS_BIND} \
-  --port ${MNEMOS_PORT}
+ExecStart=/opt/mnemos/venv/bin/mnemos serve --profile ${MNEMOS_PROFILE:-server} \
+  --host ${MNEMOS_BIND:-0.0.0.0} \
+  --port ${MNEMOS_PORT:-5002}
 Restart=always
 RestartSec=10
 
@@ -663,7 +655,7 @@ psql -d mnemos -c "REINDEX TABLE memories;"
 
 ### 409: Memory branch state is inconsistent
 
-v3.5.x maps trigger SQLSTATE `MN001` to HTTP 409 when
+v4.0 keeps the v3.5 trigger behavior: SQLSTATE `MN001` maps to HTTP 409 when
 `memory_branches` is missing, has `NULL head_version_id`, or points at a
 `memory_versions` row from another memory. Inspect and reconcile the
 branch rows before retrying:

--- a/EVOLUTION.md
+++ b/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 The version numbers on releases are tidy. The actual path was not. This
 document is the honest version — decisions, refactors, mistakes, and the
-reasoning that got us from the original prototype to the current v3.5.x release line. If you
+reasoning that got us from the original prototype to the current v4.0.0 release line. If you
 are considering MNEMOS for your own stack, you should know where it came
 from; if you are contributing, you should know which doors have been closed
 and why.
@@ -40,11 +40,14 @@ codebase took along the way.
 | 2026-04-26 | **v3.5.0 slice 2** — memory-read tenancy and DAG-integrity hardening (`d42c475`). Shared read visibility moves into `api/visibility.py`; version history becomes per-snapshot visible; merge/revert/branch writers serialize around branch heads; the v3.5 trigger raises `MN001` rather than accepting missing, NULL, or cross-memory branch heads. |
 | 2026-04-28 | **v3.5.0 GA** — the hardening branch ships: webhook retry leases/outbox discipline, federation compound cursor, consultation audit scoping, MCP stdio/HTTP registry parity, faithful OpenAI-compatible gateway behavior, PostgreSQL streaming-replication doctrine, namespace-uniform state/journal/entities/sessions/consultations, bulk webhook parity, compression cleanup, and audit closure. |
 | 2026-04-28 | **v3.5.1** — documentation-triage patch. Version metadata moves to 3.5.1 and docs are reconciled with the shipped v3.5.x state; no product behavior changes from v3.5.0. |
+| 2026-04-29 | **v4.0.0** — structural refactor release. The codebase becomes a coherent `mnemos/` package; `PersistenceBackend` lands with Postgres and SQLite implementations; `server`, `edge`, and `dev` profiles make Pi/laptop/Termux and production deployments first-class; Redis-backed reliability primitives remove the production `workers=1` pin; PyInstaller single-binary artifacts ship for Linux x86_64, Linux aarch64, and macOS aarch64. |
 
 Roughly five months. One developer with three reviewers (Codex, GRAEAE
 multi-LLM consensus, occasional Sonnet / Opus passes for design). Several
 rounds of audit-driven rework — every major surface in v3.0.0-beta has had
-its seams moved at least once, on evidence rather than vibes. The point of
+its seams moved at least once, on evidence rather than vibes. v4.0 is the point
+where those seams became explicit package boundaries instead of conventions.
+The point of
 the timeline is not the version count; it's that nothing here is a
 two-week-sprint prototype, and every architectural seam has paid for
 itself in a real failure mode at least once.
@@ -598,11 +601,10 @@ is, the list of non-obvious calls that proved out:
 Equally important — the calls that were correct at the time but would
 be made differently today:
 
-1. **Single-writer assumption.** The app currently requires `workers=1`
-   because the circuit breakers, rate limiters, and semaphores are
-   in-process state. A v3.1+ move to a shared state backend (Redis or
-   the DB itself) would let us scale horizontally. Today it's a scale
-   ceiling we accept.
+1. **Single-writer assumption.** v3.x required `workers=1` because the
+   circuit breakers, rate limiters, and semaphores were in-process state.
+   v4.0 resolved this for server deployments with Redis-backed coordination,
+   while keeping the in-process fallback for edge/dev.
 2. **OAuth state via Starlette `SessionMiddleware`.** Works, but the
    signing key regenerates on restart if `MNEMOS_SESSION_SECRET` is
    unset. We warn about it loudly; we should probably refuse to start
@@ -610,8 +612,8 @@ be made differently today:
 3. **SQL migrations as sequential files rather than a migration tool.**
    Worked at v1 when there was one file. At v3 with eleven ordered
    files, we should probably move to Alembic or sqitch. The current
-   ordering is documented in `install.py` and `installer/db.py` but
-   that documentation is two places that must stay in sync.
+   ordering now lives in `mnemos/installer/db.py`, but sequential SQL files
+   still require discipline.
 4. **FakePool in the test harness.** Substring-match-on-SQL is
    fundamentally the wrong abstraction; it silently matches shorter
    patterns as prefixes of longer ones and we've been bitten by that
@@ -628,9 +630,9 @@ If you're here to contribute and want to understand the history:
 - Read `CHANGELOG.md` for what shipped.
 - Read this file for why, and what almost shipped and didn't.
 - The biggest "don't touch this without understanding why" areas are:
-  - **The audit chain lock** (`api/handlers/consultations.py::_write_audit_entry_on_conn`) — widening or narrowing the lock window changes both correctness and throughput. Don't adjust casually.
+  - **The audit chain lock** (`mnemos/api/routes/consultations.py::_write_audit_entry_on_conn`) — widening or narrowing the lock window changes both correctness and throughput. Don't adjust casually.
   - **The FK edge ON-DELETE choices** (`db/migrations_*.sql`) — each one is the result of a real design conversation about whether history survives deletion.
-  - **The SSRF validator** (`api/handlers/webhooks.py::validate_webhook_url`) — the block list and the async-resolve path have both been tightened in response to real concerns. Loosen carefully.
+  - **The SSRF validator** (`mnemos/webhooks/validation.py::validate_webhook_url`) — the block list and the async-resolve path have both been tightened in response to real concerns. Loosen carefully.
   - **The Greek names.** They look like whimsy from outside. From inside they are subsystem labels that appear in logs, tables, migrations, and code paths. Renaming one is a distributed refactor.
 
 ---

--- a/QUICK_START_REQUIREMENTS.md
+++ b/QUICK_START_REQUIREMENTS.md
@@ -1,12 +1,26 @@
 # MNEMOS Quick Start Requirements
 
-**Applies to**: current v3.5.x release line
-**TL;DR**: Python 3.11+, PostgreSQL 16, 8GB RAM, 50GB disk
+**Applies to**: current v4.0.0 release line
+**TL;DR**: Python 3.11+ for package installs; no host Python for single-binary.
+Use SQLite for `edge`/`dev`, or PostgreSQL 16 + Redis for `server`.
 **Full Details**: See `SYSTEM_REQUIREMENTS.md`
 
 ---
 
-## Bare Metal (Fastest to Deploy)
+## Single Binary (Fastest Edge Deploy)
+
+```bash
+curl -L https://github.com/mnemos-os/mnemos/releases/download/v4.0.0/mnemos-linux-x86_64 -o mnemos
+chmod +x mnemos
+./mnemos install --profile edge
+./mnemos serve --profile edge
+```
+
+**Total Time**: ~5 minutes
+
+---
+
+## Bare Metal Python Package
 
 ### Install (Ubuntu 22.04 LTS)
 
@@ -14,30 +28,30 @@
 # 1. Python (2 minutes)
 sudo apt update && sudo apt install -y python3.11 python3.11-venv python3.11-dev
 
-# 2. PostgreSQL with pgvector (5 minutes)
-sudo apt install -y postgresql-16 postgresql-16-pgvector postgresql-client
-
-# 3. System dependencies (1 minute)
+# 2. System dependencies (1 minute)
 sudo apt install -y git curl build-essential libpq-dev
 
-# 4. MNEMOS code (2 minutes)
-git clone https://github.com/mnemos-os/mnemos
-cd mnemos
+# 3. MNEMOS package (2 minutes)
+python3.11 -m venv ~/.venvs/mnemos
+source ~/.venvs/mnemos/bin/activate
+pip install mnemos-os==4.0.0
+
+# 4. SQLite-backed dev profile
+mnemos install --profile dev
+mnemos serve --profile dev
+```
+
+For a production `server` profile, add PostgreSQL + pgvector and Redis:
+
+```bash
+sudo apt install -y postgresql-16 postgresql-16-pgvector postgresql-client redis-server
 python3.11 -m venv venv
 source venv/bin/activate
-pip install -e .
-
-# 5. Database setup and migrations (1 minute)
-psql -U postgres -d postgres -c "CREATE USER mnemos_user WITH PASSWORD 'mnemos_local';"
-psql -U postgres -d postgres -c "CREATE DATABASE mnemos OWNER mnemos_user;"
-python install.py
-
-# 6. Configure (if install.py did not already write config)
-cp .env.example .env
-# Edit .env with your settings
-
-# 7. Run (30 seconds)
-python api_server.py
+pip install mnemos-os==4.0.0
+export MNEMOS_PROFILE=server
+export RATE_LIMIT_STORAGE_URI=redis://localhost:6379/1
+mnemos install --profile server
+mnemos serve --profile server
 ```
 
 **Total Time**: ~15 minutes
@@ -73,7 +87,7 @@ curl http://localhost:5002/health
 
 For existing Docker volumes, `docker compose up -d` also runs the
 one-shot `postgres-upgrade` service before MNEMOS starts. This applies
-the v3.5.x migration tail because Postgres initdb scripts do not rerun on
+the ordered migration tail because Postgres initdb scripts do not rerun on
 already-initialized volumes.
 
 ---
@@ -269,7 +283,7 @@ export MNEMOS_API_KEY=$(uuidgen)
 ```bash
 lsof -i :5002
 kill -9 <PID>
-# or use different port: MNEMOS_PORT=5003 python api_server.py
+# or use a different port: mnemos serve --profile dev --port 5003
 ```
 
 **"Connection timeout to api.together.ai"**
@@ -312,6 +326,6 @@ kill -9 <PID>
 
 ---
 
-**Version**: v3.5.x; v3.5.1 documentation-triage patch
+**Version**: v4.0.0
 **Updated**: 2026-04-28
 **Accuracy**: Production-verified

--- a/README.md
+++ b/README.md
@@ -4,53 +4,99 @@
 
 # MNEMOS + GRAEAE
 
-**A memory operating system for serious agentic work — not a memory-storage provider.**
-**The memory system for everyone. We interoperate.**
-**In daily production use since December 2025.**
+**MNEMOS v4.0.0 is the memory operating system for serious agentic work: a
+packaged FastAPI runtime, multi-backend persistence layer, GRAEAE reasoning bus,
+operator-audited compression stack, and CLI-first deployment surface.**
 
-The distinction matters. A *storage provider* gives you a place to put bytes. An *operating system* gives you named subsystems — a scheduler, a compressor, a process manager, a security layer, an auditor — that manage the full lifecycle of a resource the application no longer has to babysit.
+MNEMOS is not just a place to put bytes. It is a runtime of named subsystems that
+manage the full lifecycle of agent memory across providers, agents, and time
+horizons: **write, embed, search, compress, version, reason-over, audit,
+federate, export, import, and operate**.
 
-MNEMOS is the second thing. It is the operating system for agent memory: a runtime composed of named subsystems that cooperate to manage the full lifecycle of memory across multiple agents, providers, and time horizons — **write, embed, compress, version, reason-over, audit, federate, archive** — each one a first-class citizen of the runtime, not a feature bolted onto a vector store.
+## What MNEMOS Is
 
-- **MNEMOS** is the memory kernel and the overall system name. Storage, versioning, operator-batched compression, and lifecycle sit here.
-- **GRAEAE** is the reasoning bus — a multi-provider consensus layer that scores and selects across live LLM backends with a cryptographic audit chain on every decision.
-- **THE MOIRAI** is the compression subsystem. The current built-in stack is **APOLLO + ARTEMIS**, with a written receipt on every transformation.
-- A **self-maintaining model registry**, when the shipped sync timer is enabled, keeps itself current from provider APIs and Arena.ai Elo rankings, so the kernel knows what models exist, what they cost, and how good they currently are.
-- **Federation**, **webhooks**, **OAuth**, **RLS**, **DAG versioning**, and the **/v1/** REST surface are services built on top of that kernel, not retrofits onto a library.
+- **MNEMOS** is the memory kernel and the overall system name. Storage,
+  versioning, operator-batched compression, portability, and lifecycle sit here.
+- **GRAEAE** is the reasoning bus: a multi-provider routing and consensus layer
+  with routing-strategy modes (`auto`, `local`, `external`, `all`) and reasoning
+  shapes (`single`, `debate`, `majority`).
+- **THE MOIRAI** is the compression subsystem. The current built-in stack is
+  **APOLLO + ARTEMIS**, with a written receipt on every transformation.
+- A **self-maintaining model registry**, when the shipped sync timer is enabled,
+  keeps itself current from provider APIs and Arena.ai Elo rankings.
+- **Federation**, **webhooks**, **OAuth**, **RLS**, **DAG versioning**, MCP, and
+  the `/v1/` REST surface are services built on top of the kernel, not retrofits
+  onto a vector store.
 
-This is not vocabulary borrowed from a dictionary of compelling words. Each of those names is a subsystem with an actual code path, an actual SQL table, an actual lifecycle worker, and an actual failure mode. Read the source tree; it's laid out that way.
+The v4.0 codebase is a coherent `mnemos/` package: `api/routes`, `core`, `db`,
+`domain`, `persistence`, `mcp`, `webhooks`, `workers`, `hooks`, `installer`,
+`tools`, and `cli`. The old top-level script sprawl is gone; operators use the
+single `mnemos` command.
 
-You can treat MNEMOS like a memory storage provider if you want — `POST /v1/memories`, `GET /v1/memories/{id}`, you're done. The system will happily oblige. But the reason it holds up in production is that everything underneath that surface is operating-system-shaped: write-ahead transactions on the audit chain, supervised workers for distillation, per-provider circuit breakers, hash-chained reasoning logs, operator-triggered compression contests with quality manifests, advisory-locked DAG merges, SSRF-hardened outbound webhooks, and a dynamically-weighted model registry maintained by the shipped sync job. It is infrastructure built to operate, not a demo feature built to demo.
+## What You Get
 
-**What it is, concretely:**
+- A FastAPI service on port 5002 with three deployment profiles: `server`,
+  `edge`, and `dev`.
+- A `PersistenceBackend` abstraction with Postgres (`asyncpg`, pgvector, RLS,
+  LISTEN/NOTIFY) and SQLite (`aiosqlite`, sqlite-vec, FTS5, JSON1, WAL)
+  implementations.
+- Multi-worker production support when Redis backs shared rate-limit,
+  circuit-breaker, and concurrency state. The in-process fallback remains for
+  single-worker dev and edge installs and logs a warning if used with multiple
+  workers.
+- A single `/v1/*` REST surface covering memories, consultations, providers,
+  sessions, webhooks, federation, portability, and an OpenAI-compatible
+  chat-completions gateway.
+- Git-like DAG versioning on memory: `log`, `branch`, `merge`, `revert`. Every
+  mutation snapshots; history reads are filtered per snapshot and branch writers
+  refuse cross-memory parent edges.
+- Operator-batched compression contests through the `CompressionEngine` ABC,
+  competitive APOLLO/ARTEMIS selection, and persisted winner/loser audit rows.
+- Single-binary builds for `linux-x86_64`, `linux-aarch64`, and
+  `macos-aarch64` with sqlite-vec bundled.
+- Seven import-linter contracts in CI enforcing the package architecture, plus a
+  Pydantic Settings singleton that replaces ad-hoc environment reads outside the
+  config and installer layers.
+- 1055 unit tests passing, with GitLab integration tiers for cross-namespace
+  isolation, multi-worker smoke, and Postgres/SQLite persistence parity.
 
-- A FastAPI service (port 5002), with `server` (Postgres + Redis), `edge` (SQLite), and `dev` (SQLite + debug logging) deployment profiles. Python 3.11+. Apache-2.0.
-- A single `/v1/*` REST surface covering memories, consultations, providers, sessions, webhooks, federation, and an OpenAI-compatible chat-completions gateway.
-- A multi-LLM consensus reasoning layer (GRAEAE) that distributes one prompt across multiple providers, scores the responses, and writes a tamper-evident SHA-256 hash-chained audit entry — every time.
-- Git-like DAG versioning on memory: `log`, `branch`, `merge`, `revert`. Every mutation snapshots. In v3.5.x, history reads are filtered per snapshot and branch writers refuse cross-memory parent edges.
-- Operator-batched compression contest (APOLLO schema-aware dense encoding + ARTEMIS extractive compression) with a written quality manifest on every transformation. Runs in the background distillation worker through the plugin `CompressionEngine` ABC, competitive per-memory selection, and a persisted audit log of winners and losers.
-- Per-owner multi-tenant isolation, Bearer API keys + OAuth/OIDC session cookies, SSRF-hardened webhooks, cross-instance federation with per-memory opt-in. The v3.5.x read path uses the shared `read_visibility_predicate` in `api/visibility.py:40-96` across memory list/get/search/rehydrate/gateway surfaces.
-- Runs alongside your applications the way Redis, PostgreSQL, or a message bus would. Deploy once, every agent in your stack shares the same memory substrate.
+MNEMOS has been in daily production use since December 2025. The current release
+line is **v4.0.0**, shipped on **2026-04-29**, and it is the first release where
+the package layout, persistence layer, deployment profiles, CLI, single-binary
+distribution, and multi-worker coordination all match the intended production
+shape.
 
-The current release line is **v3.5.x**. **v3.5.0 shipped on 2026-04-28** with audit-driven hardening, uniform owner+namespace tenancy, webhook retry and outbox repairs, the federation compound-cursor tie-breaker, MCP transport parity, faithful OpenAI-compatible gateway controls, and the PostgreSQL streaming-replication doctrine. **v3.5.1 is the 2026-04-28 documentation-triage patch**: no product behavior changes, just version metadata and documentation reconciliation. The active built-in compression stack is **APOLLO + ARTEMIS**.
-
-## Quick install — single binary
-
-For edge and dev hosts, download the matching binary from the
-[MNEMOS releases page](https://github.com/mnemos-os/mnemos/releases):
+## Quick Install
 
 ```bash
-chmod +x mnemos-linux-x86_64
-sudo mv mnemos-linux-x86_64 /usr/local/bin/mnemos
-mnemos install --profile edge
-mnemos serve --profile edge
+pip install mnemos-os==4.0.0
+mnemos serve --profile dev
 ```
 
-The v4.0 binary artifacts bundle Python, MNEMOS runtime dependencies, sqlite-vec,
-and the migration chain. No host Python or `pip install` is required. See
-[`docs/SINGLE_BINARY.md`](./docs/SINGLE_BINARY.md) for platform-specific
+```bash
+docker pull ghcr.io/mnemos-os/mnemos:4.0.0
+```
+
+For a single binary with no host Python:
+
+```bash
+curl -L https://github.com/mnemos-os/mnemos/releases/download/v4.0.0/mnemos-linux-x86_64 -o mnemos
+chmod +x mnemos
+./mnemos install --profile edge
+./mnemos serve --profile edge
+```
+
+See [`docs/SINGLE_BINARY.md`](./docs/SINGLE_BINARY.md) for platform-specific
 filenames, macOS quarantine notes, limitations, and build-from-source
 instructions.
+
+## Deployment Topologies
+
+| Profile | Backend | Coordination | Use it for |
+|---|---|---|---|
+| `server` | Postgres + pgvector | Redis-backed shared state | Production, teams, multi-worker services |
+| `edge` | SQLite + sqlite-vec | In-process single-worker state | Laptops, Pi-class hosts, local appliances, Termux-style installs |
+| `dev` | SQLite + sqlite-vec | In-process single-worker state + DEBUG logging | Local development and tests |
 
 ## Works with
 
@@ -58,7 +104,7 @@ MNEMOS is designed to be the memory layer for the agentic tooling you already us
 
 ### How we interoperate
 
-1. **MCP (Model Context Protocol).** MNEMOS ships a stdio MCP server (`mcp_server.py`) that exposes memory operations — search, create, update, delete, DAG versioning, model optimizer — as first-class tool calls. Register it in any MCP-aware client (Claude Code, OpenClaw, ZeroClaw, Hermes) and the agent gets persistent memory without your framework having to know MNEMOS exists at the code level.
+1. **MCP (Model Context Protocol).** MNEMOS ships stdio and HTTP/SSE MCP transports (`mnemos.mcp.stdio`, `mnemos.mcp.http`) that expose memory operations — search, create, update, delete, DAG versioning, model optimizer — as first-class tool calls. Register it in any MCP-aware client (Claude Code, OpenClaw, ZeroClaw, Hermes) and the agent gets persistent memory without your framework having to know MNEMOS exists at the code level.
 2. **OpenAI-compatible gateway.** `POST /v1/chat/completions` and `GET /v1/models` are drop-in for the OpenAI SDK. Point `OPENAI_BASE_URL` at your MNEMOS instance and any client that already speaks OpenAI gets memory injection, multi-provider routing, propagated generation controls (`temperature`, `max_tokens`, `top_p`), streaming SSE, and explicit 400s when the selected provider cannot honor tools, response formats, penalties, or multimodal content. This is the path for LangChain, LlamaIndex, CrewAI, AutoGen, and anything else that was written against the OpenAI wire protocol.
 3. **Native `/v1/*` REST surface.** For integrations that want to speak to MNEMOS directly: `/v1/memories`, `/v1/consultations`, `/v1/providers`, `/v1/sessions`, `/v1/webhooks`, `/v1/federation`, `/v1/kg/triples`. The full API is language-agnostic; pick your HTTP client and go.
 
@@ -95,7 +141,7 @@ MNEMOS was built to solve those problems in a way that reflects real platform ex
 
 Its design is informed by years of enterprise platform work, large-vendor systems thinking, open-source infrastructure experience, and current work in the AI industry, without assuming that professional users want marketing language where they really need operational clarity.
 
-**MNEMOS has been in daily production use since December 2025**, backing multiple active agentic systems simultaneously. By early 2026 the running install was holding thousands of memories and had performed thousands of compressions, each with a written quality manifest. The v3.0 release line unified that production codebase into the single-service FastAPI shape shipped here; **v3.5.0 is the current shipped GA line**, and **v3.5.1** is its documentation-triage patch. See [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
+**MNEMOS has been in daily production use since December 2025**, backing multiple active agentic systems simultaneously. By early 2026 the running install was holding thousands of memories and had performed thousands of compressions, each with a written quality manifest. The v3.0 release line unified that production codebase into the single-service FastAPI shape; **v4.0.0 is the current shipped GA line**, adding the coherent package layout, persistence abstraction, SQLite profiles, single-binary artifacts, and multi-worker production support. See [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
 
 For the longer story — the original catalyzing moment, the architectural decisions (and mistakes) that took MNEMOS from a single-file prototype to a unified runtime, and the scrubs, refactors, and release-gate audits that landed the public cut — see [`EVOLUTION.md`](./EVOLUTION.md). Written for future contributors as much as for future readers who want to know what they're inheriting.
 
@@ -187,7 +233,7 @@ In particular, MNEMOS shares MemPalace's bets that:
 |---|---|---|
 | **Form factor** | Desktop library, embedded in-process | Network service (FastAPI on port 5002), runs as a daemon |
 | **Deployment** | `pip install`, runs inside your agent | Deployed alongside your stack the way you'd run PostgreSQL or Redis; many agents and processes connect over REST |
-| **Storage** | ChromaDB (SQLite-backed vector store) | PostgreSQL + pgvector with ACID transactions |
+| **Storage** | ChromaDB (SQLite-backed vector store) | Postgres + pgvector for server deployments, or SQLite + sqlite-vec for edge/dev profiles |
 | **Primary user** | Individual developer on a single machine | Teams / platforms operating shared infrastructure |
 | **Concurrency model** | Single-process, single-user | Multi-tenant with per-owner isolation, multi-process clients |
 | **Audit surface** | Local logs | SHA-256 hash-chained audit chain, tamper-evident and externally reviewable |
@@ -202,7 +248,7 @@ The shared premise — that agent memory deserves first-class treatment — is t
 
 ## What works now
 
-This is the current state of the v3.5.x release line. Features described here are implemented unless explicitly called out as forward-looking in [`ROADMAP.md`](./ROADMAP.md).
+This is the current state of the v4.0.0 release line. Features described here are implemented unless explicitly called out as forward-looking in [`ROADMAP.md`](./ROADMAP.md).
 
 The API surface is namespaced under `/v1/*`.
 
@@ -227,7 +273,7 @@ The API surface is namespaced under `/v1/*`.
 | `GET /health` | Health check (not namespaced) |
 | `GET /stats` | Memory counts by category, compression statistics |
 
-Read access for `GET /v1/memories`, `GET /v1/memories/{id}`, search, rehydrate, and gateway context now flows through the same application predicate: owner, federated, world-readable, or Unix group-readable (`api/visibility.py:40-96`). Writes remain owner-scoped; being able to read a world/group/federated row does not grant update or delete rights.
+Read access for `GET /v1/memories`, `GET /v1/memories/{id}`, search, rehydrate, and gateway context now flows through the same application predicate: owner, federated, world-readable, or Unix group-readable (`mnemos/core/visibility.py`). Writes remain owner-scoped; being able to read a world/group/federated row does not grant update or delete rights.
 
 ### Multi-user and provenance (v1, shipped)
 
@@ -242,7 +288,7 @@ Each memory carries full ownership and LLM provenance. Since v3.2, tenancy is tw
 - `source_session` — session ID at time of creation
 - `source_agent` — agent name or identifier
 
-**Row Level Security** is defined in PostgreSQL and remains opt-in for multi-user server deployments. The application layer mirrors the RLS read contract so SQLite/edge installs and RLS-backed server installs behave consistently. v3.5.x closes task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
+**Row Level Security** is defined in PostgreSQL and remains opt-in for multi-user server deployments. The application layer mirrors the RLS read contract so SQLite/edge installs and RLS-backed server installs behave consistently. The v3.5 hardening work closed task #25 with `db/migrations_v3_5_rls_group_select_unix_bits.sql`: `read_visibility_predicate` and the `mnemos_group_select` RLS policy now use identical Unix group-bit math, `((permission_mode / 10) % 10) >= 4`.
 
 **Deployment topologies** — selected with `mnemos install --profile ...`,
 `mnemos serve --profile ...`, or `MNEMOS_PROFILE`:
@@ -388,8 +434,8 @@ Sessions are DB-backed, revocable, and expire after 30 days by default. User pro
 For single-site HA, use PostgreSQL streaming replication: one writable primary,
 read-only standbys, and a stable writer endpoint for MNEMOS. Federation remains
 first-class, but it is for genuinely remote data flows: multi-site deployments,
-multi-org curated feeds, developer laptop replicas with intermittent
-connectivity, and planned v4 SQLite-based local-replica profiles.
+multi-org curated feeds, and developer laptop or edge replicas with
+intermittent connectivity using the v4 SQLite-backed `edge` profile.
 
 Do not use federation between same-LAN MNEMOS nodes for HA; it creates
 application-level dedup work that PostgreSQL WAL streaming already solves below
@@ -400,7 +446,7 @@ and [`docs/STREAMING_REPLICATION.md`](./docs/STREAMING_REPLICATION.md).
 
 MNEMOS Portability Format (MPF) is the native envelope for moving memories between MNEMOS instances and across compatible external systems. `GET /v1/export` writes an MPF v0.1.x envelope; `POST /v1/import` reads the envelope back. Root callers may use `preserve_owner=true` for authoritative restore and migration work; non-root imports are scoped to the caller's owner+namespace.
 
-CLI helpers live in [`tools/memory_export.py`](./tools/memory_export.py), [`tools/memory_import.py`](./tools/memory_import.py), and [`tools/mpf_validate.py`](./tools/mpf_validate.py). The schema is documented in [`docs/MEMORY_EXPORT_FORMAT.md`](./docs/MEMORY_EXPORT_FORMAT.md), and v3.4.1 added CHARON schema-compat preflight so federating peers can refuse incompatible migration sets before sync.
+CLI helpers live in [`mnemos/tools/memory_export.py`](./mnemos/tools/memory_export.py), [`mnemos/tools/memory_import.py`](./mnemos/tools/memory_import.py), and [`mnemos/tools/mpf_validate.py`](./mnemos/tools/mpf_validate.py). The schema is documented in [`docs/MEMORY_EXPORT_FORMAT.md`](./docs/MEMORY_EXPORT_FORMAT.md), and v3.4.1 added CHARON schema-compat preflight so federating peers can refuse incompatible migration sets before sync.
 
 ### Federation — cross-instance memory sync (v3, shipped)
 
@@ -440,7 +486,7 @@ The reasoning engine behind `/v1/consultations` provides:
 
 ### Model registry and dynamic provider weighting
 
-Most multi-LLM routers hardcode a provider list. MNEMOS ships a **self-populating PostgreSQL-backed model registry** that keeps itself current when the sync job is installed.
+Most multi-LLM routers hardcode a provider list. MNEMOS ships a **self-populating persistence-backed model registry** that keeps itself current when the sync job is installed.
 
 **What's in the registry.** Every known model from every configured provider — OpenAI, Groq, xAI, Together, Nvidia, Gemini, Anthropic — with per-model metadata: provider + model_id, display name, family (grok-4, gpt-5, gemini-3, …), capabilities (`chat`, `vision`, `code`, `reasoning`, `web_search`), context window, max output tokens, input / output / cache pricing (USD per million tokens), availability, deprecation flag, **Arena.ai Elo score**, **Arena.ai rank**, and the normalized `graeae_weight` (0.50–1.00) actually used by the consensus scorer.
 
@@ -469,7 +515,7 @@ A lot of the v3.x surface is held up by background work that doesn't show up in 
 - **OAuth session garbage collector** — hourly sweep of expired and long-revoked sessions. Bounds the `oauth_sessions` table so a long-running install doesn't accumulate dead rows forever.
 - **Federation sync worker** — for genuinely remote peers, iterates enabled peers on their individual sync intervals, pulls batches, reconciles local + remote timestamps before overwriting, logs per-sync results to `federation_sync_log`. Single-site HA uses PostgreSQL streaming replication instead.
 - **Advisory-lock-serialized audit chain writer** — the hash chain writer takes `pg_advisory_xact_lock` before reading the chain tip, so concurrent consultations cannot compute against the same stale previous hash. Closes a TOCTOU window in tamper-evident logging that most implementations leave open.
-- **Advisory-lock-serialized DAG writers** — merges and feature-branch reverts share `_branch_advisory_lock_key` in `api/handlers/dag.py:21-40`, then take row locks in the same order. Concurrent writers on the same `(memory_id, branch)` serialize instead of orphaning branch heads.
+- **Advisory-lock-serialized DAG writers** — merges and feature-branch reverts share `_branch_advisory_lock_key` in `mnemos/api/routes/dag.py`, then take row locks in the same order. Concurrent writers on the same `(memory_id, branch)` serialize instead of orphaning branch heads.
 - **Trigger-level DAG parent guard** — `db/migrations_v3_5_trigger_same_memory_parent.sql` replaces `mnemos_version_snapshot()` so UPDATE/DELETE resolve branch HEADs under lock, reject missing/NULL/foreign heads with SQLSTATE `MN001`, and keep delete snapshots live for deployments that still attach the delete trigger.
 - **ASGI body-size middleware** — native ASGI (not `BaseHTTPMiddleware`), so it rejects chunked uploads whose running byte count exceeds `MAX_BODY_BYTES` *as they arrive*, before the full body lands in memory. Content-Length–declared uploads are rejected before the app is even invoked.
 - **SSRF-hardened webhook dispatch** — URLs are re-validated at send time (not just at subscription time); DNS resolves asynchronously so a slow resolver can't freeze the event loop; cloud metadata hostnames (AWS IMDS, Google `metadata.google.internal`, Tencent, Alibaba, IPv6 variants) are on a deny list alongside the RFC1918 / loopback / link-local filter.
@@ -513,7 +559,7 @@ The constraints are enforced at the database level. Application bugs cannot viol
 
 ### Compression — the MOIRAI contest
 
-Compression is operator-batched in v3.5.x. It is not an automatic session-column flag and it no longer uses the retired LETHE / ANAMNESIS / ALETHEIA engines. Operators enqueue work through the admin endpoints; the distillation worker runs a competitive contest over the active engines and persists the winner plus the losing candidates for audit.
+Compression is operator-batched in v4.0. It is not an automatic session-column flag and it no longer uses the retired LETHE / ANAMNESIS / ALETHEIA engines. Operators enqueue work through the admin endpoints; the distillation worker runs a competitive contest over the active engines and persists the winner plus the losing candidates for audit.
 
 - **ARTEMIS** — CPU-only extractive compression with identifier preservation, labeled-block handling, and evidence-based self-scoring.
 - **APOLLO** — schema-aware dense encoding for LLM-to-LLM wire use. Rule-based schema detection with optional LLM fallback for fact-shaped content that misses a known schema.
@@ -521,16 +567,16 @@ Compression is operator-batched in v3.5.x. It is not an automatic session-column
 - Original content always retained; compressed and original stored independently.
 - Configurable quality thresholds per task type (security review: 95%, architecture: 90%, general: 80%).
 - The plugin `CompressionEngine` ABC is open to operator-registered engines. The contest logs the winner plus every loser with its score and rejection reason.
-- `/v1/memories/search` still carries reserved `compression_applied` / `compression_metadata` response fields from the v3.2 API shape; in v3.5.x search responses set `compression_applied=false`. Use `/v1/memories/rehydrate` or `/v1/memories/{id}/compression-manifests` when you need to know whether a compressed variant was used.
+- `/v1/memories/search` still carries reserved `compression_applied` / `compression_metadata` response fields from the v3.2 API shape; v4.0 search responses set `compression_applied=false`. Use `/v1/memories/rehydrate` or `/v1/memories/{id}/compression-manifests` when you need to know whether a compressed variant was used.
 
 ### Memory tier selector (advisory)
 
-The `modules/memory_categorization` package still exposes a hot/warm/cold/archive selector for hook-side prompt budgeting. It is advisory metadata used by integrations; it is not the removed `sessions.compression_tier` database column and does not drive automatic background compression.
+The `mnemos/domain/memory_categorization` package still exposes a hot/warm/cold/archive selector for hook-side prompt budgeting. It is advisory metadata used by integrations; it is not the removed `sessions.compression_tier` database column and does not drive automatic background compression.
 
 ### Versioning and audit
 
 - Memory version history (`memory_versions` table) — every mutation auto-snapshots previous state
-- Diff and revert API: `GET /v1/memories/{id}/versions`, `GET /v1/memories/{id}/versions/{n}`, `GET /v1/memories/{id}/diff`, `POST /v1/memories/{id}/revert/{n}`. Non-root callers see only snapshots whose own `owner_id` / `namespace` / `permission_mode` pass `version_visibility_predicate` (`api/visibility.py:99-137`).
+- Diff and revert API: `GET /v1/memories/{id}/versions`, `GET /v1/memories/{id}/versions/{n}`, `GET /v1/memories/{id}/diff`, `POST /v1/memories/{id}/revert/{n}`. Non-root callers see only snapshots whose own `owner_id` / `namespace` / `permission_mode` pass `version_visibility_predicate` (`mnemos/core/visibility.py`).
 - DAG (git-like) versioning: `GET /v1/memories/{id}/log`, `POST /v1/memories/{id}/branch`, `POST /v1/memories/{id}/merge`, `GET /v1/memories/{id}/commits/{commit}`. Logs do not bridge across invisible snapshots; a visible child whose immediate parent is hidden reports `parent_hash=null`.
 - SHA-256 hash-chained audit log for consultations: `GET /v1/consultations/audit`, `GET /v1/consultations/audit/verify`
 
@@ -566,7 +612,7 @@ Landed with the v3.0 release line:
 - ✅ **Slice 1: audit quick wins** (`a62a099`) — session history returns the most recent messages first with deterministic system-row pinning, and project URLs now point at `mnemos-os/mnemos`.
 - ✅ **Slice 2: memory-read tenancy + DAG integrity** (`d42c475`) — shared memory read visibility, per-snapshot history visibility, same-memory DAG guards, race-safe branch creation, `MN001` to HTTP 409 reconciliation guidance, and a compose `postgres-upgrade` service for existing volumes.
 - ✅ **Webhook retry state machine + leases + outbox discipline** — persisted leases, one-success-per-chain guards, repair worker separation, bulk-create parity, and terminal success trigger.
-- ✅ **MCP unified registry** — stdio and HTTP/SSE expose the same 18 tools from `api/mcp_tools.py`, including CRUD, KG, DAG, bulk create, stats, and model recommendation.
+- ✅ **MCP unified registry** — stdio and HTTP/SSE expose the same 18 tools from `mnemos/mcp/tools/`, including CRUD, KG, DAG, bulk create, stats, and model recommendation.
 - ✅ **Faithful OpenAI-compatible gateway** — propagated generation controls, OpenAI-format SSE, registry-honest model discovery, and explicit 400/404 responses when the selected provider cannot honor a requested feature.
 - ✅ **Namespace-uniform tenancy** — state, journal, entities, sessions, consultations, webhooks, and memory read/history paths use the owner+namespace discipline.
 - ✅ **PostgreSQL streaming-replication doctrine** — single-site HA uses Postgres primary/standby replication; MNEMOS federation is for remote or curated data flows.
@@ -576,90 +622,101 @@ Landed with the v3.0 release line:
 
 v3.5.1 is a documentation-triage patch shipped on 2026-04-28. It bumps package/runtime version metadata to 3.5.1 and reconciles release-state docs with the v3.5.0 GA tag; it does not change product behavior from v3.5.0.
 
-### Beyond v3.5.x
+### Shipped in v4.0.0
 
-Forward-looking scope is maintained in [`ROADMAP.md`](./ROADMAP.md), which lists shipped v3.x scope and items explicitly deferred with rationale.
+- ✅ **Coherent package layout** — production code now lives under `mnemos/` with `api/routes`, `core`, `db`, `domain`, `persistence`, `mcp`, `webhooks`, `workers`, `hooks`, `installer`, `tools`, and `cli` subpackages.
+- ✅ **Persistence abstraction** — `PersistenceBackend` owns the contract; `PostgresBackend` uses asyncpg + pgvector + RLS + LISTEN/NOTIFY, and `SqliteBackend` uses aiosqlite + sqlite-vec + FTS5 + JSON1 + WAL.
+- ✅ **Deployment profiles** — `server`, `edge`, and `dev` select safe defaults through `MNEMOS_PROFILE` or `mnemos serve --profile`.
+- ✅ **Multi-worker support** — Redis-backed circuit breaker, rate limiter, and concurrency limiter coordinate API workers; in-process fallback remains for single-worker dev and edge installs.
+- ✅ **Single-binary distribution** — PyInstaller artifacts for linux-x86_64, linux-aarch64, and macos-aarch64 bundle sqlite-vec and the migration chain.
+- ✅ **Unified CLI** — `mnemos serve / install / worker / export / import / consult / health / version` replaces the old top-level Python entry points.
+- ✅ **Architectural enforcement** — seven import-linter contracts keep API, domain, db, core, persistence, MCP, and webhook boundaries honest in CI.
+- ✅ **GRAEAE mode validation** — routing modes plus `single`, `debate`, and `majority` are modeled as a `Literal`; unknown modes 422 instead of falling through.
+
+### Beyond v4.0
+
+Forward-looking scope is maintained in [`ROADMAP.md`](./ROADMAP.md), which lists shipped v3.x/v4.0 scope and items explicitly deferred with rationale.
 
 Near-term not-yet-scoped candidates:
 
-- Distributed consensus for multi-writer federation
-- Server-push streaming API for long-lived subscriptions
-- Direct-import adapters for major memory competitors (beyond the current `POST /v1/memories/bulk` manual path)
+- Web UX in the separate `mnemos-web` frontend repo
+- Mobile clients: Android Termux hardening first, iOS native later
+- Rust rewrites for selected hot paths after the Python v4 architecture settles
+- Hosted MNEMOS Cloud and foundation-tier OSS standardization work (MCP-MD via LF AI & Data) in the v5.0+ frame
 
 ---
 
 ## Architecture
 
-```
-Agents (any language, any framework)
+```text
+Agents / MCP clients / OpenAI-compatible SDKs
         │
-        │  REST API (port 5002)
+        │  REST, MCP stdio, MCP HTTP/SSE
         ▼
-┌─────────────────────────────────┐
-│           MNEMOS API            │
-│  auth · namespaces · search     │
-│  compression · ingest · admin   │
-│  knowledge graph · rehydrate    │
-└──────────────┬──────────────────┘
-               │
-    ┌──────────┴──────────┐
-    │                     │
-    ▼                     ▼
-PostgreSQL           GRAEAE (embedded)
-memories             multi-LLM consensus
-users / groups       circuit breaker
-api_keys             semantic cache
-compression_log      quality scorer
-knowledge_graph
+mnemos.api.routes  ->  mnemos.domain  ->  mnemos.db
+        │                    │                │
+        │                    ▼                ▼
+        │             GRAEAE / MOIRAI    PersistenceBackend
+        │                                  ├─ PostgresBackend
+        │                                  └─ SqliteBackend
+        ▼
+mnemos.core lifecycle/config/visibility
+        │
+        ├─ mnemos.webhooks
+        ├─ mnemos.workers
+        ├─ mnemos.mcp
+        └─ mnemos.cli
 ```
 
 ---
 
 ## Quick start
 
-### Edge install (Docker Compose)
+### Edge install (single binary)
 
 ```bash
-git clone <your-repo-url>
+curl -L https://github.com/mnemos-os/mnemos/releases/download/v4.0.0/mnemos-linux-x86_64 -o mnemos
+chmod +x mnemos
+./mnemos install --profile edge
+./mnemos serve --profile edge
+```
+
+### Package install
+
+```bash
+pip install mnemos-os==4.0.0
+mnemos install --profile dev
+mnemos serve --profile dev
+```
+
+### Source install
+
+```bash
+git clone https://github.com/mnemos-os/mnemos.git
 cd mnemos
-docker compose up
-# MNEMOS: http://localhost:5002
-# GRAEAE is embedded in the MNEMOS API (port 5002) — no separate server
+python -m pip install -e ".[dev,sqlite]"
+mnemos install --profile dev
+mnemos serve --profile dev
 ```
 
-### Manual install
-
-```bash
-git clone <your-repo-url>
-cd mnemos
-pip install -r requirements.txt
-python install.py
-# Prompts for: server, edge, or dev profile; database path/connection; provider API keys
-# Writes config.toml and initializes SQLite or Postgres as appropriate
-```
-
-### Manual database setup (if not using install.py)
-
-```bash
-psql -U postgres -c "CREATE USER mnemos WITH PASSWORD 'yourpassword';"
-psql -U postgres -c "CREATE DATABASE mnemos OWNER mnemos;"
-python install.py
-```
-
-`install.py` and `installer/db.py` are the canonical migration order. For Docker installs with an existing `postgres_data` volume, `docker-compose.yml` and `docker-compose.staging.yml` also run a one-shot `postgres-upgrade` service because `/docker-entrypoint-initdb.d` files only execute on fresh database initialization.
+For the `server` profile, create or point at a Postgres database, set
+`MNEMOS_PROFILE=server`, and provide `MNEMOS_DATABASE_URL` / Postgres settings
+plus a Redis-backed `RATE_LIMIT_STORAGE_URI`. For Docker installs with an
+existing `postgres_data` volume, `docker-compose.yml` and
+`docker-compose.staging.yml` still run a one-shot `postgres-upgrade` service
+because `/docker-entrypoint-initdb.d` files only execute on fresh database
+initialization.
 
 ### Start
 
 ```bash
-python api_server.py        # MNEMOS on port 5002
-# GRAEAE is embedded in the MNEMOS API (port 5002) — no separate server needed
-
+mnemos serve --profile server
 curl http://localhost:5002/health
 ```
 
-MNEMOS runs single-worker by default with `RATE_LIMIT_STORAGE_URI=memory://`.
-Horizontal scaling is supported when Redis backs shared rate-limit and
-circuit-breaker state; see `docs/SCALING.md`.
+MNEMOS runs one worker by default. Increase `MNEMOS_WORKERS` only with Redis
+backing shared rate-limit, circuit-breaker, and concurrency state; see
+[`docs/SCALING.md`](./docs/SCALING.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,36 @@ This document is kept intentionally narrow. It lists what the next release will 
 
 ---
 
+## Current status — v4.0.0 shipped on 2026-04-29
+
+v4.0.0 is shipped. The v4.0 work that used to be forward-looking is now current
+state:
+
+- ✅ Coherent `mnemos/` package layout: `api/routes`, `core`, `db`, `domain`,
+  `persistence`, `mcp`, `webhooks`, `workers`, `hooks`, `installer`, `tools`,
+  `cli`.
+- ✅ `PersistenceBackend` abstraction with Postgres and SQLite implementations.
+- ✅ Deployment profiles: `server`, `edge`, and `dev`.
+- ✅ SQLite profile: aiosqlite + sqlite-vec + FTS5 + JSON1 + WAL.
+- ✅ Single-binary distribution for linux-x86_64, linux-aarch64, and
+  macos-aarch64.
+- ✅ Unified `mnemos` CLI for serve / install / worker / export / import /
+  consult / health / version.
+- ✅ Redis-backed multi-worker support for circuit breaker, rate limiter, and
+  concurrency limiter state.
+- ✅ Seven import-linter contracts and Pydantic Settings singleton discipline.
+- ✅ GRAEAE modes: `auto`, `local`, `external`, `all`, `single`, `debate`,
+  `majority`; unknown values now 422.
+
+Next planning focus:
+
+- **v4.1**: web UX in the separate `mnemos-web` frontend repo (Tier-1 MVP),
+  mobile hardening for Android Termux first, iOS native client later, connector
+  gallery expansion, and any targeted Rust rewrites deferred on 2026-04-29.
+- **v5.0+**: hosted MNEMOS Cloud, foundation-tier OSS standardization
+  (MCP-MD via LF AI & Data), and larger Rust/mobile investments once the v4
+  Python architecture has settled under production use.
+
 ## v3.1 — compression platform + v3.0 unblocks
 
 **Headline:** plugin-interfaced compression platform with competitive per-memory engine selection, a persisted audit log on every compression decision, and a first-class GPU batcher that works across integrated graphics, discrete GPUs, and remote OpenAI-compatible endpoints.
@@ -144,35 +174,41 @@ Remaining after v3.5.0:
 
 ---
 
-## v4.0 — Pluggable Monolith + Surface Integrations + Lite Profile
+## v4.0 — Pluggable Monolith + Lite Profile — SHIPPED 2026-04-29
 
-The 4.0 charter is structural, not feature-driven. Three coupled work streams:
+The 4.0 charter was structural, not feature-driven. Tracks 5, 5b, and horizontal
+scaling shipped in v4.0.0. Connector gallery expansion moves to v4.1; hosted
+cloud, MCP-MD foundation standardization, and larger Rust/mobile work move to
+v5.0+ framing.
 
 ### Track 5 — modularization + persistence abstraction
 
 Same repo, internal API boundaries enforced by tooling. Pattern: Django, SQLAlchemy, Airflow.
 
-- 🔵 `src/mnemos/` package layout. Subsystems become subpackages (`mnemos.graeae`, `mnemos.compression`, `mnemos.morpheus`, `mnemos.federation`, `mnemos.charon`, `mnemos.knossos`).
-- 🔵 `import-linter` config in `pyproject.toml`. CI fails on cross-subsystem internal imports.
-- 🔵 Public APIs via `__all__`; private surfaces under `_internal/`.
-- 🔵 `installer/` extracted to a separate package (operators don't need it at runtime).
-- 🔵 Plugin entry-points for `CompressionEngine`, judges, federation backends, MORPHEUS phases. Third-party engines install as packages and self-register on startup.
-- 🔵 Optional-extras: `pip install mnemos-os`, `mnemos-os[graeae,morpheus]`, `mnemos-os[full]`. Lets embedding apps pull only the slice they need.
-- 🔵 **Persistence abstraction** — `mnemos.persistence.{postgres,sqlite}` swappable. Foundation for the lite profile (next).
+- ✅ `mnemos/` package layout. Subsystems are subpackages: `api/routes`, `core`, `db`, `domain`, `persistence`, `mcp`, `webhooks`, `workers`, `hooks`, `installer`, `tools`, `cli`.
+- ✅ Seven `import-linter` contracts in `pyproject.toml`. CI fails on package-boundary regressions.
+- ✅ Public API surfaces exposed through package modules; top-level Python script entry points retired in favor of `mnemos`.
+- ✅ `mnemos/installer/` extracted from the old top-level installer flow.
+- ✅ Plugin entry-points and ABCs remain for `CompressionEngine`; third-party extension work continues after v4.0.
+- ✅ Optional extras: `build`, `sqlite`, `tracing`, `structlog`, `docling`, `full`, `phi`.
+- ✅ **Persistence abstraction** — `mnemos.persistence.{postgres,sqlite}` swappable.
 
 ### Track 5b — SQLite "lite" profile
 
 Same code, same API, same KNOSSOS interop. Single-binary, embeddable, MemPalace-compatible MCP from day one.
 
-- 🔵 `mnemos.persistence.sqlite` implementation: SQLite + `sqlite-vec` (replaces pgvector) + FTS5 (replaces pg's tsvector).
-- 🔵 SQL dialect translation: `<=>` cosine ops, jsonb, generated columns, partial indexes — the persistence layer hides this.
-- 🔵 Migration parity: `db/migrations/sqlite/` mirrors `db/migrations/postgres/`. Same conceptual schema, different SQL.
-- 🔵 Single-binary build: `pyinstaller`-style bundle that ships MNEMOS + SQLite-vec + the static assets in one executable.
-- 🔵 Pitch: **"Run it as a single SQLite binary on your laptop, scale it to a Postgres+pgvector+GPU stack on a fleet, anywhere in between."** The MemPalace-compatible variant of MNEMOS that doesn't sacrifice the schema-extensibility our database choice gives us.
+- ✅ `mnemos.persistence.sqlite` implementation: SQLite + `sqlite-vec` + FTS5 + JSON1 + WAL.
+- ✅ SQL dialect translation lives behind the persistence layer.
+- ✅ SQLite migration chain mirrors the Postgres conceptual schema.
+- ✅ Single-binary build via PyInstaller ships MNEMOS + sqlite-vec + migrations in one executable.
+- ✅ Pitch: **"Run it as a single SQLite binary on your laptop, scale it to a Postgres+pgvector+GPU stack on a fleet, anywhere in between."**
 
-### Track 6 — surface integrations (multi-vendor MCP + REST connectors)
+### Track 6 — surface integrations (multi-vendor MCP + REST connectors) — v4.1
 
-MNEMOS exposes a mature MCP server (`mcp_server.py`, 18 tools from one canonical registry, working in Claude Code today). Goal: make MNEMOS the easiest memory layer to wire into *any* agent surface. v4.0 ships a connectors gallery + bridge tooling for the surfaces that don't natively speak MCP.
+MNEMOS exposes mature MCP transports (`mnemos.mcp.stdio`, `mnemos.mcp.http`) and
+18 tools from one canonical registry. v4.0 keeps the working MCP surface and the
+initial connector docs; broad connector-gallery packaging and bridge tooling are
+v4.1 work.
 
 | Surface | MCP support | Plan |
 |---|---|---|
@@ -188,11 +224,11 @@ MNEMOS exposes a mature MCP server (`mcp_server.py`, 18 tools from one canonical
 | **OpenWebUI / LM Studio / Ollama** | ⚠️ partial | OpenAI-compat tool-call path; MNEMOS REST endpoints accessible via tool-use config |
 
 Deliverables:
-- 🔵 `docs/connectors/` directory with one Markdown per surface, including the exact config snippet to paste.
-- 🔵 `mnemos-openapi.json` published as a downloadable artifact in CI; consumed by Custom GPTs and any OpenAPI-aware client.
-- 🔵 `mnemos-bridges/gemini/` — small Python package that runs alongside MNEMOS, exposes the MCP tool surface as a Gemini-compatible REST endpoint.
-- 🔵 `mnemos-bridges/openai-actions/` — Custom GPT manifest + OAuth scaffold for the consumer ChatGPT path.
-- 🔵 Smoke tests per surface in CI (where automatable; some surfaces require real credentials and are manual).
+- ✅ Initial `docs/connectors/` directory exists with ChatGPT Pro Developer Mode guidance.
+- 🔵 v4.1: one Markdown per surface with exact config snippets.
+- 🔵 v4.1: `mnemos-openapi.json` artifact for Custom GPTs and OpenAPI-aware clients.
+- 🔵 v4.1: Gemini and OpenAI Actions bridge packages if demand holds.
+- 🔵 v4.1: smoke tests per surface where automatable.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,20 +3,18 @@
 ## Supported versions
 
 The most recently maintained release branch is supported. The current
-release line is `v3.5.x`. v3.5.0 shipped on 2026-04-28; v3.5.1 is the
-2026-04-28 documentation-triage patch with no product behavior changes from
-v3.5.0.
+release line is `v4.0.x`. v4.0.0 shipped on 2026-04-29.
 
 ## Current security invariants
 
-As of v3.5.x:
+As of v4.0.0:
 
 - Memory read visibility is symmetric across list/get/search/rehydrate,
   OpenAI-compatible gateway context, version history, DAG history, and MCP
   version tools. The live-memory predicate is centralized in
-  `read_visibility_predicate` (`api/visibility.py:40-96`).
+  `read_visibility_predicate` (`mnemos/core/visibility.py`).
 - Version history is gated per snapshot by `version_visibility_predicate`
-  (`api/visibility.py:99-137`), so a later-public memory does not expose
+  (`mnemos/core/visibility.py`), so a later-public memory does not expose
   an earlier private snapshot.
 - DAG logs stay within one memory and do not bridge across invisible
   snapshots. `parent_hash` is emitted only when the immediate parent is
@@ -38,8 +36,14 @@ As of v3.5.x:
   v3.4.x cross-tenant audit metadata leak in v3.5.0.
 - Webhook delivery uses persisted leases, retry-chain convergence, terminal
   success guards, and SSRF checks at subscription and delivery time.
-- MCP stdio and HTTP/SSE use the same registry in `api/mcp_tools.py`, with
+- MCP stdio and HTTP/SSE use the same registry under `mnemos/mcp/tools/`, with
   per-user HTTP token mapping available through `MNEMOS_MCP_TOKENS`.
+- Multi-worker server deployments use Redis-backed circuit breaker, rate-limit,
+  and concurrency state. The in-process fallback remains for single-worker edge
+  and dev installs and logs a warning if multiple workers are configured.
+- Runtime configuration is centralized in the Pydantic Settings singleton;
+  direct `os.environ` reads are limited to `mnemos/core/config.py` and the
+  installer path.
 - The OpenAI-compatible gateway passes supported generation controls through
   to providers and rejects unsupported tool, response-format, or multimodal
   requests instead of silently ignoring them.

--- a/SYSTEM_REQUIREMENTS.md
+++ b/SYSTEM_REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # MNEMOS System Requirements
 
-**Applies to**: current v3.5.x release line
-**Updated**: 2026-04-28
+**Applies to**: current v4.0.0 release line
+**Updated**: 2026-04-29
 **Applies To**: Bare Metal, Docker, and Cloud Deployments
 
 ---
@@ -11,10 +11,10 @@
 | Component | Minimum | Recommended | Notes |
 |-----------|---------|-------------|-------|
 | **CPU** | 2 cores | 4+ cores | More cores = faster GRAEAE consensus |
-| **RAM** | 4 GB | 8+ GB | Python + PostgreSQL + service |
+| **RAM** | 4 GB | 8+ GB | Python + SQLite edge, or Python + PostgreSQL server |
 | **Disk** | 10 GB | 50+ GB | Depends on memory storage size |
 | **Python** | 3.11 | 3.11+ | Required for asyncio features |
-| **PostgreSQL** | 13 | 16 (pgvector) | Requires pgvector, pgcrypto, uuid-ossp |
+| **Database** | SQLite 3.40+ for edge/dev | PostgreSQL 16 + pgvector for server | Server profile also expects Redis for multi-worker |
 | **Docker** | 20.10+ | 24+ | If using containers |
 | **GPU** | Optional | Optional | Not required; fully CPU-capable |
 
@@ -94,9 +94,9 @@ psql -U postgres -d mnemos -c "CREATE EXTENSION IF NOT EXISTS uuid-ossp;"
 ```
 
 **Migration note for Docker volumes**: fresh volumes run all mounted
-`/docker-entrypoint-initdb.d` SQL. Existing volumes do not. The v3.5.x
-compose files therefore include a one-shot `postgres-upgrade` service
-that applies the v3.5 migration tail before MNEMOS starts.
+`/docker-entrypoint-initdb.d` SQL. Existing volumes do not. The compose files
+therefore include a one-shot `postgres-upgrade` service that applies the ordered
+migration tail before MNEMOS starts.
 
 **Storage Requirements**:
 - Initial database: ~50 MB (empty schema)
@@ -682,5 +682,5 @@ Solution: Check disk usage: df -h
 ---
 
 **Last Updated**: 2026-04-28
-**Version**: v3.5.x; v3.5.1 documentation-triage patch
+**Version**: v4.0.0
 **Status**: Production-ready for tagged releases

--- a/docs/COMPRESSION.md
+++ b/docs/COMPRESSION.md
@@ -23,7 +23,7 @@ The compression flow is:
    compression artifacts.
 
 The admin endpoint request models and queue inserts live in
-[`api/handlers/admin.py`](../api/handlers/admin.py).
+[`mnemos/api/routes/admin.py`](../mnemos/api/routes/admin.py).
 
 Session messages and session memory injections do not carry compression tags.
 Slice 12 dropped the always-NULL `compression_ratio` columns from

--- a/docs/GRAEAE_FEATURES.md
+++ b/docs/GRAEAE_FEATURES.md
@@ -1,7 +1,6 @@
 # GRAEAE Feature Surface
 
-**Status:** current v3.5.x documentation. v3.5.0 shipped on 2026-04-28;
-v3.5.1 is the documentation-triage patch.
+**Status:** current v4.0.0 documentation. v4.0.0 shipped on 2026-04-29.
 
 GRAEAE is MNEMOS's multi-provider reasoning bus. It fans a prompt out to live
 LLM providers, scores the responses, persists consultations, and writes a
@@ -11,17 +10,17 @@ hash-chained audit record for each committed consultation.
 
 | Capability | Current module | Notes |
 |---|---|---|
-| Provider routing | `graeae/engine.py` | Config-driven providers with OpenAI-compatible, Anthropic, and Gemini adapter paths. |
-| Circuit breaking | `graeae/_circuit_breaker.py` | Per-provider CLOSED / OPEN / HALF_OPEN guard; process-local. |
-| Rate limiting | `graeae/_rate_limiter.py` | Sliding-window requests-per-minute guard; process-local. |
-| Concurrency limiting | `graeae/_concurrency.py` | Per-provider async slot limiter; skips saturated providers instead of queueing them. |
-| Quality weighting | `graeae/_quality.py` | Rolling success-rate and latency tracker used to adjust provider weights. |
-| Response cache | `graeae/_cache.py` | In-memory normalized prompt cache with TTL; not a persistent semantic cache. |
-| Model registry sync | `graeae/provider_sync.py`, `graeae/elo_sync.py`, `scripts/sync_provider_models.py` | Provider model discovery plus Arena.ai/LMArena weighting when the sync job is installed. |
+| Provider routing | `mnemos/domain/graeae/engine.py` | Config-driven providers with OpenAI-compatible, Anthropic, and Gemini adapter paths. |
+| Circuit breaking | `mnemos/domain/graeae/_circuit_breaker.py` | Per-provider CLOSED / OPEN / HALF_OPEN guard; Redis-backed in server multi-worker mode, in-process fallback otherwise. |
+| Rate limiting | `mnemos/domain/graeae/_rate_limiter.py` | Sliding-window requests-per-minute guard; Redis-backed when configured. |
+| Concurrency limiting | `mnemos/domain/graeae/_concurrency.py` | Per-provider async slot limiter; Redis-backed when configured. |
+| Quality weighting | `mnemos/domain/graeae/_quality.py` | Rolling success-rate and latency tracker used to adjust provider weights. |
+| Response cache | `mnemos/domain/graeae/_cache.py` | In-memory normalized prompt cache with TTL; not a persistent semantic cache. |
+| Model registry sync | `mnemos/domain/graeae/provider_sync.py`, `mnemos/domain/graeae/elo_sync.py`, `scripts/sync_provider_models.py` | Provider model discovery plus Arena.ai/LMArena weighting when the sync job is installed. |
 
-The reliability state above is intentionally process-local in v3.5.x. MNEMOS
-therefore remains pinned to one API worker for production correctness; moving
-these guards to shared/external coordination is future horizontal-scaling work.
+The reliability state above uses Redis in the `server` profile when
+`RATE_LIMIT_STORAGE_URI=redis://...` is configured. In-process fallback remains
+for `edge`/`dev` and logs a warning when used with multiple workers.
 
 ## API Surface
 
@@ -58,7 +57,7 @@ request validation with HTTP 422.
 
 OpenAI-compatible access is separate but uses the same routing engine:
 `POST /v1/chat/completions`, `GET /v1/models`, and `GET /v1/models/{model_id}`.
-In v3.5.x, generation controls propagate when the selected provider supports
+In v4.0, generation controls propagate when the selected provider supports
 them; unsupported tools, response formats, and multimodal requests are rejected
 instead of silently ignored.
 
@@ -74,6 +73,6 @@ Committed consultations write three related records in one transaction:
 
 If the audit write fails, consultation persistence fails too. This is the
 current compliance boundary for GRAEAE. MNEMOS does not have one generic
-`audit_log` table for every memory operation in v3.5.x; memory integrity is
+`audit_log` table for every memory operation in v4.0; memory integrity is
 tracked through the version DAG, webhook delivery rows, compression contest
 records, and subsystem-specific audit tables.

--- a/docs/KNOSSOS.md
+++ b/docs/KNOSSOS.md
@@ -74,7 +74,7 @@ the MemPalace tool-response shape.
 
 ## What you gain by moving
 
-| Capability | MemPalace 3.3.x | MNEMOS v3.5.x via KNOSSOS |
+| Capability | MemPalace 3.3.x | MNEMOS v4.0 via KNOSSOS |
 |---|---|---|
 | Multi-user memory | ❌ | ✅ — `owner_id`, `group_id`, `permission_mode` |
 | HTTP API | ❌ | ✅ — `/v1/memories/*`, `/v1/kg/*`, `/v1/export`, `/v1/import` |
@@ -84,7 +84,7 @@ the MemPalace tool-response shape.
 | Version/audit trail | ❌ | ✅ — memory DAG snapshots, consultation hash chain, webhook/compression audit rows |
 | Compression (APOLLO/ARTEMIS contest) | AAAK only (~30× on a subset) | Full contest — APOLLO schema + ARTEMIS extractive, judge-scored |
 | Federation across instances | ❌ | ✅ — `/v1/federation/*`, pull-based |
-| Knowledge graph (temporal) | ✅ — SQLite-backed | ✅ — Postgres-backed, same temporal semantics |
+| Knowledge graph (temporal) | ✅ — SQLite-backed | ✅ — Postgres-backed server profile or SQLite edge profile, same temporal semantics |
 | MCP surface | 29 native tools | 16 MemPalace-compatible phase-1 tools via KNOSSOS, plus the native 18-tool MNEMOS MCP surface |
 | Retrieval benchmark R@5 (LongMemEval) | 96.6% raw / 98.4% hybrid | (see `benchmarks/compression_corpus_v3_3.jsonl`) |
 
@@ -196,7 +196,7 @@ Deferred phase-2 surface:
 
 KNOSSOS is one spoke; CHARON is the hub. KNOSSOS translates the
 MemPalace MCP tool surface. CHARON handles bulk import/export via
-MPF envelopes (`tools/memory_import.py`, `tools/memory_export.py`,
+MPF envelopes (`mnemos/tools/memory_import.py`, `mnemos/tools/memory_export.py`,
 `docs/MEMORY_EXPORT_FORMAT.md`). A full MemPalace → MNEMOS migration uses both:
 
 1. CHARON one-time bulk import of the existing palace (via

--- a/docs/MEMORY_EXPORT_FORMAT.md
+++ b/docs/MEMORY_EXPORT_FORMAT.md
@@ -120,7 +120,7 @@ know about. This is deliberate forward/backward compatibility.
 {
   "mpf_version": "0.1.0",
   "source_system": "mnemos",
-  "source_version": "3.5.1",
+  "source_version": "4.0.0",
   "source_instance": "pythia.internal",         // optional diagnostic
   "source_commit": "1838507",                   // optional diagnostic
   "exported_at": "2026-04-23T15:00:00Z",

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -41,7 +41,7 @@ What this doc does NOT cover:
                      /         \
                     /           \
               PYTHIA (.67)    CERBERUS (.96)
-              v3.5.x prod     dark prod / GPU host
+              v4.0 prod       dark prod / GPU host
               pg17 primary    standby + inference
               11,756 memories + Apollo Gemma 4 (ports 8080/8081)
               5,045 compressions
@@ -64,8 +64,8 @@ What this doc does NOT cover:
 
 | Host | IP | OS | CPU | RAM | GPU | Role | MNEMOS version | Status |
 |---|---|---|---|---|---|---|---|---|
-| **PYTHIA** | 192.168.207.67 | Ubuntu 22.04 | 12-core | 30GB | — | Primary (prod) + GRAEAE + CNXN | v3.5.x stable target | ✅ Operational |
-| **CERBERUS** | 192.168.207.96 | Debian 12 | 24-core (Threadripper) | 125GB | RTX 4500 ADA 24GB | Secondary/dark prod + Apollo GPU inference | v3.5.x stable target | ✅ Operational |
+| **PYTHIA** | 192.168.207.67 | Ubuntu 22.04 | 12-core | 30GB | — | Primary (prod) + GRAEAE + CNXN | v4.0 stable target | ✅ Operational |
+| **CERBERUS** | 192.168.207.96 | Debian 12 | 24-core (Threadripper) | 125GB | RTX 4500 ADA 24GB | Secondary/dark prod + Apollo GPU inference | v4.0 stable target | ✅ Operational |
 | **PROTEUS** | 192.168.207.25 | Debian 12 | Intel i7-6700 | 60GB | — | Staging + restore-drill target | latest cut / release drills | ✅ Used for drills |
 | **ARGONAS** | 192.168.207.101 | TrueNAS | — | — | — | NFS + git origin (planned: LB) | nginx 1.26 (TrueNAS UI proxy only) | ✅ Running |
 
@@ -88,7 +88,7 @@ Production MNEMOS runs on a **canary + ratchet** model: new features bake in sta
 
 | Tier | Host(s) | Version target | Stability | Deployment source |
 |---|---|---|---|---|
-| **Prod** | PYTHIA + CERBERUS | *latest stable* (v3.5.x) | GA, no alpha/beta | git tag, N+1 weeks after staging bake |
+| **Prod** | PYTHIA + CERBERUS | *latest stable* (v4.0.x) | GA, no alpha/beta | git tag, N+1 weeks after staging bake |
 | **Staging** | PROTEUS | *latest cut* / next release branch | alpha/rc, real federation | release branch, merged + tagged |
 | **Test** | docker-compose + mnemos-test-pg on CERBERUS | *feature branches* | ephemeral, parallel | PR builds via CI, cleaned up post-merge |
 
@@ -248,7 +248,8 @@ sudo -u postgres psql -d mnemos -v ON_ERROR_STOP=1 \
   -f db/migrations_v3_5_trigger_same_memory_parent.sql
 ```
 
-See `installer/db.py:51-63` (`_psql_superuser`) and `installer/db.py:230-254` (migration sequence) for canonical order. `install.py:150-169` carries the ordered installer migration list and must stay in the same order.
+See `mnemos/installer/db.py` for the canonical migration order. Docker compose,
+the CLI installer, and manual runbooks must mirror that loader.
 
 ### 5.3 Pre-migration backup (mandatory)
 
@@ -318,7 +319,7 @@ WHERE proname = 'mnemos_version_snapshot';
 
 `MN001` means the trigger found broken branch state while resolving the
 parent for an UPDATE or DELETE. The API maps it to HTTP 409 through
-`handle_trigger_pgerror` (`api/visibility.py:24-37`).
+`handle_trigger_pgerror` (`mnemos/core/visibility.py`).
 
 Causes:
 
@@ -389,7 +390,7 @@ pg_dump -U postgres mnemos | gzip > \
 
 ### 6.3 Restore procedure (quarterly drill)
 
-**Status:** Dev↔prod MPF restore drill documented and last run for v3.4.1; repeat before high-risk v3.5.x schema work.
+**Status:** Dev↔prod MPF restore drill documented and last run for v3.4.1; repeat before high-risk schema work.
 Repeat quarterly and before high-risk schema work.
 
 To restore from backup to PROTEUS (test/staging host):
@@ -461,7 +462,8 @@ Response (JSON):
 ```json
 {
   "status": "healthy",
-  "version": "3.5.1",
+  "version": "4.0.0",
+  "profile": "server",
   "database_connected": true,
   "distillation_worker": "healthy"
 }
@@ -474,8 +476,8 @@ Response (JSON):
 Simple dashboard (Grafana or custom HTML) that queries each node's `/health` and shows:
 
 ```
-PYTHIA:   3.5.1         (prod target)
-CERBERUS: 3.5.1         (dark prod / GPU host)
+PYTHIA:   4.0.0         (prod target)
+CERBERUS: 4.0.0         (dark prod / GPU host)
 PROTEUS:  next cut      (staging / restore-drill target)
 ```
 
@@ -580,14 +582,14 @@ During the 2026-04-26 audit:
 
 ### 9.2 Solution: weekly version check
 
-Implement `scripts/ops/version_check.sh` (to be written, v3.5 target):
+Implement `scripts/ops/version_check.sh`:
 
 ```bash
 #!/bin/bash
 # Check each node's version vs. declared target
 
-PYTHIA_DECLARED="3.5.1"
-CERBERUS_DECLARED="3.5.1"
+PYTHIA_DECLARED="4.0.0"
+CERBERUS_DECLARED="4.0.0"
 PROTEUS_DECLARED="next-cut"
 
 PYTHIA_ACTUAL=$(curl -s -H "Authorization: Bearer $TOKEN" \
@@ -652,14 +654,16 @@ See `~/.claude/rules/github-behavior.md` for full rate-limit rules and the ratio
 
 ## 11. Federation health
 
-### 11.1 Architecture (v3.5.x current)
+### 11.1 Architecture (v4.0.0 current)
 
-Federation (peer-to-peer memory sync) is specified in `api/handlers/federation.py:280-390`. Key points:
+Federation (peer-to-peer memory sync) is specified in `mnemos/api/routes/federation.py`. Key points:
 
 - Each MNEMOS node maintains a `federation_peers` table (schema in `db/migrations_v3_federation.sql`)
 - Sync is **pull-based:** node A asks node B for updates since the last sync point
 - Compound-cursor pagination over `(updated, id)` (not full-dump on every sync)
-- **Status as of 2026-04-28:** Schema-compat preflight, restore drills, and the stable compound cursor are validated. Peer heartbeat and per-peer ACL remain future work.
+- **Status as of 2026-04-29:** Schema-compat preflight, restore drills, the
+  stable compound cursor, and v4 package boundaries are validated. Peer
+  heartbeat and per-peer ACL remain future work.
 
 ### 11.2 What happens when a peer is unreachable
 
@@ -667,9 +671,9 @@ Currently: node logs an error and retries on next sync interval (default 1h). **
 
 Risk: Silent failure — if CERBERUS goes down mid-night, PYTHIA won't know for 1–2 hours.
 
-### 11.3 Required: Peer heartbeat detection (v3.5 target)
+### 11.3 Required: Peer heartbeat detection
 
-Implement lightweight heartbeat check in `api/handlers/federation.py`:
+Implement lightweight heartbeat check in `mnemos/api/routes/federation.py`:
 
 ```python
 async def check_peer_health(peer_url: str, token: str, timeout: int = 5) -> bool:
@@ -833,9 +837,9 @@ The following three shell scripts codify operational patterns and reduce manual 
 - **Feature roadmap:** `docs/V3_5_CHARTER.md` (PANTHEON + IRIS + ops hardening), `docs/V3_6_CHARTER.md` (APOLLO consolidation + PERSEPHONE archival), `docs/V4_PLAN.md` (API consolidation + GPU stack)
 - **Architecture:** `README.md`, `docs/ARCHITECTURE.md`
 - **API docs:** `docs/API.md`, `examples/`
-- **Database:** `db/migrations_*.sql` (all schema changes), `installer/db.py` (canonical migration order)
-- **Observability:** `api/observability.py` (request-ID middleware, Prometheus, OTEL)
-- **Federation:** `api/handlers/federation.py` (peer sync logic)
+- **Database:** `db/migrations_*.sql` and `db/migrations_sqlite/` (schema changes), `mnemos/installer/db.py` (canonical migration order)
+- **Observability:** `mnemos/api/observability.py` (request-ID middleware, Prometheus, OTEL)
+- **Federation:** `mnemos/api/routes/federation.py` (peer sync logic)
 
 ---
 

--- a/docs/PANTHEON.md
+++ b/docs/PANTHEON.md
@@ -30,7 +30,7 @@ import path to the **root + preserve_owner=true** admin/migration
 path. Non-root callers can ship `kg_triples` and
 `compression_manifest` sidecars without restriction, but
 `memory_versions` requires a root bearer token (`--preserve-metadata`
-on `tools/memory_import.py`). This restriction is structural:
+on `mnemos/tools/memory_import.py`). This restriction is structural:
 the interaction of caller-scoped deterministic id derivation,
 ON CONFLICT idempotency, and `memory_versions` surviving memory
 deletion makes the non-root path a defect-prone surface where

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -1,6 +1,6 @@
 # MPF restore drill — dev ↔ prod import / export
 
-CHARON's `tools/memory_export.py` + `tools/memory_import.py` are
+CHARON's `mnemos/tools/memory_export.py` + `mnemos/tools/memory_import.py` are
 the primary tools for moving an MNEMOS corpus between deployments.
 This document is the operator runbook for the drill — exporting from
 a source MNEMOS, validating the envelope, and restoring into a target.
@@ -46,7 +46,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 ```bash
 cd /path/to/mnemos
-python3 tools/mpf_validate.py --file /tmp/source-export.json
+python3 -m mnemos.tools.mpf_validate --file /tmp/source-export.json
 ```
 
 Output should include `OK`. A failed validation means either the source
@@ -61,7 +61,7 @@ For anything bigger, use the CLI tool.
 ```bash
 TARGET='http://192.168.207.25:5002'
 
-python3 tools/memory_import.py json \
+python3 -m mnemos.tools.memory_import json \
     --file /tmp/source-export.json \
     --preserve-metadata \
     --endpoint "$TARGET" \

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,8 +1,8 @@
 # MNEMOS Scaling
 
-MNEMOS defaults to one Uvicorn worker and `RATE_LIMIT_STORAGE_URI=memory://`.
-That shape remains valid for existing single-host installs and does not require
-Redis.
+MNEMOS defaults to one Uvicorn worker. The `edge` and `dev` profiles use
+SQLite plus in-process coordination; the `server` profile should use Redis when
+you raise the worker count.
 
 Multi-worker deployments are supported when shared rate-limit and resilience
 state is backed by Redis. Without Redis, each worker keeps its own in-process
@@ -18,8 +18,8 @@ MNEMOS_WORKERS=1
 RATE_LIMIT_STORAGE_URI=memory://
 ```
 
-This is the migration-safe path for existing v3.5 installs. No Redis service,
-schema change, or config migration is required.
+This is the migration-safe path for edge/dev and existing single-host installs.
+No Redis service, schema change, or config migration is required.
 
 ## Multi-worker pattern
 
@@ -112,8 +112,8 @@ Current operator notes:
 
 ## Migration Story
 
-Existing v3.5 single-worker installs continue to work without changing
-anything. `memory://` remains the default fallback.
+Existing single-worker installs continue to work without changing anything.
+`memory://` remains the default fallback for dev/edge profiles.
 
 Operators who want more throughput should:
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,209 +1,195 @@
 # MNEMOS Specification
 
-**Version**: v3.5.x current; v3.5.0 shipped 2026-04-28, v3.5.1 is the 2026-04-28 documentation-triage patch
-**Status**: Authoritative for the checked-out v3.5.x tree. Behavior not
+**Version**: v4.0.0 current; shipped 2026-04-29
+**Status**: Authoritative for the checked-out v4.0.0 tree. Behavior not
 described here is either undefined (report as a bug) or scoped to a
 future release via `ROADMAP.md`.
 **Purpose**: supply enough structural detail that a scoping tool
 (human or LLM) can estimate effort to build MNEMOS from scratch, or
 to re-implement any named subsystem. Not a marketing doc. Not a
-roadmap. Not an API reference — see README, ROADMAP.md, and
+roadmap. Not an API reference; see README, ROADMAP.md, and
 API_DOCUMENTATION.md respectively.
 
 ---
 
 ## 1. Abstract
 
-MNEMOS is a memory operating system for agentic software. A single
-HTTP service (port 5002 default) plus one stdio MCP server, backed by
-PostgreSQL with the pgvector extension, running on Python 3.11+.
-Runs alongside your applications the way Redis or PostgreSQL would:
-one deployment; every agent shares the same memory substrate.
+MNEMOS is a memory operating system for agentic software. It is a Python
+3.11+ package (`mnemos/`) exposing a FastAPI service on port 5002, MCP stdio
+and HTTP/SSE transports, background workers, installer helpers, and one
+operator CLI (`mnemos`). It runs in three deployment profiles:
 
-The system is operating-system-shaped rather than library-shaped.
-Hash-chained reasoning audit logs, content-addressed DAG versioning
-on every memory, a plugin compression contest with a persisted
-per-decision audit trail, SSRF-hardened outbound webhooks with
-per-delivery signing, cross-instance federation with per-memory
-opt-in, per-user tenancy on a two-axis gate (owner_id + namespace),
-shared read-visibility predicates across live and historical memory
-surfaces,
-a model registry with scheduled sync from upstream provider APIs and
-Arena.ai Elo rankings, request-scoped observability (request-ID
-correlation / Prometheus / OpenTelemetry / opt-in structured logs),
-and an OpenAI-compatible gateway that injects compressed memory
-context on the fly.
+- `server`: Postgres + pgvector + Redis, suitable for multi-worker production.
+- `edge`: SQLite + sqlite-vec, single-worker, suitable for laptops, Pi-class
+  hosts, local appliances, and Termux-style installs.
+- `dev`: SQLite + sqlite-vec with debug logging and development defaults.
 
-Apache-2.0. MNEMOS runs single-worker by default; horizontal scaling is
-supported when Redis backs shared rate-limit and circuit-breaker state.
-See `docs/SCALING.md`.
+The system is operating-system-shaped rather than library-shaped:
+hash-chained reasoning audit logs, content-addressed DAG versioning on every
+memory, a plugin compression contest with a persisted per-decision audit trail,
+SSRF-hardened outbound webhooks, cross-instance federation, owner+namespace
+tenancy, shared read-visibility predicates across live and historical memory
+surfaces, a model registry with scheduled sync from provider APIs and Arena.ai
+Elo rankings, request-scoped observability, and an OpenAI-compatible gateway
+that injects memory context on the fly.
+
+v4.0 adds the package restructure, `PersistenceBackend` abstraction,
+Postgres/SQLite backends, deployment profiles, single-binary distribution,
+unified CLI, and Redis-coordinated multi-worker support. Apache-2.0.
 
 ## 2. System Scope
 
-### 2.1 In scope at v3.5.x
+### 2.1 In scope at v4.0.0
 
-- **Memory**: CRUD, search (FTS + pgvector), DAG versioning with
-  branch/merge, knowledge-graph triples, categories + namespaces,
-  on-demand + background compression with persisted audit.
-- **Reasoning (GRAEAE)**: multi-LLM consensus consultation across
-  registered providers with cryptographic hash-chain audit on every
-  decision, Custom Query lineup selection, reliability stack
-  (circuit breaker + rate limiter + concurrency guard).
-- **Gateway**: OpenAI-compatible `/v1/chat/completions` +
-  `/v1/models` with registry-backed provider resolution,
-  compressed memory context injection, propagated generation controls,
-  SSE streaming, and explicit pass-or-400 handling for provider-specific
-  tool/format/multimodal support.
+- **Memory**: CRUD, search, DAG versioning with branch/merge, knowledge-graph
+  triples, categories + namespaces, background compression with persisted audit.
+- **Persistence**: `mnemos.persistence.base.PersistenceBackend` with
+  `PostgresBackend` (asyncpg + pgvector + RLS + LISTEN/NOTIFY) and
+  `SqliteBackend` (aiosqlite + sqlite-vec + FTS5 + JSON1 + WAL).
+- **Reasoning (GRAEAE)**: multi-LLM consultation across registered providers
+  with cryptographic hash-chain audit, Custom Query lineup selection,
+  routing-strategy modes (`auto`, `local`, `external`, `all`), reasoning-shape
+  modes (`single`, `debate`, `majority`), and Redis-backed reliability
+  primitives for multi-worker operation.
+- **Gateway**: OpenAI-compatible `/v1/chat/completions` + `/v1/models` with
+  registry-backed provider resolution, memory context injection, propagated
+  generation controls, SSE streaming, and explicit pass-or-400 handling for
+  provider-specific tool/format/multimodal support.
 - **Sessions**: multi-turn conversation state with memory injection at turn
   boundaries. Legacy session compression columns were removed in v3.5.
-- **Tenancy**: per-user `owner_id` + `namespace` two-axis gate; root
-  role bypasses both. Live memory reads use owner/federation/world/group
-  visibility; version and DAG history use per-snapshot visibility.
-- **Auth**: Bearer API keys (`/admin/users/{id}/apikeys`), OAuth /
-  OIDC browser login (authlib), RLS-capable schema.
-- **Federation**: pull-based cross-instance sync with Bearer-auth
-  peers, schema-compat preflight, compound feed cursor, per-memory opt-in,
-  and loop-prevention via `federation_source`.
+- **Tenancy**: per-user `owner_id` + `namespace` two-axis gate; root bypasses
+  both. Live memory reads use owner/federation/world/group visibility; version
+  and DAG history use per-snapshot visibility.
+- **Auth**: Bearer API keys (`/admin/users/{id}/apikeys`), OAuth/OIDC browser
+  login (authlib), and RLS-capable schema on the Postgres profile.
+- **Federation**: pull-based cross-instance sync with Bearer-auth peers,
+  schema-compat preflight, compound feed cursor, per-memory opt-in, and
+  loop-prevention via `federation_source`.
 - **Webhooks**: SSRF-hardened outbound delivery with HMAC signing, persisted
   leases, retry-chain convergence, and terminal-success database guard.
-- **Portability**: MPF v0.1.x export + import with sidecars, Docling-based document
-  ingest (optional extra).
+- **Portability**: MPF v0.1.x export/import with sidecars, Docling-based
+  document ingest (optional extra).
 - **Observability**: request-ID ContextVar, Prometheus `/metrics`,
   OpenTelemetry spans (opt-in), structured JSON logs (opt-in).
 - **MORPHEUS**: operator-triggered dream-state runs with REPLAY / CLUSTER /
   SYNTHESISE / COMMIT phases, cluster introspection, namespace scoping, and
   rollback by `morpheus_run_id`.
-- **Recall tracking**: search hits increment `recall_count` and stamp
-  `last_recalled_at` asynchronously.
-- **Two-protocol surface**: REST over HTTP (102 mounted application routes,
-  excluding FastAPI's generated docs/openapi routes) + MCP over stdio and
-  HTTP/SSE from one registry (18 tools).
+- **Two-protocol surface**: REST over HTTP plus MCP over stdio and HTTP/SSE
+  from one tool registry.
 
-### 2.2 Explicitly out of scope at v3.5.x
+### 2.2 Explicitly out of scope at v4.0.0
 
-- Published multi-worker throughput guarantees. Redis-backed reliability
-  primitives support multi-worker operation, but measured load-test ceilings
-  remain TODO.
 - Full per-memory deletion-log / GDPR wipe subsystem. v3.5 keeps DELETE
   tombstone snapshots live in the version DAG, but it does not add a separate
   deletion-log table.
 - Federation per-peer ACL beyond the current peer credentials, namespace
   filters, category filters, and feed role gate.
 - PERSEPHONE archival and MORPHEUS mutation paths (consolidate / archive /
-  extract). These remain v3.6+ work.
-- SQLite backend. Current backend is Postgres-only; SQLite +
-  sqlite-vec for embedded tier is v4/lite-profile work.
+  extract). These move to v4.1+ planning.
+- Web UX in `mnemos-web`, mobile native clients, and Rust rewrites. These are
+  post-v4.0 tracks.
 
 ### 2.3 Non-goals (permanent)
 
 - General-purpose key-value store. Use Redis.
-- Blob storage. Memory content is text; binary handling is upstream
-  of MNEMOS.
-- Inference engine. MNEMOS routes to providers (OpenAI, Together,
-  Groq, local vLLM/Ollama); it does not serve model weights.
-- Application framework. MNEMOS is the memory kernel that agents
-  call; agent logic lives in callers.
+- Blob storage. Memory content is text; binary handling is upstream of MNEMOS.
+- Inference engine. MNEMOS routes to providers (OpenAI, Together, Groq, local
+  vLLM/Ollama); it does not serve model weights.
+- Application framework. MNEMOS is the memory kernel that agents call; agent
+  logic lives in callers.
 
-## 3. Subsystem Inventory
+## 3. Architecture And Subsystem Inventory
 
-Nineteen addressable subsystems grouped into eight layers. Each
-subsystem has a REST router or a worker module or both.
+The v4.0 source tree is organized by boundary:
 
-### 3.1 Storage layer (7 subsystems)
+```text
+mnemos/
+  api/routes/      FastAPI route adapters
+  core/            config, lifecycle, visibility, pool, resilience primitives
+  db/              repository functions and SQL access helpers
+  domain/          business logic: compression, GRAEAE, MORPHEUS, portability
+  persistence/     backend ABC plus Postgres and SQLite implementations
+  mcp/             stdio + HTTP/SSE transports and tool registry
+  webhooks/        validation, dispatcher, delivery/recovery/repair workers
+  workers/         out-of-process background workers
+  hooks/           integration hooks
+  installer/       install wizard, db bootstrap, service generation
+  tools/           CHaron/MPF utilities and adapters
+  cli/             unified Typer command surface
+```
 
-| ID | REST router | DB tables | Role |
-|----|-------------|-----------|------|
-| memories   | `api/handlers/memories.py`   | `memories` | Core CRUD + search (FTS + pgvector hybrid); hot-path compression-variant reads via three-tier COALESCE |
-| versions   | `api/handlers/versions.py`   | `memory_versions`, `memory_branches` | Read-only view over the DAG with per-snapshot visibility |
-| dag        | `api/handlers/dag.py`        | `memory_versions`, `memory_branches` | Git-like operations: log, branch, merge, revert; same-memory parent guards |
-| kg         | `api/handlers/kg.py`         | `kg_triples` | Knowledge-graph triples with subject/predicate/object + vector embeddings on each leg |
-| entities   | `api/handlers/entities.py`   | `entities` | Named-entity registry with tenancy gates |
-| state      | `api/handlers/state.py`      | `state` | Arbitrary key/value state attached to memories |
-| journal    | `api/handlers/journal.py`    | `journal` | Append-only operational log |
+Seven import-linter contracts enforce the architecture in CI: layered
+api -> domain -> persistence/db -> core; API routes do not call `mnemos.db`
+directly; domain modules remain sibling-independent; MCP does not call route
+handlers as functions; webhooks are independent from domain; core has no upward
+dependencies; persistence has no upward dependencies.
 
-### 3.2 Reasoning layer (2 subsystems)
-
-| ID | REST router | DB tables | Role |
-|----|-------------|-----------|------|
-| consultations | `api/handlers/consultations.py` | `graeae_consultations`, `graeae_audit_log`, `consultation_memory_refs` | Multi-LLM consensus reasoning with hash-chain audit |
-| providers    | `api/handlers/providers.py`    | `model_registry`, `model_registry_sync_log` | Provider inventory + model registry + scheduled sync |
-
-Engine-side: `graeae/engine.py` houses the consult() / route() core,
-`graeae/providers/` holds per-provider HTTP adapters (8+ providers),
-`graeae/reliability/` holds circuit breaker + rate limiter + concurrency
-semaphore. Reliability primitives are process-local; see §7.
-
-### 3.3 Access layer (3 subsystems)
+### 3.1 Storage layer
 
 | ID | REST router | DB tables | Role |
 |----|-------------|-----------|------|
-| openai_compat | `api/handlers/openai_compat.py` | (reads `model_registry`, writes `session_messages`) | OpenAI-compatible `/v1/chat/completions` + registry-honest `/v1/models` with compression-aware memory injection, SSE streaming, and provider capability validation |
-| sessions     | `api/handlers/sessions.py`     | `sessions`, `session_messages`, `session_memory_injections` | Multi-turn conversation state, owner+namespace scoped, memory injection at turn boundaries |
-| health       | `api/handlers/health.py`       | (reads `memory_stats`) | Liveness + readiness + statistics |
+| memories | `mnemos/api/routes/memories.py` | `memories` | Core CRUD + search; hot-path compression-variant reads via three-tier COALESCE |
+| versions | `mnemos/api/routes/versions.py` | `memory_versions`, `memory_branches` | Read-only view over the DAG with per-snapshot visibility |
+| dag | `mnemos/api/routes/dag.py` | `memory_versions`, `memory_branches` | Git-like operations: log, branch, merge, revert; same-memory parent guards |
+| kg | `mnemos/api/routes/kg.py` | `kg_triples` | Knowledge-graph triples with subject/predicate/object |
+| entities | `mnemos/api/routes/entities.py` | `entities` | Named-entity registry with tenancy gates |
+| state | `mnemos/api/routes/state.py` | `state` | Arbitrary key/value state attached to memories |
+| journal | `mnemos/api/routes/journal.py` | `journal` | Append-only operational log |
 
-### 3.4 Tenancy + auth (4 subsystems)
+### 3.2 Reasoning layer
 
-| ID | REST router | DB tables | Role |
-|----|-------------|-----------|------|
-| admin     | `api/handlers/admin.py`    | `users`, `api_keys`, `oauth_providers`, `groups`, `user_groups` | User/key/group/provider provisioning (root-only) |
-| oauth     | `api/handlers/oauth.py`    | `oauth_identities`, `oauth_sessions` | OAuth/OIDC browser login (authlib) |
-| (auth resolution — shared) | `api/auth.py` | — | Bearer-token and session-cookie resolver, `owner_id` + `namespace` attachment |
-| (visibility filters — shared)  | `api/visibility.py` | — | `read_visibility_predicate` for live memory reads; `version_visibility_predicate` for historical snapshots; `MN001` → HTTP 409 trigger conflict mapping |
+| ID | REST router / module | DB tables | Role |
+|----|----------------------|-----------|------|
+| consultations | `mnemos/api/routes/consultations.py` + `mnemos/domain/graeae/engine.py` | `graeae_consultations`, `graeae_audit_log`, `consultation_memory_refs` | Multi-LLM reasoning with hash-chain audit |
+| providers | `mnemos/api/routes/providers.py` + `mnemos/domain/graeae/provider_sync.py` | `model_registry`, `model_registry_sync_log` | Provider inventory + model registry + scheduled sync |
 
-### 3.5 Cross-instance (2 subsystems)
+GRAEAE reliability modules live under `mnemos/domain/graeae/`. Redis-backed
+rate limiter, circuit breaker, and concurrency limiter coordinate multi-worker
+server deployments; the in-process fallback is retained for edge/dev and logs a
+warning when used with multiple workers.
 
-| ID | REST router | DB tables | Role |
-|----|-------------|-----------|------|
-| federation | `api/handlers/federation.py` | `federation_peers`, `federation_sync_log` | Pull-based cross-instance memory sync; schema preflight; compound cursor; `owner_id='federation'` sentinel + `federation_source` loop guard |
-| webhooks   | `api/handlers/webhooks.py`   | `webhook_subscriptions`, `webhook_deliveries` | Outbound delivery with SSRF-hardened URL allowlist, HMAC signing, persisted leases, repair/recovery workers, retry-chain guards |
+### 3.3 Access, auth, and cross-instance layers
 
-### 3.6 Portability (3 subsystems)
+| ID | REST router / module | DB tables | Role |
+|----|----------------------|-----------|------|
+| openai_compat | `mnemos/api/routes/openai_compat.py`, `mnemos/domain/openai_compat/` | `model_registry`, `session_messages` | OpenAI-compatible gateway with memory injection and provider capability validation |
+| sessions | `mnemos/api/routes/sessions.py` | `sessions`, `session_messages`, `session_memory_injections` | Multi-turn conversation state |
+| health | `mnemos/api/routes/health.py` | `memory_stats` | Liveness, readiness, profile, and statistics |
+| admin | `mnemos/api/routes/admin.py` | `users`, `api_keys`, `oauth_providers`, `groups`, `user_groups` | User/key/group/provider provisioning |
+| oauth | `mnemos/api/routes/oauth.py` | `oauth_identities`, `oauth_sessions` | OAuth/OIDC browser login |
+| visibility | `mnemos/core/visibility.py` | - | Live and historical read predicates; `MN001` conflict mapping |
+| federation | `mnemos/api/routes/federation.py` | `federation_peers`, `federation_sync_log` | Pull-based peer sync and schema preflight |
+| webhooks | `mnemos/api/routes/webhooks.py`, `mnemos/webhooks/` | `webhook_subscriptions`, `webhook_deliveries` | Outbound delivery, leases, repair/recovery |
+| portability | `mnemos/api/routes/portability.py`, `mnemos/domain/portability/` | - | `/v1/export` + `/v1/import` (MPF v0.1) |
+| document_import | `mnemos/api/routes/document_import.py` | - | Docling-based PDF/DOCX/HTML extraction |
 
-| ID | REST router | DB tables | Role |
-|----|-------------|-----------|------|
-| ingest         | `api/handlers/ingest.py`         | (writes `memories`, `kg_triples`) | Bulk memory import |
-| portability    | `api/handlers/portability.py`    | — | `/v1/export` + `/v1/import` (MPF v0.1) |
-| document_import| `api/handlers/document_import.py`| — | Docling-based PDF/DOCX/HTML extraction into memories (optional `docling` extra) |
+### 3.4 Persistence feature matrix
 
-### 3.7 Observability (1 subsystem, 4 instruments)
+| Capability | PostgresBackend | SqliteBackend |
+|---|---|---|
+| Driver | asyncpg | aiosqlite |
+| Vector search | pgvector | sqlite-vec when available, cosine fallback otherwise |
+| Full-text search | PostgreSQL FTS / tsvector | FTS5 |
+| JSON | jsonb | JSON text + JSON1 |
+| Transactions | ACID, row locks, advisory locks | WAL, serialized writer mutex |
+| Tenancy enforcement | application predicates + optional RLS | application predicates only |
+| Notifications | LISTEN/NOTIFY | polling |
+| Multi-worker profile | supported with Redis | not recommended; edge/dev are single-worker |
 
-| Instrument | Module | Transport | Opt-in |
-|------------|--------|-----------|--------|
-| Request-ID | `api/observability.py`      | `X-Request-ID` header + ContextVar | always on |
-| Prometheus | `api/observability.py`      | `/metrics` endpoint | always on |
-| OpenTelemetry | `api/observability.py`   | OTLP/HTTP export | `tracing` extra + env var |
-| Structured JSON logs | `api/observability.py` | stdout | `structlog` extra + `MNEMOS_STRUCTURED_LOGS=true` |
+### 3.5 Workers, compression, and client protocols
 
-All four share the same `current_request_id()` ContextVar. Middleware
-stack order (outer → inner): RequestID → CORS → Session → SlowAPI →
-Tracing → Prometheus → BodySizeLimit → handler.
+| Surface | Entry point | Role |
+|---|---|---|
+| API | `mnemos.api.main:app` via `mnemos serve` | REST service on port 5002 |
+| CLI | `mnemos.cli.main:app` | `serve`, `install`, `worker`, `export`, `import`, `consult`, `health`, `version` |
+| MCP | `mnemos.mcp.stdio`, `mnemos.mcp.http` | 18 tools from `mnemos/mcp/tools/` |
+| Distillation worker | `mnemos/workers/distillation.py` | Drains `memory_compression_queue`; runs APOLLO + ARTEMIS contests |
+| Registry sync | `scripts/sync_provider_models.py` | Scheduled provider + Arena/LMArena sync |
 
-### 3.8 Out-of-process workers (2 subsystems)
-
-| ID | Module | Role |
-|----|--------|------|
-| distillation_worker | `distillation_worker.py` | Drains `memory_compression_queue` via `process_contest_queue`; runs ARTEMIS + APOLLO engines in parallel per memory; writes winner to `memory_compressed_variants` + full audit to `memory_compression_candidates`; stranded-running sweep at batch head |
-| registry_sync      | `scripts/sync_provider_models.py` + `systemd/graeae-model-sync.timer` | Scheduled pull from provider APIs + Arena.ai/LMArena rankings into `model_registry` |
-
-### 3.9 Compression platform (2 active engines + plugin ABC)
-
-Engines are not REST-addressable; they're contest participants.
-
-| Engine | Module | gpu_intent | Identifier policy | Role |
-|--------|--------|------------|-------------------|------|
-| ARTEMIS   | `compression/artemis.py`   | `cpu_only`     | STRICT | CPU extractive compression with identifier preservation |
-| APOLLO    | `compression/apollo.py` + `compression/apollo_schemas/` | `gpu_optional` | STRICT (schema) / OFF (LLM fallback) | Schema-aware dense encoding with optional LLM fallback |
-
-Contest orchestrator: `compression/contest.py`. Persistence:
-`compression/contest_store.py`. Plugin ABC: `compression/base.py`.
-GPU circuit breaker (per-endpoint, process-local): `compression/gpu_guard.py`.
-
-### 3.10 Client protocols (2)
-
-| Protocol | Entry point | Tools / endpoints |
-|----------|-------------|-------------------|
-| REST over HTTP | `api_server.py` (uvicorn on port 5002) | 102 mounted application routes across 21 routers, excluding generated docs/openapi routes |
-| MCP stdio + HTTP/SSE | `mcp_server.py`, `mcp_http_server.py` | 18 tools (§5.2) from `api/mcp_tools.py::TOOL_REGISTRY` |
+Compression engines live under `mnemos/domain/compression/`: ARTEMIS is
+CPU-only extractive compression; APOLLO is schema-aware dense encoding with
+optional LLM fallback. Contest orchestration, scoring profiles, and persistence
+live in that package and the backend repositories.
 
 ## 4. Data Model
 
@@ -214,7 +200,7 @@ GPU circuit breaker (per-endpoint, process-local): `compression/gpu_guard.py`.
 | 1 | `memories`                       | owner_id, namespace | Core memory content + FTS + embedding |
 | 2 | `memory_versions`                | (inherits)          | DAG version history; `commit_hash`, `parent_version_id`, `merge_parents UUID[]`, `branch` |
 | 3 | `memory_branches`                | (inherits)          | Branch HEAD pointers |
-| 4 | `memory_compression_queue`       | owner_id            | Work queue for distillation_worker |
+| 4 | `memory_compression_queue`       | owner_id            | Work queue for `mnemos/workers/distillation.py` |
 | 5 | `memory_compression_candidates`  | —                   | Full contest audit (winner + losers + reject_reason + scores) |
 | 6 | `memory_compressed_variants`    | —                   | Current winning variant per memory (hot-path read target) |
 | 7 | `memory_stats`                   | —                   | Cached aggregates for `/stats` |
@@ -255,11 +241,11 @@ extension). Default embedding dimension is 768; configurable via
 **Content-addressed column**: `memory_versions.commit_hash` (SHA-256
 of memory_id + version_num + content + snapshot_at). Unique index.
 
-### 4.2 Migrations (38 files)
+### 4.2 Migrations
 
-SQL migrations in `db/` are idempotent. Canonical order is the ordered
-list in `install.py` and `installer/db.py`, mirrored by
-`docker-compose.yml` / `docker-compose.staging.yml` initdb mounts:
+SQL migrations in `db/` and `db/migrations_sqlite/` are idempotent. Canonical
+order is defined in `mnemos/installer/db.py`, mirrored by `docker-compose.yml`
+and `docker-compose.staging.yml` initdb mounts:
 
 1. `migrations.sql` (v1 baseline)
 2. `migrations_v1_multiuser.sql` (users, api_keys, groups, RLS policies)
@@ -322,7 +308,7 @@ belongs to the same memory before ordinary UPDATE/DELETE writes.
 | I4 | `memory_compressed_variants` has at most one current winning row per memory_id (primary key on `memory_id`). |
 | I5 | `memory_compression_candidates` records every attempt per contest; a completed contest selects one winner into `memory_compressed_variants`, while historical winning candidates remain in the candidate log. |
 | I6 | `graeae_audit_log` is a hash-chain: each row's `prev_hash` equals the previous row's `commit_hash` within the same consultation. |
-| I7 | Non-root live-memory reads use the shared owner/federation/world/group predicate from `api/visibility.py:40-96`; writes remain owner+namespace scoped. |
+| I7 | Non-root live-memory reads use the shared owner/federation/world/group predicate from `mnemos/core/visibility.py`; writes remain owner+namespace scoped. |
 | I8 | Non-root historical reads use the snapshot's own `owner_id`, `namespace`, and `permission_mode`; live-memory visibility does not authorize hidden old snapshots. |
 | I9 | DAG walks and branch-head joins are same-memory scoped; `parent_hash` is only emitted for an immediate parent that is also visible. |
 | I10 | Ordinary trigger-driven UPDATE/DELETE must resolve an existing non-NULL same-memory branch HEAD or raise SQLSTATE `MN001`. |
@@ -360,7 +346,7 @@ Surface breakdown:
 | MORPHEUS | 3 | `GET /v1/morpheus/runs`, `GET /v1/morpheus/runs/{id}`, `GET /v1/morpheus/runs/{id}/clusters` |
 
 All REST endpoints use Pydantic request/response models (defined in
-`api/models.py`). All non-public endpoints require Bearer auth or
+`mnemos/domain/models.py`). All non-public endpoints require Bearer auth or
 session cookie. Non-root writes are owner+namespace gated; memory reads
 use the live or per-snapshot visibility predicates described in §10.2.
 
@@ -371,8 +357,8 @@ aware streaming limiter (not just Content-Length check).
 
 ### 5.2 MCP (stdio and HTTP/SSE, 18 tools)
 
-Entry points: `mcp_server.py` and `mcp_http_server.py`. Both use
-`api/mcp_tools.py::TOOL_REGISTRY`. Tool manifest:
+Entry points: `mnemos.mcp.stdio` and `mnemos.mcp.http`. Both use
+the shared tool registry under `mnemos/mcp/tools/`. Tool manifest:
 
 | Tool | Maps to REST |
 |------|--------------|
@@ -440,10 +426,10 @@ OpenAI-compatible field support matrix:
 
 ## 6. State Machines
 
-### 6.1 GPU circuit breaker (`compression/gpu_guard.py`)
+### 6.1 GPU circuit breaker (`mnemos/domain/compression/gpu_guard.py`)
 
-Per-endpoint, process-local. States: `CLOSED → OPEN → HALF_OPEN →
-CLOSED` with:
+Per-endpoint, Redis-backed when configured and in-process otherwise. States:
+`CLOSED → OPEN → HALF_OPEN → CLOSED` with:
 
 - Failure threshold (N consecutive) → open.
 - Probe identity handshake on `HALF_OPEN` (v3.2): each probe carries
@@ -494,7 +480,7 @@ Read contract:
 Write contract:
 
 - `merge_branch` and feature-branch `revert_memory` take the shared
-  `(memory_id, branch)` advisory lock from `api/handlers/dag.py:21-40`
+  `(memory_id, branch)` advisory lock from `mnemos/api/routes/dag.py`
   before row locks.
 - Main-branch revert mutates `memories` under the trigger after checking
   live row drift against the current main HEAD.
@@ -695,13 +681,11 @@ Plus non-`MNEMOS_`-prefixed standards: `GPU_PROVIDER_HOST`,
   application visibility after
   `db/migrations_v3_5_rls_group_select_unix_bits.sql`.
 
-### 10.4 Known gaps (as of v3.5.x)
+### 10.4 Known gaps (as of v4.0.0)
 
-- Horizontal process scaling still requires externalized circuit breakers,
-  rate limiters, dispatch semaphores, and recovery-worker coordination.
 - Full deletion-log/GDPR wipe workflow is not present. DELETE tombstone
   snapshots exist in the version DAG when the delete trigger is attached, but
-  no separate deletion-log table ships in v3.5.x.
+  no separate deletion-log table ships in v4.0.
 - Federation per-peer ACLs beyond bearer identity, role gate, namespace
   filters, and category filters remain future work.
 - No in-process secrets encryption layer (values read from env + config
@@ -717,55 +701,51 @@ Plus non-`MNEMOS_`-prefixed standards: `GPU_PROVIDER_HOST`,
 | Workstation | 4+ cores  | 8 GB   | 20 GB SSD  | Optional (4+ GB VRAM) |
 | Edge        | 2 cores   | 4 GB   | 10 GB      | None (contest disabled) |
 
-### 11.2 Throughput baseline (single-worker)
+### 11.2 Throughput baseline
 
 - API request latency (cached path): 5–30 ms.
 - API request latency (DB path): 20–100 ms.
-- Vector search: <50 ms for corpus ≤100k rows with HNSW.
+- Vector search: <50 ms for corpus <=100k rows with HNSW on Postgres; SQLite
+  profile performance depends on sqlite-vec availability and local storage.
 - Compression contest throughput depends on APOLLO fallback/judge use;
   ARTEMIS and APOLLO schema matches are CPU-cheap.
 
-### 11.3 Throughput baseline (Redis multi-worker)
+### 11.3 Horizontal scaling
 
-Redis-backed multi-worker mode is supported for shared rate-limit and
-circuit-breaker state. Measured multi-worker throughput numbers are not yet
-published.
-
-TODO: add load-test results for 2-worker and 3-worker deployments with Redis.
-
-### 11.4 Horizontal scaling
-
-Single-worker remains the default. Multi-worker is supported with Redis via
+Single-worker remains the default for `edge` and `dev`. Multi-worker is
+supported for `server` with Redis via
 `RATE_LIMIT_STORAGE_URI=redis://host:6379/1`; in-process `memory://` fallback
-logs a startup warning when `MNEMOS_WORKERS > 1` because rate-limit and
-circuit-breaker state can drift between processes.
+logs a startup warning when `MNEMOS_WORKERS > 1` because rate-limit,
+circuit-breaker, and concurrency state can drift between processes.
 
-### 11.5 Backup / restore
+### 11.4 Backup / restore
 
-- `pg_dump` + rolling storage (see `tools/backup/`).
+- `pg_dump` + rolling storage for Postgres (see `mnemos/tools/backup/`).
+- SQLite profile backups must include the `.sqlite3`, WAL, and shm files or
+  checkpoint first.
 - MPF v0.1 `/v1/export` endpoint for portable snapshots (not a
   backup substitute — no audit-log preservation in v0.1).
 
 ## 12. Complexity Indicators
 
-Raw metrics at v3.5.x (`d8a035b`), measured from the checked-out tree unless noted.
+Raw metrics at v4.0.0, measured from the checked-out tree unless noted.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
 | Total Python LOC | ~67,000 | Excludes virtualenvs; simple `wc -l` over Python files |
-| Production LOC | ~40,800 | api + compression + graeae + installer + modules + scripts/tools + morpheus |
+| Production LOC | ~40,800 | `mnemos/` package + scripts/tools |
 | Test LOC | ~24,900 | tests/ only |
-| Python files | 185 | Primary modules + tests |
-| Test files | 74 | Unit + integration + live-gated E2E |
-| Test count | ~900 collected definitions | `rg "def test_|async def test_" tests` count; DB-gated tests are selectively ignored in CI/doc sweeps |
+| Python files | 185+ | Primary modules + tests |
+| Test files | 86 | Unit + integration + live-gated E2E |
+| Test count | 1055+ passing cases in the doc-sweep tier | `pytest` collection includes parametrized cases; DB-gated tests are selectively ignored in CI/doc sweeps |
 | REST endpoints | 102 mounted application routes | Across 21 routers; excludes generated FastAPI docs/openapi routes |
 | MCP tools | 18 | Memory CRUD + KG + stats + DAG + model recommendation |
 | DB tables | 32 | See §4.1 |
-| Migrations | 38 ordered SQL migrations | Idempotent, ordered |
+| Migrations | 39 Postgres SQL files + SQLite mirror chain | Idempotent, ordered |
 | Named concepts | ~40 | See Appendix H |
 | External service protocols | 4 | Postgres wire, HTTP (providers + peers + webhooks + GPU), OAuth/OIDC, MCP stdio |
-| Required Python deps | 18 | See §8.2 |
-| Optional dep groups | 5 | tracing, structlog, docling, full, phi |
+| Required Python deps | 18+ | See §8.2 |
+| Optional dep groups | 6 | build, sqlite, tracing, structlog, docling, full/phi |
 | Env vars (MNEMOS_ prefix) | ~30 | See §9.1 |
 | FK edges | 22+ | Explicit ON DELETE on every edge |
 | Invariants | 10 | See §4.4 |
@@ -879,6 +859,11 @@ See `CHANGELOG.md` for the authoritative list. Selected milestones:
   bulk webhook parity, compression cleanup, and audit closure passes.
 - **v3.5.1** — documentation-triage patch and version metadata correction;
   no product behavior changes from v3.5.0.
+- **v4.0.0** — structural package refactor, `PersistenceBackend`
+  abstraction, Postgres + SQLite backends, `server` / `edge` / `dev`
+  deployment profiles, Redis-coordinated multi-worker support, single-binary
+  distribution, unified `mnemos` CLI, seven import-linter contracts, Pydantic
+  Settings singleton, and seven validated GRAEAE modes.
 
 ---
 
@@ -892,13 +877,13 @@ See `CHANGELOG.md` for the authoritative list. Selected milestones:
 10. openai_compat  11. sessions       12. health
 13. admin          14. oauth          15. federation
 16. webhooks       17. ingest         18. portability
-19. document_import 20. distillation_worker 21. registry_sync
-22. MCP stdio/HTTP server
+19. document_import 20. distillation worker 21. registry_sync
+22. MCP stdio/HTTP server 23. persistence backends 24. unified CLI
 
 ## B. REST endpoint inventory (102 mounted application routes, router-grouped)
 
 (see §5.1 for the count breakdown; full list in the router modules
-at `api/handlers/*.py`)
+at `mnemos/api/routes/*.py`)
 
 ## C. Table inventory (32)
 
@@ -914,9 +899,10 @@ session_memory_injections, session_messages, sessions, state,
 user_groups, users, webhook_deliveries, webhook_subscriptions,
 memory_stats.
 
-## D. Migration inventory (38)
+## D. Migration inventory
 
-Ordered as applied (see §4.2 for detail).
+Postgres and SQLite migration chains are ordered as applied (see §4.2 for the
+Postgres list and `db/migrations_sqlite/` for the SQLite mirror).
 
 ## E. Test inventory (74 test files)
 

--- a/docs/STREAMING_REPLICATION.md
+++ b/docs/STREAMING_REPLICATION.md
@@ -7,8 +7,8 @@ receive WAL from that primary and stay read-only until promoted.
 
 Federation is not the single-site HA mechanism. Keep federation for genuinely
 remote data flows: multi-site deployments, multi-org curated feeds, developer
-laptop replicas with intermittent connectivity, and planned v4 SQLite-based
-local-replica profiles.
+laptop replicas with intermittent connectivity, and v4 SQLite-backed edge
+profiles.
 
 References:
 

--- a/docs/SYSTEM_REQUIREMENTS.md
+++ b/docs/SYSTEM_REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # System Requirements
 
 Reference for operators planning a MNEMOS deployment. Covers the
-resource floor for each of the operating modes that the v3.x line supports
+resource floor for each of the operating modes that the v4.0 line supports
 today, plus what drops off at each tier.
 
 Profiles are descriptive sizing tiers. The feature set is controlled by
@@ -12,29 +12,27 @@ section at the bottom.
 
 | Tier          | CPU     | RAM    | Disk (data) | GPU        | Notes                                              |
 | ------------- | ------- | ------ | ----------- | ---------- | -------------------------------------------------- |
-| **Server**    | 8+ cores| 16 GB+ | 50 GB+ SSD  | CUDA 12+ GPU w/ 8 GB+ VRAM (recommended) | Full contest path (APOLLO + ARTEMIS); Postgres 15+ on same host or nearby |
-| **Workstation** | 4+ cores | 8 GB  | 20 GB SSD  | Optional GPU (4 GB+ VRAM acceptable)     | Full contest path; APOLLO LLM fallback uses GPU when configured |
-| **Edge**      | 2 cores | 4 GB   | 10 GB       | None       | Contest path disabled via `MNEMOS_CONTEST_ENABLED=false`; compression queue is not drained |
+| **Server**    | 8+ cores| 16 GB+ | 50 GB+ SSD  | CUDA 12+ GPU w/ 8 GB+ VRAM (recommended) | Postgres + pgvector + Redis; multi-worker supported |
+| **Workstation** | 4+ cores | 8 GB  | 20 GB SSD  | Optional GPU (4 GB+ VRAM acceptable)     | `dev` profile with SQLite, or `server` profile for local Postgres |
+| **Edge**      | 2 cores | 4 GB   | 10 GB       | None       | SQLite + sqlite-vec single-worker profile |
 
-Embedded Pi-class is now a **lite-profile target** (SQLite + sqlite-vec
-backend) and is out of scope for the current Postgres-only branch. Pi 4 class is the intended
-floor for the embedded tier when it lands.
+Embedded Pi-class is now the **edge** profile target (SQLite + sqlite-vec
+backend). Pi 4 class is the intended floor for the embedded tier.
 
 ## Baseline requirements (all tiers)
 
 * **Python**: 3.11+ (`tomllib` stdlib dependency)
-* **Postgres**: 15+ with `pgvector` extension. Either co-located or on
-  a local network (latency < 5 ms for the worker's dequeue path to
-  keep up with production ingest).
+* **Database**: SQLite for `edge`/`dev`; Postgres 15+ with `pgvector`
+  extension for `server`. Server multi-worker deployments also need Redis.
 * **Disk**: corpus + manifests + backups.
   - Memory text: ~1 KB/row average; 100k rows ≈ 100 MB.
   - v3.1 compression candidates: ~1.5x the memory row count, ~2 KB/row.
-  - Backups: see `tools/backup/` — daily pg_dump + weekly rsync
+  - Backups: see `mnemos/tools/backup/` — daily pg_dump + weekly rsync
     pattern uses another ~2x the live corpus size in rolling storage.
-* **Network**: internal only for the v3.1 contest path; outbound only
+* **Network**: internal only for the contest path; outbound only
   required if using an externally hosted embedding/LLM endpoint.
 
-## Server tier — full v3.1 feature set
+## Server tier — full v4.0 feature set
 
 Intended for the primary deployment host that runs the API + worker
 for production ingest.
@@ -113,13 +111,13 @@ From real deployments as of 2026-04-23:
 These are operational rather than prescriptive — real workloads will
 differ. Use these as a sanity check when sizing a new host.
 
-## v3.5.x deployment note
+## Deployment note
 
 Docker fresh volumes run all mounted initdb migrations. Existing volumes
-do not. For v3.5.x, the compose files include a one-shot
-`postgres-upgrade` service so the trigger replacement migration applies
-to existing data directories before MNEMOS starts.
+do not. The compose files include a one-shot `postgres-upgrade` service so the
+ordered migration tail applies to existing data directories before MNEMOS
+starts.
 
 ---
 
-*Last updated: 2026-04-28 (v3.5.1 doc triage)*
+*Last updated: 2026-04-29 (v4.0.0 doc triage)*

--- a/docs/V3_5_CHARTER.md
+++ b/docs/V3_5_CHARTER.md
@@ -355,11 +355,11 @@ With IRIS in place, other MCP-aware frameworks (Hermes, Continue, AutoGPT, CrewA
 
 ## 4. Explicitly NOT in v3.5
 
-- **KRONOS** (Tesseract time-series integration) → v4.0
-- **API consolidation pass** (unifying security, pool, IDs logic) → v4.0
-- **MCP consolidation** (merging `mcp_server.py` + `api/mcp_tools.py`) → v4.0
-- **Encrypted CHARON envelopes** (NaCl-style optional encryption) → v4.0
-- **GDPR wipe path** (right-to-be-forgotten for compliance) → v4.0
+- **KRONOS** (Tesseract time-series integration) → deferred beyond v4.0
+- **API/package consolidation** → shipped in v4.0
+- **MCP memory-tool consolidation** → shipped in v4.0 under `mnemos/mcp/tools/`
+- **Encrypted CHARON envelopes** (NaCl-style optional encryption) → deferred beyond v4.0
+- **GDPR wipe path** (right-to-be-forgotten for compliance) → deferred beyond v4.0
 - **Rust ports** → v5.0
 - **Full PERSEPHONE archival** (cold-set rotation) → v3.6; foundation only in v3.5
 - **APOLLO S-IVB phases 3–4** (CONSOLIDATE / ARCHIVE / EXTRACT mutation paths) → v3.6; EXTRACT mining only in v3.5

--- a/docs/V3_6_CHARTER.md
+++ b/docs/V3_6_CHARTER.md
@@ -1,7 +1,9 @@
 # MNEMOS v3.6 Charter — APOLLO S-IVB Evolution + IRIS Second-Wave Adoption + Mutation Paths
 
-**Status:** Forward-looking specification (target: ships after v3.5.x; not shipped in v3.5.0 or v3.5.1)
-**Position in roadmap:** Extends APOLLO S-IVB work after the v3.5.0 hardening release; broadens any shipped IRIS adoption across frameworks; sets stage for v4.0 consolidation.
+**Status:** Historical / deferred specification. v4.0.0 shipped on 2026-04-29
+without this v3.6 feature bundle; unshipped items move to v4.1+ planning.
+**Position in roadmap:** Preserved as design context for APOLLO S-IVB,
+PERSEPHONE, and IRIS adoption ideas. It no longer gates v4.0.
 **Theme:** *Derivative-idea layers + memory state evolution + industry-wide IRIS adoption.*
 
 ---
@@ -165,11 +167,11 @@ env = {PANTHEON_API_KEY = "..."}
 
 ## 3. Explicitly NOT in v3.6
 
-- **KRONOS** (Tesseract time-series) → v4.0
-- **API consolidation pass** → v4.0
-- **MCP consolidation** → v4.0
-- **Encrypted CHARON envelopes** → v4.0
-- **GDPR wipe path** → v4.0
+- **KRONOS** (Tesseract time-series) → deferred beyond v4.0
+- **API consolidation pass** → shipped in v4.0
+- **MCP memory-tool consolidation** → shipped in v4.0; IRIS discovery remains deferred
+- **Encrypted CHARON envelopes** → deferred beyond v4.0
+- **GDPR wipe path** → deferred beyond v4.0
 - **Rust ports** → v5.0
 - **PANTHEON streaming-via-MQ** (Nats-token-by-token) → v4.1 (bypass-direct sufficient for v3.6)
 - **Content-hash caching layer for reasoning workloads** → v4.1
@@ -226,13 +228,14 @@ v3.6 GA gate:
 
 ## 7. Post-v3.6 preview
 
-v3.6 GA unlocks the v4.0 sprint:
+Historical v3.6 framing expected this work to unlock the v4.0 sprint. Actual
+v4.0 shipped the structural pieces directly:
 
-- **API consolidation:** Now that APOLLO S-IVB dream-state, compression, and archival are stable, consolidate the 9 handler files' security/pool/ID patterns into reusable modules.
-- **MCP consolidation:** Merge `mcp_server.py` + `api/mcp_tools.py` into one source of truth.
-- **Horizontal scaling:** Move GRAEAE breaker + rate-limit state from in-process to Redis (unlock multi-worker PANTHEON deployment).
-- **GPU expansion:** Deploy KRONOS + Tesseract on CERBERUS/TYPHON; measure time-series anomaly detection + forecasting cost/accuracy.
-- **MCP-MD v1.0 stabilization:** Throughout v3.5–v3.6, the MCP-MD specification collects feedback from second-wave implementer adoption (Hermes, Continue, AutoGPT, CrewAI). By v4.0 entry, the specification is ready for promotion to v1.0 (stable contract; breaking changes require v2). v1.0 stabilization gates the formal proposal to Linux Foundation AI & Data for Sandbox standardization.
+- **API/package consolidation:** Shipped in v4.0 as the coherent `mnemos/` package.
+- **MCP consolidation:** Memory tools now live under `mnemos/mcp/tools/`; IRIS discovery remains deferred.
+- **Horizontal scaling:** Shipped in v4.0 with Redis-backed breaker/rate-limit/concurrency state.
+- **GPU expansion / KRONOS:** Deferred.
+- **MCP-MD v1.0 stabilization:** Deferred to v5.0+ foundation-tier work.
 
 ---
 
@@ -244,7 +247,9 @@ v3.6 GA unlocks the v4.0 sprint:
 - **APOLLO S-IVB dream-state:** Foundation in v3.3, slice 2 in v3.3 (parallel), phases 3–4 in v3.6.
 - **PERSEPHONE archival:** Planned for v3.6; no v3.5.0 archival foundation shipped beyond recall tracking already present from v3.3.
 - **Design papers:** Existing `PANTHEON.md`, new `IRIS_DISCOVERY.md`, `DREAM_STATE_DESIGN.md`, new `MEMORY_ARCHITECTURE.md` (v3.6).
-- **v4.0 next:** Modularization, GPU scaling, surface integrations, IRIS expansion to all ETLANTIS operations.
+- **v4.0 actual:** Modularization, SQLite profile, single-binary distribution,
+  multi-worker Redis support, and architectural enforcement shipped; GPU
+  scaling, broad surface integrations, and IRIS expansion moved later.
 
 ---
 

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -1,8 +1,31 @@
 # MNEMOS v4.0 Plan — ETLANTIS Universe Consolidation + GPU Stack
 
-**Status:** Architecture specification (target: ships after v3.6 GA)
-**Position in roadmap:** Forward-looking v4 architecture plan after the v3.5.x hardening release and planned v3.6 work; opens horizontal scaling + GPU integration.
-**Theme:** *Structural refactoring + GPU-backed AI infrastructure + unified ETLANTIS Universe.*
+**STATUS: SHIPPED v4.0.0 on 2026-04-29.**
+**Position in roadmap:** Historical v4 planning record. Tracks 5, 5b, and 8
+shipped in v4.0.0; the body is preserved as planning context, not current
+commitment.
+**Theme:** *Structural refactoring + multi-backend persistence + horizontal scaling.*
+
+## 0. Shipped / Deferred Summary
+
+Shipped in v4.0.0:
+
+- ✅ Track 5: API/package consolidation into the coherent `mnemos/` package,
+  with 7 import-linter contracts enforcing architecture.
+- ✅ Track 5b: persistence abstraction, Postgres + SQLite backends, `server` /
+  `edge` / `dev` profiles, and PyInstaller single-binary distribution.
+- ✅ Track 8: Redis-backed horizontal scaling primitives and removal of the
+  production `workers=1` pin.
+- ✅ Unified `mnemos` CLI and Pydantic Settings singleton.
+
+Deferred / reframed after the 2026-04-29 v4.0 ship decision:
+
+- 🔵 Track 3 IRIS operations discovery: v4.1/v5.0 timeframe.
+- 🔵 Track 6 connectors gallery expansion: v4.1.
+- 🔵 Track 7 MCP-MD LF AI & Data standardization: v5.0+ foundation-tier work.
+- 🔵 KRONOS/GPU-stack integration, hosted MNEMOS Cloud, Rust rewrites, web UX,
+  and mobile clients: v4.1/v5.0+ depending on product pressure. Rust rewrites
+  are explicitly deferred per user direction on 2026-04-29.
 
 ---
 
@@ -20,7 +43,7 @@ Post-v4.0, MNEMOS is production-ready for enterprise deployment; v5.0 pivots to 
 
 ---
 
-## 2. Track 5: API consolidation pass
+## 2. Track 5: API consolidation pass — SHIPPED in v4.0.0
 
 ### 2.1 `api/security.py` — unified authorization
 
@@ -158,9 +181,11 @@ contracts = [
 
 ---
 
-## 3. Track 7: MCP-MD v1.0 stabilization + Linux Foundation AI & Data proposal track
+## 3. Track 7: MCP-MD v1.0 stabilization + Linux Foundation AI & Data proposal track — DEFERRED to v5.0+
 
-**Strategic context:** This assumes MCP-MD (MCP Model Discovery) and IRIS have shipped before v4.0. They did not ship in v3.5.0 or v3.5.1; treat this section as conditional forward-looking scope.
+**Strategic context:** This assumed MCP-MD (MCP Model Discovery) and IRIS would
+ship before v4.0. They did not. Treat this section as a v5.0+ foundation-tier
+standardization record.
 
 **v4.0 deliverables:**
 
@@ -189,9 +214,11 @@ The proposal follows LF's standard Sandbox project intake — no expedited track
 
 ---
 
-## 3. Track 3: IRIS expansion to full ETLANTIS operations discovery
+## 3. Track 3: IRIS expansion to full ETLANTIS operations discovery — DEFERRED to v4.1/v5.0
 
-**Strategic context:** Once IRIS exists for model discovery (capability-based selection of PANTHEON models), v4.0 generalizes IRIS to expose **all ETLANTIS operations** — not just models, but also compression engines, dream-state generators, time-series forecasters, etc. Agents query IRIS for "show me anomaly detectors with <3s latency" or "which clustering algorithm is most memory-efficient?" instead of hardcoding operation names.
+**Strategic context:** Once IRIS exists for model discovery (capability-based
+selection of PANTHEON models), later releases can generalize IRIS to expose
+operations beyond models. This did not ship in v4.0.
 
 ### 3.1 Extend IRIS tools + resources beyond models
 
@@ -225,7 +252,7 @@ This is the single source of truth for IRIS's operations discovery. Each subsyst
 
 ---
 
-## 3.3 SQLite "lite" profile (persistence abstraction first)
+## 3.3 SQLite "lite" profile (persistence abstraction first) — SHIPPED in v4.0.0
 
 ### 3.1 Persistence abstraction layer
 
@@ -302,7 +329,7 @@ pyinstaller --onefile mnemos-cli.spec
 
 ---
 
-## 4. Track 6: Surface integrations + MCP consolidation
+## 4. Track 6: Surface integrations + MCP consolidation — PARTIAL, remainder v4.1
 
 ### 4.1 MCP consolidation (unified tool source + IRIS integration)
 
@@ -718,18 +745,18 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 
 ---
 
-## 11. Effort estimate
+## 11. Effort estimate (historical)
 
 | Work stream | Effort (days) | Dependencies |
 |---|---|---|
-| Track 5: API consolidation | 7–8 | None (can start immediately) |
-| **Track 3: IRIS operations discovery expansion** | **4–5** | **None (can start in parallel with Track 5)** |
-| Track 5b: Persistence abstraction + SQLite | 8–10 | None (can start immediately) |
-| **Track 6: MCP consolidation (unified MNEMOS + IRIS server)** | **3** | **IRIS expansion (§3.1–3.2) should be complete before consolidation** |
-| Track 6b: Connectors gallery | 7–10 | MCP consolidation first, then connectors in parallel |
-| KRONOS / Tesseract GPU stack (with IRIS integration) | 5–6 | IRIS expansion (so health state flows to discovery) |
+| Track 5: API consolidation | 7–8 | ✅ shipped in v4.0.0 |
+| Track 3: IRIS operations discovery expansion | 4–5 | 🔵 deferred to v4.1/v5.0 |
+| Track 5b: Persistence abstraction + SQLite | 8–10 | ✅ shipped in v4.0.0 |
+| Track 6: MCP consolidation (unified MNEMOS + IRIS server) | 3 | 🔵 non-IRIS MCP surface shipped; IRIS consolidation deferred |
+| Track 6b: Connectors gallery | 7–10 | 🔵 v4.1 |
+| KRONOS / Tesseract GPU stack (with IRIS integration) | 5–6 | 🔵 deferred |
 | Security + compliance (token rotation, GDPR, audits) | 6–7 | Consolidation items first (so we know where security logic lives) |
-| Horizontal scaling (Redis) | 3–4 | Consolidation first |
+| Horizontal scaling (Redis) | 3–4 | ✅ shipped in v4.0.0 |
 | Docs + governance | 9 | All other items mostly done |
 
 **Total:** ~55–70 days focused work. **Calendar:** 7–9 weeks (2 dev-weeks/person in parallel). **Team:** 1–2 engineers.
@@ -738,30 +765,26 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 
 ---
 
-## 12. Success criteria
+## 12. v4.0.0 Success Criteria
 
-- ✅ All 9 handler files use centralized `api/security.py`, `api/pool.py`, `api/ids.py`.
-- ✅ **IRIS operations discovery** operational: agents query IRIS for compression engines, dream generators, anomaly detectors, forecasters + models; health state synchronized across subsystems.
-- ✅ **Unified MCP server** (`pantheon-mnemos`) serves both memory operations + discovery tools; separate IRIS server deprecated.
-- ✅ SQLite persistence layer works end-to-end (create memory → search → archive → restore on SQLite and Postgres).
-- ✅ Single-binary MNEMOS-CLI executable ships.
-- ✅ **IRIS adoption ecosystem:** Hermes, Continue, AutoGPT, CrewAI all ship with IRIS pre-configured (config-only; no code donations).
-- ✅ `docs/connectors/` covers 8+ surfaces with working smoke tests; includes IRIS discovery examples.
-- ✅ KRONOS (Tesseract) deployed; anomaly detection + forecasting producing actionable alerts; alerts reflected in IRIS health state.
-- ✅ Token rotation + revocation working; GDPR wipe path tested.
-- ✅ MCP tool surface audit clean (Codex adversarial review passed; includes discovery tools).
-- ✅ Horizontal scaling validated: 3-worker MNEMOS setup using Redis for shared state; load-test passes.
-- ✅ All docs (SECURITY.md, GOVERNANCE.md, CONTRIBUTING.md, PROJECT_POSTURE.md, IRIS_DISCOVERY.md, compression semantics, CHARON trust) published.
+- ✅ Codebase lives under coherent `mnemos/` package boundaries.
+- ✅ Persistence abstraction works with Postgres and SQLite.
+- ✅ `server`, `edge`, and `dev` profiles are selectable through settings or CLI.
+- ✅ Single-binary artifacts build for the official v4.0 matrix.
+- ✅ MCP memory tool surface remains unified across stdio and HTTP/SSE.
+- ✅ Horizontal scaling primitives use Redis when configured; in-process fallback warns for multi-worker.
+- ✅ Seven import-linter contracts enforce the package architecture.
+- 🔵 Connector gallery, IRIS, KRONOS, GDPR wipe path, and foundation-standardization work are explicitly deferred.
 
 ---
 
 ## 13. Post-v4.0 vision (v5.0+)
 
-**Once v4.0 GA lands:**
+**After v4.0 GA:**
 
 1. **Foundation visibility work** — academic papers on MNEMOS memory architecture + APOLLO compression (target: NeurIPS 2027, ICML workshops).
 2. **Sustained-quality upstream contributions** — small, high-value patches to MemPalace, Cognee, Graphiti, langgraph.
-3. **Rust ports** — `mnemos-rs` (same API, native performance).
+3. **Rust ports** — `mnemos-rs` and selected hot-path rewrites are deferred until the Python v4 architecture has production soak.
 4. **ETLANTIS Universe federation demo** — zeroclaw + zterm + MNEMOS + nclawzero agents sharing memory across system boundaries.
 5. **Foundation exploration** — once multi-implementer adoption is established, scope conversations with senior LF AI & Data practitioners about MNEMOS or MCP-MD as a potential LF-hosted project. No fast-track sought.
 
@@ -778,9 +801,9 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 | CHARON | ferryman | cross-system portability | ✅ v0.2 |
 | GRAEAE | gray sisters | multi-LLM consensus | ✅ core |
 | PANTHEON | temple of all gods | unified LLM gateway | 🔵 prerequisite / planned |
-| IRIS | messenger of the gods | MCP discovery + capability-based selection (models + all ETLANTIS ops) | 🔵 planned expansion |
-| KRONOS | titan of time | time-series anomaly + forecasting | ✅ Tesseract integrated |
-| PERSEPHONE | queen of the underworld | archival subsystem | ✅ v3.6 |
+| IRIS | messenger of the gods | MCP discovery + capability-based selection (models + all ETLANTIS ops) | 🔵 deferred to v4.1/v5.0 |
+| KRONOS | titan of time | time-series anomaly + forecasting | 🔵 deferred |
+| PERSEPHONE | queen of the underworld | archival subsystem | 🔵 deferred |
 
 ---
 
@@ -788,7 +811,10 @@ All items from the Audit Remediation Log in ROADMAP.md that remain open post-v3.
 
 - **v3.5 shipped reality:** audit hardening, uniform tenancy, webhook retry/outbox discipline, MCP registry parity, faithful OpenAI compatibility, streaming-replication doctrine, compression cleanup, and documentation triage in v3.5.1. PANTHEON/IRIS and APOLLO EXTRACT did not ship in v3.5.x.
 - **v3.6 charter:** CONSOLIDATE, PERSEPHONE, APOLLO S-IVB phases 3–4, IRIS second-wave adoption.
-- **v4.0 plan:** API consolidation, IRIS operations discovery expansion, unified MCP server, KRONOS integration.
+- **v4.0 shipped reality:** package/API consolidation, persistence abstraction,
+  SQLite profile, single-binary distribution, multi-worker Redis support, and
+  architectural enforcement. IRIS operations discovery, connector gallery
+  expansion, MCP-MD LF work, and KRONOS integration moved beyond v4.0.
 - **ROADMAP.md:** Full history + audit log.
 - **Existing docs:** PANTHEON.md, IRIS_DISCOVERY.md (new v4.0), DREAM_STATE_DESIGN.md, MEMORY_EXPORT_FORMAT.md, SPECIFICATION.md.
 - **ETLANTIS Universe repos:** zeroclaw, zterm, nclawzero, meta-nclawzero, pi-gen-nclawzero.

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -6,8 +6,8 @@
 > Codex CLI). Defaults are off; configuration is opt-in; surface area is
 > intentionally narrow. APIs may change between minor releases without a
 > deprecation cycle until the surface is promoted to `stable` in a later
-> release. v3.5.0 shipped stdio/HTTP registry parity, but remote connector
-> packaging remains experimental.
+> release. v4.0.0 keeps stdio/HTTP registry parity in the `mnemos.mcp`
+> package, but broad remote connector packaging remains experimental.
 
 ## Audience
 
@@ -68,13 +68,12 @@ register it as a Custom Connector, paste the bearer token. See:
 
 ### Mobile / laptop tether to a home or SOHO MNEMOS
 
-The "MNEMOS Lite" laptop edition (planned v4.0) runs a single-tenant
-SQLite-backed MNEMOS locally and tethers to your authoritative
+The v4 `edge` profile runs a single-tenant SQLite-backed MNEMOS locally and
+tethers to your authoritative
 MNEMOS on a server via federation. Same MCP surface, offline-tolerant,
-conflict resolution via the existing version DAG. Until lite ships,
-power users use SSH port-forwarding or Tailscale to point a local
-agent at a remote MNEMOS — the MCP server doesn't care which transport
-delivers the bytes.
+conflict resolution via the existing version DAG. Power users can also use SSH
+port-forwarding or Tailscale to point a local agent at a remote MNEMOS; the MCP
+server does not care which transport delivers the bytes.
 
 ## Why we publish these as experimental
 
@@ -88,7 +87,7 @@ Three reasons:
    2026 building an installer-app for the consumer market — that's a
    different product with a different operations footprint. The
    connectors targeting that market (a hosted SaaS, a Tauri desktop
-   app) aren't on the roadmap. See `ROADMAP.md` for the v4.x charter.
+   app) are v5.0+ framing, not v4.0 scope. See `ROADMAP.md`.
 3. **We are not trying to displace MemPalace, OpenWebUI, Mem0, Letta,
    Graphiti, or Cognee**. Each of those serves a real audience well.
    MNEMOS exists for users who outgrew them or whose workload —
@@ -154,8 +153,8 @@ open to them. Public evidence:
 - **MemPalace, Mem0, Letta, Graphiti, Cognee**: bug reports and
   goodwill PRs as we encounter issues testing the CHARON adapters
   against real instances. The first wave of upstream MemPalace
-  contributions and KNOSSOS bridge RFC re-engagement is deferred after
-  v3.5.0. See `ROADMAP.md`.
+  contributions and KNOSSOS bridge RFC re-engagement remain staged work. See
+  `ROADMAP.md`.
 
 We'll grow this list as PRs land. The principle is simple: when
 KNOSSOS or CHARON adapters surface bugs in upstream memory systems,

--- a/docs/connectors/chatgpt-pro-developer-mode.md
+++ b/docs/connectors/chatgpt-pro-developer-mode.md
@@ -46,10 +46,9 @@ service; everything stays in your MNEMOS.
                   via tunnel: ngrok / cloudflared / Tailscale
 ```
 
-The MCP HTTP/SSE bridge (`mcp_http_server.py`) shares the exact same
-`Server("mnemos")` instance and 18 tool definitions as the stdio MCP
-server. A memory written from Claude Desktop is queryable from
-ChatGPT and vice versa.
+The MCP HTTP/SSE bridge (`mnemos serve mcp-http`) shares the exact same
+18 tool definitions as the stdio MCP server. A memory written from Claude
+Desktop is queryable from ChatGPT and vice versa.
 
 ## Setup — manual path (works today)
 
@@ -60,12 +59,12 @@ Add to your `docker-compose.override.yml` (PYTHIA prod example):
 ```yaml
 services:
   mnemos-mcp-http:
-    image: mnemos-v3x-mnemos
+    image: ghcr.io/mnemos-os/mnemos:4.0.0
     pull_policy: never
     depends_on:
       - mnemos
     restart: unless-stopped
-    command: ["python3", "/app/mcp_http_server.py", "--host", "0.0.0.0", "--port", "5004"]
+    command: ["mnemos", "serve", "mcp-http", "--host", "0.0.0.0", "--port", "5004"]
     ports:
       - "5004:5004"
     environment:
@@ -210,7 +209,7 @@ token, prints the connector config, and copies URL+token to your clipboard.
 
 - **ngrok free tier URL rotates**: re-paste into ChatGPT after every
   ngrok restart. Use the paid tier or Cloudflare Named Tunnel to fix.
-- **TLS is the tunnel's responsibility**: `mcp_http_server.py` listens
+- **TLS is the tunnel's responsibility**: `mnemos serve mcp-http` listens
   on plain HTTP. Never bind it to a public IP without the tunnel
   providing TLS termination.
 - **No OAuth on the MCP edge yet**: bearer auth only. Anyone with the token can

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -8,7 +8,10 @@ Each bundle contains:
 - A **config snippet** for the framework's MCP / hook system.
 - A **README** with install steps specific to that framework.
 
-All bundles talk to MNEMOS through the stdio MCP server at `mcp_server.py` in the repo root. **You must set `MNEMOS_BASE`** to your MNEMOS deployment's URL — there is no default. MNEMOS is network infrastructure; localhost is not a meaningful fallback.
+All bundles talk to MNEMOS through the stdio MCP transport (`mnemos serve
+mcp-stdio`, implemented by `mnemos.mcp.stdio`). **You must set `MNEMOS_BASE`**
+to your MNEMOS deployment's URL — there is no default. MNEMOS is network
+infrastructure; localhost is not a meaningful fallback.
 
 | Bundle | Discovery | Access | Enforcement |
 |--------|-----------|--------|-------------|
@@ -25,14 +28,18 @@ MNEMOS is designed to run as a shared network service on a dedicated host (a "me
 
 Pick your deployment URL:
 
-- **Unified MNEMOS+GRAEAE:** `http://mnemos.internal:5002` (default in v3)
+- **Unified MNEMOS+GRAEAE:** `http://mnemos.internal:5002`
 - **Loopback-only personal dev:** `http://127.0.0.1:5002`
 
-Use the same `MNEMOS_BASE` value everywhere. If you run team or enterprise profile, set `MNEMOS_API_KEY` too.
+Use the same `MNEMOS_BASE` value everywhere. If you run the `server` profile
+with auth enabled, set `MNEMOS_API_KEY` too.
 
 ## Authentication
 
-Set `MNEMOS_API_KEY` in the MCP server's environment — `mcp_server.py` attaches `Authorization: Bearer $MNEMOS_API_KEY` on every outbound HTTP request when the var is set, and omits the header when it isn't. For personal-profile installs (no auth) leave it unset.
+Set `MNEMOS_API_KEY` in the MCP server's environment; the v4 MCP transport
+attaches `Authorization: Bearer $MNEMOS_API_KEY` on every outbound HTTP request
+when the var is set, and omits the header when it isn't. For unauthenticated
+edge/dev installs, leave it unset.
 
 The bundled MCP config examples may still omit `MNEMOS_API_KEY` — add it to the `env` block of each framework's MCP server entry if you run team or enterprise profile:
 
@@ -40,8 +47,8 @@ The bundled MCP config examples may still omit `MNEMOS_API_KEY` — add it to th
 {
   "mcpServers": {
     "mnemos": {
-      "command": "python",
-      "args": ["/opt/mnemos/mcp_server.py"],
+      "command": "/opt/mnemos/venv/bin/mnemos",
+      "args": ["serve", "mcp-stdio"],
       "env": {
         "MNEMOS_BASE": "http://mnemos.internal:5002",
         "MNEMOS_API_KEY": "mnemos_..."   // only if MNEMOS has auth enabled
@@ -56,4 +63,4 @@ The Claude Code hooks (bundle in `claude-code/hooks/`) already handle `MNEMOS_AP
 Alternative transports for operators who don't want the token in a local env file:
 
 1. Run the MCP server on the same host as MNEMOS with MNEMOS bound to loopback (`listen_host = "127.0.0.1"`). Local MCP connects without auth; external network can't reach MNEMOS directly.
-2. Use SSH transport: `command: ssh` and `args: ["user@host", "/opt/mnemos/venv/bin/python", "/opt/mnemos/mcp_server.py"]`. Credentials ride the SSH channel, not the MCP config.
+2. Use SSH transport: `command: ssh` and `args: ["user@host", "/opt/mnemos/venv/bin/mnemos", "serve", "mcp-stdio"]`. Credentials ride the SSH channel, not the MCP config.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -6,7 +6,7 @@ Two integration modes. You can use either or both.
 
 Set `MNEMOS_BASE` to your MNEMOS deployment's URL. **There is no default** — MNEMOS is network infrastructure, not an embedded library. Typical values:
 
-- `http://mnemos.internal:5002` — unified MNEMOS+GRAEAE (default in v3)
+- `http://mnemos.internal:5002` — unified MNEMOS+GRAEAE
 - `http://127.0.0.1:5002` — loopback-only personal dev
 
 ## 1. MCP server (recommended)
@@ -17,7 +17,7 @@ Gives Claude Code direct tool access to MNEMOS: `search_memories`, `create_memor
 
 ```bash
 cp integrations/claude-code/mcp.example.json ./.mcp.json
-# edit .mcp.json — set MNEMOS_BASE and the absolute path to mcp_server.py
+# edit .mcp.json — set MNEMOS_BASE and the absolute path to the mnemos CLI
 ```
 
 Claude Code auto-detects `.mcp.json` on session start.

--- a/integrations/claude-code/mcp.example.json
+++ b/integrations/claude-code/mcp.example.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "mnemos": {
-      "command": "python",
-      "args": ["/path/to/mnemos/mcp_server.py"],
+      "command": "/path/to/mnemos/venv/bin/mnemos",
+      "args": ["serve", "mcp-stdio"],
       "env": {
-        "MNEMOS_BASE": "http://<your-mnemos-host>:5000"
+        "MNEMOS_BASE": "http://<your-mnemos-host>:5002"
       }
     }
   }

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -12,8 +12,8 @@
 2. Register MNEMOS as an MCP server via the Hermes CLI:
    ```bash
    hermes mcp add mnemos \
-     --command python \
-     --args "/path/to/mnemos/mcp_server.py" \
+     --command /path/to/mnemos/venv/bin/mnemos \
+     --args "serve mcp-stdio" \
      --env MNEMOS_BASE=http://mnemos.internal:5002
    ```
 

--- a/integrations/hermes/mcp_servers.example.yaml
+++ b/integrations/hermes/mcp_servers.example.yaml
@@ -3,8 +3,8 @@
 
 mcp_servers:
   mnemos:
-    command: python
-    args: ["/path/to/mnemos/mcp_server.py"]
+    command: /path/to/mnemos/venv/bin/mnemos
+    args: ["serve", "mcp-stdio"]
     env:
-      MNEMOS_BASE: "http://<your-mnemos-host>:5000"
+      MNEMOS_BASE: "http://<your-mnemos-host>:5002"
       # MNEMOS_API_KEY: "<optional-bearer-key-for-team-enterprise-profiles>"

--- a/integrations/hermes/optional-skills/memory/mnemos/SKILL.md
+++ b/integrations/hermes/optional-skills/memory/mnemos/SKILL.md
@@ -31,8 +31,8 @@ MNEMOS is persistent memory infrastructure running as a separate network service
 
 ```bash
 hermes mcp add mnemos \
-  --command python \
-  --args "/path/to/mnemos/mcp_server.py" \
+  --command /path/to/mnemos/venv/bin/mnemos \
+  --args "serve mcp-stdio" \
   --env MNEMOS_BASE=http://mnemos.internal:5002
 ```
 
@@ -41,8 +41,8 @@ Or edit `~/.hermes/config.yaml` directly (replace placeholder with your MNEMOS h
 ```yaml
 mcp_servers:
   mnemos:
-    command: python
-    args: ["/path/to/mnemos/mcp_server.py"]
+    command: /path/to/mnemos/venv/bin/mnemos
+    args: ["serve", "mcp-stdio"]
     env:
       MNEMOS_BASE: http://<your-mnemos-host>:5002
 ```
@@ -78,7 +78,7 @@ results = mcp.call("mnemos", "search_memories", {
 })
 
 # Large context load under a token budget — REST endpoint (not an MCP tool
-# in the current mcp_server.py). Use via httpx against MNEMOS directly, or
+# in the current `mnemos serve mcp-stdio` transport). Use via httpx against MNEMOS directly, or
 # chain several search_memories calls with a running token tally.
 #
 # POST /v1/memories/rehydrate
@@ -140,7 +140,7 @@ Before acting on a retrieved memory:
 MNEMOS API is not running, or `MNEMOS_BASE` points to the wrong host/port. Check with `curl $MNEMOS_BASE/health`.
 
 **Authentication errors on team/enterprise profiles**
-`mcp_server.py` forwards Bearer tokens when `MNEMOS_API_KEY` is set in its environment. Ensure the env block in your Hermes MCP config includes `MNEMOS_API_KEY` alongside `MNEMOS_BASE`. If you can't put the token in the MCP config, run the MCP server on the same host as MNEMOS with MNEMOS bound to loopback, or use SSH transport (see MNEMOS `mcp_server.py` docstring).
+The v4 MCP transport forwards Bearer tokens when `MNEMOS_API_KEY` is set in its environment. Ensure the env block in your Hermes MCP config includes `MNEMOS_API_KEY` alongside `MNEMOS_BASE`. If you can't put the token in the MCP config, run the MCP server on the same host as MNEMOS with MNEMOS bound to loopback, or use SSH transport with `mnemos serve mcp-stdio`.
 
 **Memories returned but low relevance**
 Try `semantic: true` for concept-level search, or narrow with `category` filter.

--- a/integrations/openclaw/mcp.example.json
+++ b/integrations/openclaw/mcp.example.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "mnemos": {
-      "command": "python",
-      "args": ["/path/to/mnemos/mcp_server.py"],
+      "command": "/path/to/mnemos/venv/bin/mnemos",
+      "args": ["serve", "mcp-stdio"],
       "env": {
-        "MNEMOS_BASE": "http://<your-mnemos-host>:5000"
+        "MNEMOS_BASE": "http://<your-mnemos-host>:5002"
       }
     }
   }

--- a/integrations/zeroclaw/mcp.example.json
+++ b/integrations/zeroclaw/mcp.example.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "mnemos": {
-      "command": "python",
-      "args": ["/path/to/mnemos/mcp_server.py"],
+      "command": "/path/to/mnemos/venv/bin/mnemos",
+      "args": ["serve", "mcp-stdio"],
       "env": {
-        "MNEMOS_BASE": "http://<your-mnemos-host>:5000"
+        "MNEMOS_BASE": "http://<your-mnemos-host>:5002"
       }
     }
   }

--- a/mnemos/_version.py
+++ b/mnemos/_version.py
@@ -11,4 +11,4 @@ without a re-install. A literal Python constant is what every runtime
 caller imports — no install-state coupling.
 """
 
-__version__ = "3.5.1"
+__version__ = "4.0.0"

--- a/mnemos/tools/README.md
+++ b/mnemos/tools/README.md
@@ -10,11 +10,11 @@ it's built to be trustworthy when you can't casually recross.
 
 | Piece | Role |
 |---|---|
-| `tools/memory_import.py` | Load side. Reads JSON / JSONL / CSV / ChatGPT / Obsidian / text into MNEMOS. |
-| `tools/memory_export.py` | Save side. Writes MNEMOS memories as JSON / JSONL / Markdown / HTML / plain text. |
-| `tools/export_memories_for_docling.py` | Formatter library for Docling-compatible text outputs (called by `memory_export.py`). |
-| `tools/docling_import.py` | Document ingest (PDF / DOCX / HTML / etc) via IBM Docling. |
-| `api/handlers/portability.py` | REST endpoints — `GET /v1/export`, `POST /v1/import`. Native MPF envelope. |
+| `mnemos/tools/memory_import.py` | Load side. Reads JSON / JSONL / CSV / ChatGPT / Obsidian / text into MNEMOS. |
+| `mnemos/tools/memory_export.py` | Save side. Writes MNEMOS memories as JSON / JSONL / Markdown / HTML / plain text. |
+| `mnemos/tools/export_memories_for_docling.py` | Formatter library for Docling-compatible text outputs (called by `memory_export.py`). |
+| `mnemos/tools/docling_import.py` | Document ingest (PDF / DOCX / HTML / etc) via IBM Docling. |
+| `mnemos/api/routes/portability.py` | REST endpoints — `GET /v1/export`, `POST /v1/import`. Native MPF envelope. |
 
 ## MPF (Memory Portability Format) envelope
 
@@ -22,7 +22,7 @@ it's built to be trustworthy when you can't casually recross.
 {
   "mpf_version": "0.1.0",
   "source_system": "mnemos",
-  "source_version": "3.2.0",
+  "source_version": "4.0.0",
   "records": [
     {
       "id": "mem_abc123",
@@ -46,7 +46,7 @@ it's built to be trustworthy when you can't casually recross.
 }
 ```
 
-## Cross-version migration (v2.3.0 → v3.x)
+## Cross-version migration (v2.3.0 -> v3.x/v4.x)
 
 The `--preserve-metadata` flag on `memory_import.py json` routes
 through the MPF envelope path (`POST /v1/import?preserve_owner=true`)
@@ -73,8 +73,8 @@ PGPASSWORD=$PG_PASSWORD psql -h localhost -U mnemos_user -d mnemos \
 # 2. Validate the JSONL parses cleanly (optional but encouraged).
 python3 -c 'import json, sys; [json.loads(l) for l in open("memories-v2.jsonl")]; print("OK")'
 
-# 3. Load into the v3.x instance, preserving ids/owners/namespaces.
-python3 tools/memory_import.py json \
+# 3. Load into the v3.x/v4.x instance, preserving ids/owners/namespaces.
+python3 -m mnemos.tools.memory_import json \
     --file memories-v2.jsonl \
     --jsonl \
     --preserve-metadata \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemos-os"
-version = "3.5.1"
-description = "MNEMOS-OS v3: Unified memory operating system with GRAEAE reasoning, DAG versioning, compression, and cost-aware routing"
+version = "4.0.0"
+description = "MNEMOS-OS v4: multi-backend memory operating system with GRAEAE reasoning, profiles, single-binary edge deploys, and multi-worker support"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -281,7 +281,7 @@ class TestDockerIntegration:
         pyproject_path = Path(__file__).parent.parent / 'pyproject.toml'
         assert pyproject_path.exists(), "pyproject.toml not found"
         content = pyproject_path.read_text()
-        assert 'version = "3.5.1"' in content, "Version not at 3.5.1"
+        assert 'version = "4.0.0"' in content, "Version not at 4.0.0"
 
     def test_pyproject_toml_has_uv_config(self):
         """pyproject.toml has uv configuration."""

--- a/tests/test_v3_integration.py
+++ b/tests/test_v3_integration.py
@@ -233,7 +233,7 @@ class TestVersions:
         resp = await client.get("/health")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["version"] == "3.5.1"
+        assert data["version"] == "4.0.0"
 
     async def test_api_version_in_responses(self, client: AsyncClient, auth_headers: dict):
         resp = await client.get("/v1/providers/health", headers=auth_headers)


### PR DESCRIPTION
Mirror of v3.5.1 slice-15 pattern. Every doc reconciled to v4.0 current state across 39 files (+864 / -634 net cleanup). Version bumped to 4.0.0 in pyproject + _version.py. CHANGELOG, ROADMAP, README, EVOLUTION, SPECIFICATION, V4_PLAN, API_DOCUMENTATION, CONTRIBUTING, integrations/* configs, tools/README all updated. v4.0 plan items marked SHIPPED; Rust + mobile + web UX pushed to v4.1/v5.0 framing. 1055 passed, ruff clean, 7 contracts kept. Authored-By: Codex