### PR TITLE
fix(build): cap fastapi <0.137 in requirements.txt to match pyproject

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,11 @@
 # Generated 2026-04-10 — reflects actual imports
 
 # API framework
-fastapi>=0.115.0
+# Upper bound mirrors pyproject.toml: fastapi >=0.137 ships _IncludedRouter,
+# which breaks the app.routes introspection the codebase/tests/MCP path-wiring
+# rely on. Without this cap the build resolves the latest fastapi and `pip check`
+# fails against mnemos-core's <0.137 constraint. Pin until adapted.
+fastapi>=0.115.0,<0.137
 uvicorn[standard]>=0.30.0
 gunicorn>=22.0.0
 starlette>=0.40.0


### PR DESCRIPTION
## Summary
`requirements.txt` pinned `fastapi>=0.115.0` with **no upper bound**, so `Dockerfile.core`'s builder (`uv pip install -r requirements.txt`) resolved the latest fastapi (0.138.2). That violates mnemos-core's intentional pyproject cap (`fastapi>=0.115.0,<0.137` — 0.137+ ships `_IncludedRouter`, breaking the `app.routes` introspection the codebase/tests/MCP path-wiring depend on), so the layered ghcr.io image build failed at `pip check`:

```
mnemos-core 6.0.0 has requirement fastapi<0.137,>=0.115.0, but you have fastapi 0.138.2
```
(release-images.yml run 28418425003, core job.)

## Fix
Mirror the upper bound in `requirements.txt` so the build resolves a compatible fastapi and `pip check` passes. One line + explanatory comment; matches the existing, documented pyproject constraint.

## Validation
The release-images.yml rebuild is the gate — re-dispatched after merge; core `pip check` must pass and the matrix (mnemos-core/mnemos/mnemos-enterprise) must publish.