### PR TITLE
fix(ci): drop relocated KNEMON test refs from pr-check.yml

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -123,11 +123,6 @@ jobs:
       - name: Unit tests
         run: |
           .venv/bin/pytest \
-            tests/domain/test_knemon_router.py \
-            tests/api/test_knemon_utilization.py \
-            tests/test_knemon_dispatch_migration.py \
-            tests/test_knemon_ledger.py \
-            tests/test_knemon_triage_llm.py \
             tests/test_migration_lists_sync.py \
             tests/test_plan_windows.py \
             tests/test_settings.py \


### PR DESCRIPTION
## Summary

The 2026-06-16 `mnemos-core`/add-on split (`reorg: carve mnemos -> mnemos-core`) moved the KNEMON domain and its tests out of this repo into the separate `ncz-os/knemon` package. `pr-check.yml`'s "Unit tests" step still hardcoded the 5 relocated test paths, so every PR since then has failed pytest collection on file-not-found before running a single real test — this repo has had no working PR-check CI signal for over a month (confirmed on PR #41, unrelated to that PR's actual diff).

## Change

Drop the 5 references to test files that no longer exist in this repo (`tests/domain/test_knemon_router.py`, `tests/api/test_knemon_utilization.py`, `tests/test_knemon_dispatch_migration.py`, `tests/test_knemon_ledger.py`, `tests/test_knemon_triage_llm.py`); keep the 3 that still live in `mnemos-core` (`tests/test_migration_lists_sync.py`, `tests/test_plan_windows.py`, `tests/test_settings.py`).

## Testing

Ran the surviving 3 files locally against a fresh venv (`pip install -e ".[dev]"`): 30 passed, 0 failed. This PR's own CI run is also the live verification — `pull_request` events execute the workflow version from the PR's merge commit, so this diff validates itself.