### PR TITLE
fix(cli): TyperOption shim filters kwargs by accepted signature

### DIFF
--- a/mnemos/cli/main.py
+++ b/mnemos/cli/main.py
@@ -57,17 +57,26 @@ def _patch_typer_click_compat() -> None:
         original_option_init = TyperOption.__init__
 
         if not getattr(TyperOption.__init__, "_mnemos_click_compat", False):
+            sig = inspect.signature(original_option_init)
+            params = sig.parameters
+            accepts_var_kwargs = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+            )
+            accepted_names = set(params.keys())
 
             def option_init(self: Any, **kwargs: Any) -> None:
                 if kwargs.get("is_flag") is True and kwargs.get("flag_value") is None:
                     kwargs["type"] = None
-                    kwargs["flag_value"] = True
+                    if accepts_var_kwargs or "flag_value" in accepted_names:
+                        kwargs["flag_value"] = True
                 if (
                     kwargs.get("is_flag") is None
                     and kwargs.get("flag_value") is None
                     and not kwargs.get("count", False)
                 ):
                     kwargs["is_flag"] = False
+                if not accepts_var_kwargs:
+                    kwargs = {key: value for key, value in kwargs.items() if key in accepted_names}
                 original_option_init(self, **kwargs)
 
             option_init._mnemos_click_compat = True
@@ -151,6 +160,28 @@ serve_app = typer.Typer(
     no_args_is_help=False,
 )
 worker_app = typer.Typer(help="Run MNEMOS background workers.", no_args_is_help=True)
+
+
+def _version_option_callback(value: bool) -> None:
+    if not value:
+        return
+    from mnemos._version import __version__
+
+    typer.echo(__version__)
+    raise typer.Exit()
+
+
+@app.callback()
+def cli(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_option_callback,
+        is_eager=True,
+        help="Print the installed MNEMOS version.",
+    ),
+) -> None:
+    """Unified MNEMOS command line interface."""
 
 
 @contextmanager

--- a/tests/test_cli_typer_click_compat.py
+++ b/tests/test_cli_typer_click_compat.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+import typer
+from click.testing import CliRunner
+from typer.core import TyperOption
+from typer.main import get_command
+
+from mnemos._version import __version__
+
+
+def test_import_installs_typer_click_compat_shim() -> None:
+    cli_main = importlib.import_module("mnemos.cli.main")
+
+    assert getattr(TyperOption.__init__, "_mnemos_click_compat", False)
+    assert cli_main.app is not None
+
+
+def test_typer_flag_option_parses_after_compat_shim() -> None:
+    importlib.import_module("mnemos.cli.main")
+    app = typer.Typer()
+    parsed: dict[str, bool] = {}
+
+    @app.command()
+    def command(flag: bool = typer.Option(False, "--flag", is_flag=True)) -> None:
+        parsed["flag"] = flag
+
+    result = CliRunner().invoke(get_command(app), ["--flag"])
+
+    assert result.exit_code == 0, result.output
+    assert parsed == {"flag": True}
+
+
+def test_typer_option_shim_drops_unsupported_flag_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_main = importlib.import_module("mnemos.cli.main")
+    calls: list[dict[str, Any]] = []
+
+    def fake_option_init(
+        self: object,
+        *,
+        param_decls: list[str],
+        type: Any = "sentinel",
+        is_flag: bool | None = None,
+    ) -> None:
+        calls.append({"param_decls": param_decls, "type": type, "is_flag": is_flag})
+
+    monkeypatch.setattr(TyperOption, "__init__", fake_option_init)
+
+    cli_main._patch_typer_click_compat()
+    TyperOption(param_decls=["--flag"], is_flag=True, flag_value=None, unsupported="dropped")
+
+    assert calls == [{"param_decls": ["--flag"], "type": None, "is_flag": True}]
+
+
+def test_mnemos_version_subcommand_smoke_does_not_touch_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    cli_main = importlib.import_module("mnemos.cli.main")
+
+    def fail_network(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("version smoke must not call the network")
+
+    monkeypatch.setattr(cli_main.httpx, "get", fail_network)
+    monkeypatch.setattr(cli_main.httpx, "post", fail_network)
+
+    result = CliRunner().invoke(get_command(cli_main.app), ["version"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == __version__
+    assert "4.0.0" in result.output


### PR DESCRIPTION
v4.0.0 GH Actions release.yml failed on all 3 platforms because the pyinstaller bundle ships Click 8.2+ where TyperOption.__init__ does not accept flag_value kwarg. Fix uses inspect.signature(original_option_init) to drive what kwargs the shim forwards. Plus eager --version callback at the app level. 1059 passed (+4), ruff + 7 contracts clean. Unblocks the v4.0.0 single-binary release artifact builds. Authored-By: Codex