### PR TITLE
fix(postgres): set supports_webhooks capability flag

### DIFF
--- a/mnemos/persistence/postgres.py
+++ b/mnemos/persistence/postgres.py
@@ -4272,6 +4272,7 @@ class PostgresBackend:
     supports_advisory_locks = True
     supports_row_level_security = True
     supports_pgvector = True
+    supports_webhooks = True  # backed by PostgresWebhookRepository, see .webhooks
 
     def __init__(self, pool: asyncpg.Pool, settings: Any):
         self._pool = pool


### PR DESCRIPTION
## Summary
- `PostgresBackend` never set `supports_webhooks`, even though it has a real `PostgresWebhookRepository` (`self._webhooks` / `.webhooks` property) — every other backend sets this flag explicitly (`OracleBackend.supports_webhooks = True`, `MariaDBBackend`/`MySQLBackend` set it `False`).
- Several call sites read the flag with a direct attribute access rather than `getattr(..., True)` (e.g. `mnemos/api/routes/dag.py:891`, and the document-import pipeline shipped in the `mnemos-core` wheel), so on Postgres they raised `AttributeError: 'PostgresBackend' object has no attribute 'supports_webhooks'` instead of correctly detecting webhook support.
- Fix mirrors the existing `OracleBackend.supports_webhooks = True  # Oracle has a real OracleWebhookRepository (see .webhooks)` pattern.

## Test plan
- [x] Reproduced against a live Postgres-backed mnemos deployment: `mnemos import-project` on a real repo failed on every chunk with `AttributeError: 'PostgresBackend' object has no attribute 'supports_webhooks'`; after adding the flag, all chunks imported successfully (memories created, no errors).
- [ ] CI / existing persistence parity suite (not run locally — no local Postgres test harness in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)