### PR TITLE
fix(spec): include all mnemos.* submodules in hiddenimports

### DIFF
--- a/mnemos.spec
+++ b/mnemos.spec
@@ -6,7 +6,7 @@ import os
 import platform
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs, collect_submodules
 
 
 ENTRY_POINT = "mnemos.cli.main:app"
@@ -70,6 +70,12 @@ BINARY_NAME = f"mnemos-{BINARY_PLATFORM}"
 
 # PyInstaller hiddenimports use importable module names. The sqlite-vec
 # distribution exposes the sqlite_vec module plus a native vec0 extension.
+#
+# CRITICAL: the mnemos CLI dispatches subcommands through dynamic imports
+# (e.g. `mnemos serve` does `import_module("mnemos.api.main")`); pyinstaller's
+# static analysis cannot follow these. Without collect_submodules("mnemos")
+# every CLI subcommand fails with ModuleNotFoundError at first invocation
+# in the bundled binary. This was the v4.0.0 first-binary-build bug.
 HIDDEN_IMPORTS = [
     "sqlite_vec",
     "aiosqlite",
@@ -86,7 +92,7 @@ HIDDEN_IMPORTS = [
     "anthropic",
     "google.genai",
     "httpx",
-]
+] + collect_submodules("mnemos")
 
 datas = []
 datas += _files_matching("db/migrations*.sql", "db")


### PR DESCRIPTION
v4.0.0 binary smoke on PROTEUS reproduced the second binary blocker: every CLI subcommand failed with `ModuleNotFoundError: No module named mnemos.installer` / `mnemos.api`. Root cause: the unified CLI in A.6 dispatches subcommands via importlib.import_module(); pyinstaller cannot follow dynamic imports. Fix uses collect_submodules("mnemos") to enumerate every mnemos.* module at spec-evaluation time. One-liner.